### PR TITLE
fix: preserve Gemini 3 thought_signature across tool turns

### DIFF
--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -283,6 +283,9 @@ class ChatCompletionClient:
                     chars += len(name)
                 if isinstance(args, str):
                     chars += len(args)
+                sig = _extract_thought_signature(tc)
+                if sig:
+                    chars += len(sig)
         if tools:
             chars += len(json.dumps(tools))
         return chars // 4

--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -37,11 +37,19 @@ class LLMResponseError(requests.HTTPError):
 class ToolCall:
     """One tool/function call emitted by the assistant. ``arguments`` is
     the raw string the model produced — the caller is responsible for
-    JSON-parsing it (and for handling models that emit malformed JSON)."""
+    JSON-parsing it (and for handling models that emit malformed JSON).
+
+    ``thought_signature`` is Gemini 3's encrypted reasoning token, carried
+    over the OpenAI-compat endpoint at ``tool_call.extra_content.google.
+    thought_signature``. It MUST be echoed back unchanged on the next
+    request or Gemini 3 rejects the follow-up turn with a 400. ``None`` for
+    every other provider (OpenAI, HF Router, Gemini 2.5), which don't send
+    it — so it round-trips invisibly for them."""
 
     id: str
     name: str
     arguments: str
+    thought_signature: Optional[str] = None
 
 
 @dataclass
@@ -739,7 +747,9 @@ class ChatCompletionClient:
         idx = chunk.get("index")
         if not isinstance(idx, int):
             idx = len(parts)
-        slot = parts.setdefault(idx, {"id": None, "name": None, "arguments": ""})
+        slot = parts.setdefault(
+            idx, {"id": None, "name": None, "arguments": "", "thought_signature": None}
+        )
         if chunk.get("id"):
             slot["id"] = chunk["id"]
         fn = chunk.get("function") or {}
@@ -748,6 +758,9 @@ class ChatCompletionClient:
         args_piece = fn.get("arguments")
         if isinstance(args_piece, str):
             slot["arguments"] += args_piece
+        sig = _extract_thought_signature(chunk)
+        if sig:
+            slot["thought_signature"] = sig
 
     @staticmethod
     def _finalize_tool_calls(parts: dict[int, dict[str, Any]]) -> list[ToolCall]:
@@ -764,9 +777,23 @@ class ChatCompletionClient:
                     id=slot.get("id") or f"call_{idx}",
                     name=name,
                     arguments=slot.get("arguments") or "",
+                    thought_signature=slot.get("thought_signature"),
                 )
             )
         return out
+
+
+def _extract_thought_signature(tc: dict[str, Any]) -> Optional[str]:
+    """Pull Gemini 3's ``extra_content.google.thought_signature`` off a raw
+    tool-call dict, returning ``None`` for any other provider's shape."""
+    extra = tc.get("extra_content")
+    if not isinstance(extra, dict):
+        return None
+    google = extra.get("google")
+    if not isinstance(google, dict):
+        return None
+    sig = google.get("thought_signature")
+    return sig if isinstance(sig, str) and sig else None
 
 
 def _parse_tool_calls_from_message(raw: Any) -> list[ToolCall]:
@@ -784,5 +811,12 @@ def _parse_tool_calls_from_message(raw: Any) -> list[ToolCall]:
         args = fn.get("arguments")
         if not isinstance(args, str):
             args = json.dumps(args) if args is not None else ""
-        out.append(ToolCall(id=tc.get("id") or f"call_{i}", name=name, arguments=args))
+        out.append(
+            ToolCall(
+                id=tc.get("id") or f"call_{i}",
+                name=name,
+                arguments=args,
+                thought_signature=_extract_thought_signature(tc),
+            )
+        )
     return out

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -807,14 +807,7 @@ def _run_agentic_loop(
             {
                 "role": "assistant",
                 "content": chat.content or None,
-                "tool_calls": [
-                    {
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {"name": tc.name, "arguments": tc.arguments},
-                    }
-                    for tc in chat.tool_calls
-                ],
+                "tool_calls": [_assistant_tool_call_dict(tc) for tc in chat.tool_calls],
             }
         )
         for tc in chat.tool_calls:
@@ -938,6 +931,21 @@ def _emit_metrics(
         }
     )
     emit("metrics", payload)
+
+
+def _assistant_tool_call_dict(tc: ToolCall) -> dict[str, Any]:
+    """Serialize a ToolCall back into the OpenAI-compat assistant message.
+    Re-attaches Gemini 3's thought_signature at the exact path the API
+    expects it, and only when one is present — so OpenAI / HF Router / Gemini
+    2.5 turns stay byte-for-byte what they were before."""
+    call: dict[str, Any] = {
+        "id": tc.id,
+        "type": "function",
+        "function": {"name": tc.name, "arguments": tc.arguments},
+    }
+    if tc.thought_signature:
+        call["extra_content"] = {"google": {"thought_signature": tc.thought_signature}}
+    return call
 
 
 def _execute_tool_call(env: ToolEnv, tc: ToolCall) -> str:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -517,6 +517,39 @@ class ChatCompletionClientTests(unittest.TestCase):
         self.assertEqual(len(result.tool_calls), 1)
         self.assertEqual(result.tool_calls[0].thought_signature, "sig-stream")
 
+    def test_estimate_input_tokens_counts_thought_signature(self) -> None:
+        # The replayed assistant turn carries Gemini's signature; the live
+        # "in" counter should account for those chars, not silently drop them.
+        base = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_x",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        with_sig = [
+            {
+                **base[0],
+                "tool_calls": [
+                    {
+                        **base[0]["tool_calls"][0],
+                        "extra_content": {"google": {"thought_signature": "x" * 400}},
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(
+            ChatCompletionClient._estimate_input_tokens(with_sig, None)
+            - ChatCompletionClient._estimate_input_tokens(base, None),
+            100,  # 400 signature chars / 4 chars-per-token
+        )
+
     def test_complete_falls_back_when_endpoint_rejects_tools(self) -> None:
         # First call (with tools) returns 400; second call (no tools) succeeds.
         rejected = Mock(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -398,6 +398,125 @@ class ChatCompletionClientTests(unittest.TestCase):
         self.assertEqual(result.tool_calls[0].name, "list_dir")
         self.assertEqual(json.loads(result.tool_calls[0].arguments), {"path": "src"})
 
+    def test_non_stream_captures_gemini_thought_signature(self) -> None:
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "choices": [
+                            {
+                                "finish_reason": "tool_calls",
+                                "message": {
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "call_x",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "read_file",
+                                                "arguments": '{"path":"a.py"}',
+                                            },
+                                            "extra_content": {
+                                                "google": {
+                                                    "thought_signature": "sig-abc"
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "id": "call_y",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "read_file",
+                                                "arguments": '{"path":"b.py"}',
+                                            },
+                                        },
+                                    ],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                raise_for_status=Mock(),
+            )
+            client = ChatCompletionClient(
+                "https://example.com/v1", "token", "gemini-3-flash", stream=False
+            )
+            result = client.complete(
+                [{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+            )
+
+        # Only the first parallel call carries the signature; the second is None.
+        self.assertEqual(result.tool_calls[0].thought_signature, "sig-abc")
+        self.assertIsNone(result.tool_calls[1].thought_signature)
+
+    def test_non_stream_tool_calls_without_signature_are_none(self) -> None:
+        # OpenAI / HF Router shape: no extra_content => no signature.
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "choices": [
+                            {
+                                "finish_reason": "tool_calls",
+                                "message": {
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "call_x",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "list_dir",
+                                                "arguments": '{"path":"src"}',
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                raise_for_status=Mock(),
+            )
+            client = ChatCompletionClient(
+                "https://example.com/v1", "token", "fixed-model", stream=False
+            )
+            result = client.complete(
+                [{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "list_dir"}}],
+            )
+
+        self.assertIsNone(result.tool_calls[0].thought_signature)
+
+    def test_stream_captures_gemini_thought_signature(self) -> None:
+        sse_lines = [
+            'data: {"choices":[{"delta":{"tool_calls":['
+            '{"index":0,"id":"call_a","function":{"name":"read_file",'
+            '"arguments":"{}"},"extra_content":{"google":'
+            '{"thought_signature":"sig-stream"}}}'
+            "]}}]}",
+            'data: {"choices":[{"finish_reason":"tool_calls","delta":{}}]}',
+            "data: [DONE]",
+        ]
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                raise_for_status=Mock(),
+                iter_lines=Mock(return_value=iter(sse_lines)),
+            )
+            client = ChatCompletionClient(
+                "https://example.com/v1", "token", "gemini-3-flash", stream=True
+            )
+            result = client.complete(
+                [{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+            )
+
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].thought_signature, "sig-stream")
+
     def test_complete_falls_back_when_endpoint_rejects_tools(self) -> None:
         # First call (with tools) returns 400; second call (no tools) succeeds.
         rejected = Mock(

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -5,6 +5,7 @@ from reviewbot.patch import parse_patch
 from reviewbot.tools import ToolEnv
 from reviewbot.reviewer import (
     _UnparseableLLMOutput,
+    _assistant_tool_call_dict,
     _build_annotated_diff_chunks,
     _content_preview,
     _extract_json,
@@ -13,6 +14,31 @@ from reviewbot.reviewer import (
     _run_agentic_loop,
     _summarize_rejected_comments,
 )
+
+
+class AssistantToolCallDictTests(unittest.TestCase):
+    def test_omits_extra_content_without_signature(self) -> None:
+        tc = ToolCall(id="t0", name="read_file", arguments='{"path":"a.py"}')
+        self.assertEqual(
+            _assistant_tool_call_dict(tc),
+            {
+                "id": "t0",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path":"a.py"}'},
+            },
+        )
+
+    def test_reattaches_thought_signature_at_gemini_path(self) -> None:
+        tc = ToolCall(
+            id="t0",
+            name="read_file",
+            arguments='{"path":"a.py"}',
+            thought_signature="sig-abc",
+        )
+        self.assertEqual(
+            _assistant_tool_call_dict(tc)["extra_content"],
+            {"google": {"thought_signature": "sig-abc"}},
+        )
 
 
 class ExtractJsonTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Reviews driven by a **Gemini 3** model (`gemini-3-flash`, `gemini-3.5-flash`, …) fail as soon as the agent takes a **second** tool-using turn. The endpoint rejects the follow-up request with:

```text
400 INVALID_ARGUMENT: Function call is missing a thought_signature in
functionCall parts. This is required for tools to work correctly...
Additional data, function call default_api:read_file, position 2.
```

`position 2` is the tell — turn 1 succeeds, turn 2 dies. Single-shot reviews never hit it, so it surfaces only once the model starts chaining tools.

## Root cause

Gemini 3 makes `thought_signature` **mandatory** for function calling. Over the OpenAI-compatible endpoint, every tool call the model emits comes back with an encrypted signature:

```jsonc
{
  "id": "call_abc",
  "type": "function",
  "function": { "name": "read_file", "arguments": "{\"path\":\"config.py\"}" },
  "extra_content": { "google": { "thought_signature": "<opaque blob>" } }
}
```

The client **must** replay that signature, unchanged, on the next request. Our `ChatCompletionClient` parsed tool calls down to `id` / `function.name` / `function.arguments` and discarded `extra_content`. So on turn 2 we sent the assistant's prior tool call back **without** the signature, and Gemini 3 refused it.

Gemini 2.5 treats the signature as optional — which is exactly why only Gemini 3 regressed.

## The fix

Carry the signature end-to-end and put it back where the API expects it.

- **Capture** — `ToolCall` gains a `thought_signature` field, populated in *both* parse paths:
  - non-streaming `_parse_tool_calls_from_message`
  - streaming `_merge_tool_call_chunk` → `_finalize_tool_calls`

  A single helper, `_extract_thought_signature`, reads only `extra_content.google.thought_signature` and returns `None` for any other provider's shape.

- **Replay** — when the agent loop rebuilds the assistant turn, `_assistant_tool_call_dict` re-attaches the signature at the identical path — **only when one is present**.

- **Token accounting** — the live input-token estimate now counts the signature chars too, so the "in" counter doesn't under-report on Gemini 3.

### Why it's safe for every other provider

The change fails closed to the previous behavior unless a Gemini signature is actually present:

| Provider | Sends `extra_content.google…`? | Resulting request |
| --- | --- | --- |
| OpenAI / HF Router / vLLM / Anthropic shim / Gemini 2.5 | No | `thought_signature` stays `None` → `extra_content` key never added → **byte-for-byte identical to before** |
| Gemini 3 | Yes | signature captured and echoed back → turn 2 succeeds |

`extra_content` only ever travels back to the provider that emitted it. Parallel calls are handled per-call (Gemini attaches the signature only to the first), and stream capture is order-independent.

## Validation

- **Unit** — coverage for capture (streaming + non-streaming), `None` when absent, replay attach/omit (exact-equality assertion guards the non-Gemini path), and the token estimate. Full suite green, `ruff` clean.
- **Live A/B** against `gemini-3.5-flash`:
  1. Turn 1 captures a 292-char signature.
  2. Replaying **without** it reproduces the exact `400 … missing a thought_signature` above.
  3. Replaying **with** it lets turn 2 complete normally.

## Reference

https://ai.google.dev/gemini-api/docs/thought-signatures