### PR TITLE
Implements GitHub App review logging for generated and user-modified reviews fixes #7

### DIFF
--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Optional
 
 from . import __version__
@@ -1361,82 +1361,111 @@ def prepare_review(
     )
 
 
-def publish_review(
-    cfg: Config,
-    gh: GitHubClient,
+def effective_draft(
     draft: ReviewDraft,
-    *,
     edits: Optional[ReviewEdits] = None,
-) -> None:
-    """Apply optional user edits to a ReviewDraft and post it via the
-    GitHub reviews API. Mirrors the body-formatting rules previously
-    inlined in run_review (persona header, dropped-comments note,
-    metrics footer)."""
+    *,
+    allow_approve: bool,
+) -> ReviewDraft:
+    """Resolve a generated draft plus optional user edits into the exact
+    review that will be posted to GitHub: summary/event overrides applied,
+    invalid events ignored, ``APPROVE`` downgraded to ``COMMENT`` unless
+    ``allow_approve``, and overridden/discarded comments materialized.
+
+    This is the single source of truth shared by ``publish_review`` (what
+    it posts) and the web app's audit log (what it records as the published
+    draft), so the two cannot drift. In particular the audit log must see
+    the same ``APPROVE`` -> ``COMMENT`` downgrade GitHub actually receives."""
     edits = edits or ReviewEdits()
 
     summary = edits.summary if edits.summary is not None else draft.summary
+
     event = edits.event or draft.event
     if event not in ("COMMENT", "REQUEST_CHANGES", "APPROVE"):
         event = draft.event
-    if event == "APPROVE" and not cfg.allow_approve:
+    if event == "APPROVE" and not allow_approve:
         log.info(
             "Downgrading APPROVE to COMMENT (Actions tokens cannot approve; set ALLOW_APPROVE=1 in App mode to permit)"
         )
         event = "COMMENT"
 
-    comments_payload: list[dict[str, Any]] = []
+    comments: list[DraftComment] = []
     for c in draft.comments:
         if c.id in edits.discarded_comment_ids:
             continue
         body = edits.comment_overrides.get(c.id, c.body)
         if not isinstance(body, str) or not body.strip():
             continue
-        comments_payload.append(
-            {"path": c.path, "side": c.side, "line": c.line, "body": body}
-        )
+        comments.append(replace(c, body=body))
 
-    body = summary or "(no overall summary provided)"
+    return replace(draft, summary=summary, event=event, comments=comments)
+
+
+def publish_review(
+    cfg: Config,
+    gh: GitHubClient,
+    draft: ReviewDraft,
+    *,
+    edits: Optional[ReviewEdits] = None,
+) -> ReviewDraft:
+    """Apply optional user edits to a ReviewDraft and post it via the
+    GitHub reviews API. Mirrors the body-formatting rules previously
+    inlined in run_review (persona header, dropped-comments note,
+    metrics footer).
+
+    Returns the *effective* ReviewDraft that was actually posted (edits
+    applied, event downgraded). Callers persist this so the audit log
+    records exactly what GitHub received rather than the raw draft."""
+    effective = effective_draft(draft, edits, allow_approve=cfg.allow_approve)
+
+    comments_payload: list[dict[str, Any]] = [
+        {"path": c.path, "side": c.side, "line": c.line, "body": c.body}
+        for c in effective.comments
+    ]
+
+    body = effective.summary or "(no overall summary provided)"
     if cfg.persona_header:
         body = f"{cfg.persona_header}\n\n{body}"
-    if draft.rejected_count:
+    if effective.rejected_count:
         body += (
-            f"\n\n_Note: {draft.rejected_count} suggested inline comment(s) "
+            f"\n\n_Note: {effective.rejected_count} suggested inline comment(s) "
             "were dropped because they referenced lines not present in the diff._"
         )
-    if draft.truncated_chunks:
+    if effective.truncated_chunks:
         body += (
             f"\n\n_Note: review finished early after hitting the input-token "
-            f"budget; {draft.truncated_chunks} remaining diff chunk(s) were "
+            f"budget; {effective.truncated_chunks} remaining diff chunk(s) were "
             "not reviewed._"
         )
     if cfg.is_staging:
         body += "\n\n_Note: posted from a staging deployment._"
     footer_parts = [f"serge `v{__version__}`"]
-    if draft.model:
-        footer_parts.append(f"model: `{draft.model}`")
-    if draft.metrics_line:
-        footer_parts.append(draft.metrics_line)
+    if effective.model:
+        footer_parts.append(f"model: `{effective.model}`")
+    if effective.metrics_line:
+        footer_parts.append(effective.metrics_line)
     if footer_parts:
         body += f"\n\n_{' · '.join(footer_parts)}_"
 
     gh.create_review(
-        draft.owner,
-        draft.repo,
-        draft.number,
-        commit_id=draft.head_sha,
+        effective.owner,
+        effective.repo,
+        effective.number,
+        commit_id=effective.head_sha,
         body=body,
         comments=comments_payload,
-        event=event,
+        event=effective.event,
     )
     log.info(
         "Posted review on %s/%s#%d (%d inline, event=%s, %s)",
-        draft.owner,
-        draft.repo,
-        draft.number,
+        effective.owner,
+        effective.repo,
+        effective.number,
         len(comments_payload),
-        event,
-        draft.metrics_line,
+        effective.event,
+        effective.metrics_line,
     )
+    return effective
 
 
 def run_review(

--- a/reviewbot/static/review.html
+++ b/reviewbot/static/review.html
@@ -79,6 +79,12 @@
         <button class="danger" id="discard-btn">Discard fully</button>
       </div>
     </section>
+
+    <section class="card" id="audit-section" style="display: none;">
+      <h2>Review log</h2>
+      <p class="hint">Stored prompt, generated draft, and published review.</p>
+      <div id="audit-content"></div>
+    </section>
   </main>
   <script src="/static/review.js" defer></script>
 </body>

--- a/reviewbot/static/review.js
+++ b/reviewbot/static/review.js
@@ -24,6 +24,8 @@
   const commentsCountEl = document.getElementById("comments-count");
   const publishBtn = document.getElementById("publish-btn");
   const discardBtn = document.getElementById("discard-btn");
+  const auditSection = document.getElementById("audit-section");
+  const auditContent = document.getElementById("audit-content");
 
   let draft = null;
   let infoCache = null;
@@ -234,7 +236,108 @@
       return;
     }
     draft = data.draft;
+    renderAudit(data.audit);
     renderDraftForm();
+  }
+
+  function renderAudit(audit) {
+    if (!audit || !auditContent) return;
+    auditContent.replaceChildren();
+
+    auditContent.appendChild(buildAuditBlock("User prompt", audit.trigger_comment || ""));
+    auditContent.appendChild(buildChangeSummary(audit.changes || {}));
+    if (audit.generated_draft) {
+      auditContent.appendChild(buildDraftAudit("AI generated review", audit.generated_draft));
+    }
+    if (audit.published_draft) {
+      auditContent.appendChild(buildDraftAudit("Published review", audit.published_draft));
+    }
+    if (audit.trace && audit.trace.length) {
+      auditContent.appendChild(buildTraceAudit(audit.trace));
+    }
+    auditSection.style.display = "";
+  }
+
+  function buildAuditBlock(title, text) {
+    const block = document.createElement("div");
+    block.className = "audit-block";
+    const h = document.createElement("h3");
+    h.textContent = title;
+    block.appendChild(h);
+    const pre = document.createElement("pre");
+    pre.textContent = text || "(empty)";
+    block.appendChild(pre);
+    return block;
+  }
+
+  function buildChangeSummary(changes) {
+    const edited = changes.edited_comment_ids || [];
+    const discarded = changes.discarded_comment_ids || [];
+    const parts = [];
+    if (changes.summary) parts.push("summary edited");
+    if (changes.event) parts.push("event changed");
+    if (edited.length) parts.push(`${edited.length} inline edited`);
+    if (discarded.length) parts.push(`${discarded.length} inline discarded`);
+    if (!parts.length) parts.push("no changes");
+
+    const block = document.createElement("div");
+    block.className = "audit-block";
+    const h = document.createElement("h3");
+    h.textContent = "Changes";
+    const p = document.createElement("p");
+    p.className = "audit-summary";
+    p.textContent = parts.join(" · ");
+    block.appendChild(h);
+    block.appendChild(p);
+    return block;
+  }
+
+  function buildDraftAudit(title, review) {
+    const block = document.createElement("div");
+    block.className = "audit-block";
+    const h = document.createElement("h3");
+    h.textContent = title;
+    block.appendChild(h);
+
+    const meta = document.createElement("p");
+    meta.className = "hint";
+    meta.textContent = `${review.event || "COMMENT"} · ${review.comments.length} inline comment(s)`;
+    block.appendChild(meta);
+
+    const summary = document.createElement("pre");
+    summary.textContent = review.summary || "(no summary)";
+    block.appendChild(summary);
+
+    for (const c of review.comments) {
+      const item = document.createElement("details");
+      item.className = "audit-comment";
+      const s = document.createElement("summary");
+      s.textContent = `${c.path}:${c.line} (${c.side})`;
+      const body = document.createElement("pre");
+      body.textContent = c.body || "";
+      item.appendChild(s);
+      item.appendChild(body);
+      block.appendChild(item);
+    }
+    return block;
+  }
+
+  function buildTraceAudit(trace) {
+    const block = document.createElement("div");
+    block.className = "audit-block";
+    const h = document.createElement("h3");
+    h.textContent = "Trace";
+    block.appendChild(h);
+    const pre = document.createElement("pre");
+    pre.textContent = trace
+      .map((e) => {
+        const kind = e.kind || "log";
+        const text = e.text || "";
+        return `[${kind}] ${text}`;
+      })
+      .join("\n");
+    block.appendChild(pre);
+    return block;
   }
 
   function renderDraftForm() {

--- a/reviewbot/static/styles.css
+++ b/reviewbot/static/styles.css
@@ -417,6 +417,45 @@ td .source-tag {
   font-size: 0.7rem;
 }
 
+.audit-block {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+  margin-top: 14px;
+}
+.audit-block:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+.audit-block h3 {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+}
+.audit-block pre {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.82rem;
+}
+.audit-summary {
+  margin: 0;
+  color: var(--muted);
+}
+.audit-comment {
+  margin-top: 8px;
+}
+.audit-comment summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.82rem;
+}
+
 .comment-card {
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -49,6 +49,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     error           TEXT,
     raw_llm_output  TEXT,
     draft_json      TEXT,
+    review_edits_json TEXT,
+    published_draft_json TEXT,
     history_json    TEXT,
     -- For tasks: the inbound TaskRequest spec (instruction/context/output).
     task_spec_json  TEXT,
@@ -127,6 +129,8 @@ class JobStore:
             self._ensure_column("llm_model", "TEXT")
             self._ensure_column("prompt_tokens", "INTEGER")
             self._ensure_column("completion_tokens", "INTEGER")
+            self._ensure_column("review_edits_json", "TEXT")
+            self._ensure_column("published_draft_json", "TEXT")
             self._ensure_column("source", "TEXT NOT NULL DEFAULT 'web'")
             self._ensure_column("kind", "TEXT NOT NULL DEFAULT 'review'")
             self._ensure_column("task_spec_json", "TEXT")
@@ -250,6 +254,40 @@ class JobStore:
                     time.time(),
                     prompt_tokens,
                     completion_tokens,
+                    job_id,
+                ),
+            )
+            self._conn.commit()
+
+    def save_published_review(
+        self,
+        job_id: str,
+        *,
+        edits: Optional[dict[str, Any]],
+        published_draft: Optional[ReviewDraft],
+    ) -> None:
+        """Persist the exact review version published from the web UI.
+
+        ``draft_json`` remains the AI-generated draft. These fields capture
+        the human's publish-time choices and the materialized draft after
+        applying those choices, so the review page can audit what changed.
+        """
+        edits_json = (
+            json.dumps(edits, ensure_ascii=False) if edits is not None else None
+        )
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE jobs
+                   SET review_edits_json = ?,
+                       published_draft_json = ?,
+                       updated_at = ?
+                 WHERE id = ?
+                """,
+                (
+                    edits_json,
+                    _encode_draft(published_draft),
+                    time.time(),
                     job_id,
                 ),
             )

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -896,14 +896,16 @@ def _execute_review(
         job.draft = draft
         if auto_publish:
             _push_event(job, "log", "Publishing review to GitHub…")
-            publish_review(worker_cfg, gh, draft)
+            # Store the effective draft publish_review actually posted (e.g.
+            # APPROVE downgraded to COMMENT) so the audit log doesn't claim
+            # an approval GitHub never received.
+            job.published_draft = publish_review(worker_cfg, gh, draft)
             job.status = "published"
-            job.published_draft = draft
             _push_event(
                 job,
                 "log",
-                f"Published review: {len(draft.comments)} inline comment(s), "
-                f"event={draft.event}",
+                f"Published review: {len(job.published_draft.comments)} inline "
+                f"comment(s), event={job.published_draft.event}",
             )
         else:
             job.status = "done"
@@ -2520,10 +2522,12 @@ async def publish(
         cfg.github_app_id, cfg.github_private_key, installation_id
     )
     gh = GitHubClient(token)
-    publish_review(cfg, gh, job.draft, edits=edits)
+    # Persist exactly what publish_review posted — including any APPROVE ->
+    # COMMENT downgrade — instead of re-deriving the draft separately (which
+    # could drift from the publish path).
+    job.published_draft = publish_review(cfg, gh, job.draft, edits=edits)
     job.status = "published"
     job.review_edits = _review_edits_to_dict(edits)
-    job.published_draft = _apply_review_edits(job.draft, edits)
     _store.update_status(job.id, "published")
     _store.save_published_review(
         job.id,
@@ -2574,28 +2578,6 @@ def _review_edits_to_dict(edits: ReviewEdits) -> dict[str, Any]:
         "comment_overrides": dict(edits.comment_overrides),
         "discarded_comment_ids": sorted(edits.discarded_comment_ids),
     }
-
-
-def _apply_review_edits(draft: ReviewDraft, edits: ReviewEdits) -> ReviewDraft:
-    comments: list[DraftComment] = []
-    for comment in draft.comments:
-        if comment.id in edits.discarded_comment_ids:
-            continue
-        body = edits.comment_overrides.get(comment.id, comment.body)
-        if not isinstance(body, str) or not body.strip():
-            continue
-        comments.append(dataclasses.replace(comment, body=body))
-
-    event = edits.event or draft.event
-    if event not in ("COMMENT", "REQUEST_CHANGES", "APPROVE"):
-        event = draft.event
-
-    return dataclasses.replace(
-        draft,
-        summary=edits.summary if edits.summary is not None else draft.summary,
-        event=event,
-        comments=comments,
-    )
 
 
 @app.post("/reviews/{owner}/{repo}/{number}/{job_id}/discard")

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -300,6 +300,8 @@ class Job:
     task_result: Optional[dict[str, Any]] = None
     status: str = "running"  # running | done | error | discarded | published
     draft: Optional[ReviewDraft] = None
+    review_edits: Optional[dict[str, Any]] = None
+    published_draft: Optional[ReviewDraft] = None
     error: Optional[str] = None
     raw_llm_output: Optional[str] = None  # only set on parse-failure errors
     queue: "asyncio.Queue[dict[str, Any]]" = field(default_factory=asyncio.Queue)
@@ -784,6 +786,12 @@ def _persist_terminal(job: Job) -> None:
             draft=job.draft,
             history=history_copy,
         )
+        if job.published_draft is not None:
+            _store.save_published_review(
+                job.id,
+                edits=job.review_edits,
+                published_draft=job.published_draft,
+            )
     except Exception:  # noqa: BLE001
         log.exception("failed to persist terminal state for job %s", job.id)
 
@@ -890,6 +898,7 @@ def _execute_review(
             _push_event(job, "log", "Publishing review to GitHub…")
             publish_review(worker_cfg, gh, draft)
             job.status = "published"
+            job.published_draft = draft
             _push_event(
                 job,
                 "log",
@@ -2293,6 +2302,12 @@ def _load_job_from_store(job_id: str) -> Optional[Job]:
         error=row["error"],
         raw_llm_output=row["raw_llm_output"],
         draft=decode_draft(row["draft_json"]) if row.get("draft_json") else None,
+        review_edits=_safe_json_obj(row.get("review_edits_json")),
+        published_draft=(
+            decode_draft(row["published_draft_json"])
+            if row.get("published_draft_json")
+            else None
+        ),
     )
     job.task_spec = _safe_json_obj(row.get("task_spec_json"))
     job.task_result = _safe_json_obj(row.get("result_json"))
@@ -2351,6 +2366,7 @@ def review_draft(
             "status": job.status,
             "error": job.error,
             "draft": _draft_to_dict(job.draft),
+            "audit": _review_audit_to_dict(job),
         }
     )
 
@@ -2368,6 +2384,49 @@ def _draft_to_dict(draft: ReviewDraft) -> dict[str, Any]:
         "model": draft.model,
         "version": __version__,
         "comments": [dataclasses.asdict(c) for c in draft.comments],
+    }
+
+
+def _review_audit_to_dict(job: Job) -> dict[str, Any]:
+    published = job.published_draft
+    changed: dict[str, Any] = {
+        "summary": False,
+        "event": False,
+        "edited_comment_ids": [],
+        "discarded_comment_ids": [],
+    }
+    if job.draft is not None and published is not None:
+        changed = _review_changes(job.draft, published)
+    return {
+        "trigger_comment": job.trigger_comment,
+        "generated_draft": _draft_to_dict(job.draft) if job.draft else None,
+        "published_draft": _draft_to_dict(published) if published else None,
+        "review_edits": job.review_edits,
+        "changes": changed,
+        "trace": [
+            {"kind": e.get("kind"), "text": e.get("text"), "ts": e.get("ts")}
+            for e in job.history
+            if e.get("kind") not in _NOISY_KINDS
+        ],
+    }
+
+
+def _review_changes(generated: ReviewDraft, published: ReviewDraft) -> dict[str, Any]:
+    generated_comments = {c.id: c for c in generated.comments}
+    published_comments = {c.id: c for c in published.comments}
+    edited_comment_ids = [
+        c.id
+        for c in published.comments
+        if c.id in generated_comments and c.body != generated_comments[c.id].body
+    ]
+    discarded_comment_ids = [
+        c.id for c in generated.comments if c.id not in published_comments
+    ]
+    return {
+        "summary": published.summary != generated.summary,
+        "event": published.event != generated.event,
+        "edited_comment_ids": edited_comment_ids,
+        "discarded_comment_ids": discarded_comment_ids,
     }
 
 
@@ -2463,7 +2522,14 @@ async def publish(
     gh = GitHubClient(token)
     publish_review(cfg, gh, job.draft, edits=edits)
     job.status = "published"
+    job.review_edits = _review_edits_to_dict(edits)
+    job.published_draft = _apply_review_edits(job.draft, edits)
     _store.update_status(job.id, "published")
+    _store.save_published_review(
+        job.id,
+        edits=job.review_edits,
+        published_draft=job.published_draft,
+    )
     return JSONResponse({"status": "published"})
 
 
@@ -2498,6 +2564,37 @@ def _edits_from_payload(payload: dict[str, Any], draft: ReviewDraft) -> ReviewEd
         event=event,
         comment_overrides=overrides,
         discarded_comment_ids=discarded,
+    )
+
+
+def _review_edits_to_dict(edits: ReviewEdits) -> dict[str, Any]:
+    return {
+        "summary": edits.summary,
+        "event": edits.event,
+        "comment_overrides": dict(edits.comment_overrides),
+        "discarded_comment_ids": sorted(edits.discarded_comment_ids),
+    }
+
+
+def _apply_review_edits(draft: ReviewDraft, edits: ReviewEdits) -> ReviewDraft:
+    comments: list[DraftComment] = []
+    for comment in draft.comments:
+        if comment.id in edits.discarded_comment_ids:
+            continue
+        body = edits.comment_overrides.get(comment.id, comment.body)
+        if not isinstance(body, str) or not body.strip():
+            continue
+        comments.append(dataclasses.replace(comment, body=body))
+
+    event = edits.event or draft.event
+    if event not in ("COMMENT", "REQUEST_CHANGES", "APPROVE"):
+        event = draft.event
+
+    return dataclasses.replace(
+        draft,
+        summary=edits.summary if edits.summary is not None else draft.summary,
+        event=event,
+        comments=comments,
     )
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -110,6 +110,59 @@ class JobStoreTests(unittest.TestCase):
             self.assertEqual(entries[0]["prompt_tokens"], 999)
             self.assertEqual(entries[0]["completion_tokens"], 222)
 
+    def test_persists_generated_and_published_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(os.path.join(tmp, "jobs.db"))
+            store.insert_job(
+                id="j3",
+                user="carol",
+                target_owner="o",
+                target_repo="r",
+                target_number=3,
+                trigger_comment="@askserge review this",
+                llm_provider="hf",
+                llm_api_base="https://router.huggingface.co/v1",
+                llm_model="model",
+                created_at=3.0,
+                status="running",
+            )
+            generated = ReviewDraft(
+                owner="o",
+                repo="r",
+                number=3,
+                head_sha="abc",
+                summary="generated",
+                event="COMMENT",
+            )
+            published = ReviewDraft(
+                owner="o",
+                repo="r",
+                number=3,
+                head_sha="abc",
+                summary="edited",
+                event="REQUEST_CHANGES",
+            )
+            store.save_terminal(
+                "j3",
+                status="done",
+                error=None,
+                raw_llm_output=None,
+                draft=generated,
+                history=[],
+            )
+            store.save_published_review(
+                "j3",
+                edits={"summary": "edited", "event": "REQUEST_CHANGES"},
+                published_draft=published,
+            )
+
+            row = store.load("j3")
+            self.assertIsNotNone(row)
+            assert row is not None
+            self.assertIn('"summary": "generated"', row["draft_json"])
+            self.assertIn('"summary": "edited"', row["published_draft_json"])
+            self.assertIn('"event": "REQUEST_CHANGES"', row["review_edits_json"])
+
     def test_adds_llm_columns_to_existing_store(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "jobs.db")

--- a/tests/test_webapp_reviews.py
+++ b/tests/test_webapp_reviews.py
@@ -11,6 +11,13 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from reviewbot.reviewer import (
+    DraftComment,
+    ReviewDraft,
+    ReviewEdits,
+    effective_draft,
+)
+
 try:
     from fastapi import HTTPException
     from fastapi.testclient import TestClient
@@ -119,8 +126,9 @@ class WebappReviewsTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(r.json()["default_max_input_tokens"], 2000000)
 
-    def test_apply_review_edits_materializes_published_draft(self):
-        draft = self.webapp.ReviewDraft(
+    # --- effective_draft (single source of truth for what gets posted) ---
+    def _sample_draft(self, **overrides):
+        kwargs = dict(
             owner="acme",
             repo="widgets",
             number=7,
@@ -128,36 +136,141 @@ class WebappReviewsTests(unittest.TestCase):
             summary="generated summary",
             event="COMMENT",
             comments=[
-                self.webapp.DraftComment(
-                    id="c1",
-                    path="a.py",
-                    side="RIGHT",
-                    line=10,
-                    body="generated body",
+                DraftComment(
+                    id="c1", path="a.py", side="RIGHT", line=10, body="generated body"
                 ),
-                self.webapp.DraftComment(
-                    id="c2",
-                    path="b.py",
-                    side="RIGHT",
-                    line=20,
-                    body="discard me",
+                DraftComment(
+                    id="c2", path="b.py", side="RIGHT", line=20, body="discard me"
                 ),
             ],
         )
-        edits = self.webapp.ReviewEdits(
+        kwargs.update(overrides)
+        return ReviewDraft(**kwargs)
+
+    def test_effective_draft_materializes_edits(self):
+        draft = self._sample_draft()
+        edits = ReviewEdits(
             summary="edited summary",
             event="REQUEST_CHANGES",
             comment_overrides={"c1": "edited body"},
             discarded_comment_ids={"c2"},
         )
 
-        published = self.webapp._apply_review_edits(draft, edits)
+        published = effective_draft(draft, edits, allow_approve=True)
 
         self.assertEqual(published.summary, "edited summary")
         self.assertEqual(published.event, "REQUEST_CHANGES")
         self.assertEqual(len(published.comments), 1)
         self.assertEqual(published.comments[0].id, "c1")
         self.assertEqual(published.comments[0].body, "edited body")
+
+    def test_effective_draft_downgrades_approve_when_disallowed(self):
+        # The generated draft asks to APPROVE and the user leaves it
+        # untouched. With allow_approve off, GitHub receives COMMENT, so the
+        # effective (= published) draft must reflect COMMENT too.
+        draft = self._sample_draft(event="APPROVE")
+
+        published = effective_draft(draft, None, allow_approve=False)
+
+        self.assertEqual(published.event, "COMMENT")
+
+    def test_effective_draft_keeps_approve_when_allowed(self):
+        draft = self._sample_draft(event="APPROVE")
+
+        published = effective_draft(draft, None, allow_approve=True)
+
+        self.assertEqual(published.event, "APPROVE")
+
+    # --- _review_changes (audit diff between generated and published) -----
+    def test_review_changes_event_and_summary(self):
+        generated = self._sample_draft(event="APPROVE")
+        published = self._sample_draft(event="COMMENT", summary="edited")
+        changes = self.webapp._review_changes(generated, published)
+        self.assertTrue(changes["event"])
+        self.assertTrue(changes["summary"])
+        self.assertEqual(changes["edited_comment_ids"], [])
+        self.assertEqual(changes["discarded_comment_ids"], [])
+
+    def test_review_changes_edited_comment(self):
+        generated = self._sample_draft()
+        published = effective_draft(
+            generated,
+            ReviewEdits(comment_overrides={"c1": "edited body"}),
+            allow_approve=True,
+        )
+        changes = self.webapp._review_changes(generated, published)
+        self.assertEqual(changes["edited_comment_ids"], ["c1"])
+        self.assertEqual(changes["discarded_comment_ids"], [])
+
+    def test_review_changes_discarded_comment(self):
+        generated = self._sample_draft()
+        published = effective_draft(
+            generated,
+            ReviewEdits(discarded_comment_ids={"c2"}),
+            allow_approve=True,
+        )
+        changes = self.webapp._review_changes(generated, published)
+        self.assertEqual(changes["discarded_comment_ids"], ["c2"])
+        self.assertEqual(changes["edited_comment_ids"], [])
+
+    def test_review_changes_no_changes(self):
+        generated = self._sample_draft()
+        published = effective_draft(generated, None, allow_approve=True)
+        changes = self.webapp._review_changes(generated, published)
+        self.assertFalse(changes["summary"])
+        self.assertFalse(changes["event"])
+        self.assertEqual(changes["edited_comment_ids"], [])
+        self.assertEqual(changes["discarded_comment_ids"], [])
+
+    # --- audit endpoint payload shape ------------------------------------
+    def test_review_draft_endpoint_returns_audit(self):
+        generated = self._sample_draft(event="APPROVE")
+        published = effective_draft(generated, None, allow_approve=False)
+        job = self.webapp.Job(
+            id="job-audit-1",
+            user="dev",
+            target_owner="acme",
+            target_repo="widgets",
+            target_number=7,
+            trigger_comment="@askserge please review",
+            llm_provider="hf",
+            llm_api_base="",
+            llm_model="some-model",
+            created_at=0.0,
+            source="webhook",
+            status="published",
+            draft=generated,
+            published_draft=published,
+            review_edits={
+                "summary": None,
+                "event": None,
+                "comment_overrides": {},
+                "discarded_comment_ids": [],
+            },
+        )
+        with self.webapp._jobs_lock:
+            self.webapp._jobs[job.id] = job
+
+        client = TestClient(self.webapp.app)
+        r = client.get("/reviews/acme/widgets/7/job-audit-1/draft")
+        self.assertEqual(r.status_code, 200, r.text)
+        audit = r.json()["audit"]
+        self.assertEqual(
+            set(audit),
+            {
+                "trigger_comment",
+                "generated_draft",
+                "published_draft",
+                "review_edits",
+                "changes",
+                "trace",
+            },
+        )
+        self.assertEqual(audit["trigger_comment"], "@askserge please review")
+        self.assertEqual(audit["generated_draft"]["event"], "APPROVE")
+        self.assertEqual(audit["published_draft"]["event"], "COMMENT")
+        # The APPROVE -> COMMENT downgrade must surface as an event change.
+        self.assertTrue(audit["changes"]["event"])
 
 
 if __name__ == "__main__":

--- a/tests/test_webapp_reviews.py
+++ b/tests/test_webapp_reviews.py
@@ -119,6 +119,46 @@ class WebappReviewsTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(r.json()["default_max_input_tokens"], 2000000)
 
+    def test_apply_review_edits_materializes_published_draft(self):
+        draft = self.webapp.ReviewDraft(
+            owner="acme",
+            repo="widgets",
+            number=7,
+            head_sha="abc",
+            summary="generated summary",
+            event="COMMENT",
+            comments=[
+                self.webapp.DraftComment(
+                    id="c1",
+                    path="a.py",
+                    side="RIGHT",
+                    line=10,
+                    body="generated body",
+                ),
+                self.webapp.DraftComment(
+                    id="c2",
+                    path="b.py",
+                    side="RIGHT",
+                    line=20,
+                    body="discard me",
+                ),
+            ],
+        )
+        edits = self.webapp.ReviewEdits(
+            summary="edited summary",
+            event="REQUEST_CHANGES",
+            comment_overrides={"c1": "edited body"},
+            discarded_comment_ids={"c2"},
+        )
+
+        published = self.webapp._apply_review_edits(draft, edits)
+
+        self.assertEqual(published.summary, "edited summary")
+        self.assertEqual(published.event, "REQUEST_CHANGES")
+        self.assertEqual(len(published.comments), 1)
+        self.assertEqual(published.comments[0].id, "c1")
+        self.assertEqual(published.comments[0].body, "edited body")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Persist the AI-generated draft separately from the final published review.
- Store publish-time user edits in `review_edits_json`
- Add `published_draft_json` to capture the exact review posted to GitHub.
- Expose review audit data through the review draft API.
- Show a `Review log` section on the review page with:
    - user prompt
    - generated draft
    - published review
    - change summary
    - stored structural trace