### PR TITLE
Fix normalize gate (force-final validate + jobs/status RBAC), deploy overlay layering, draft-ready task PRs

### DIFF
--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -9,7 +9,7 @@
 
 image:
   # Bump to a newer sha-<commit> (pushed by CI on merge to main) or use latest.
-  tag: sha-2ce3810
+  tag: sha-8640519
 
 replicas: 1
 

--- a/deploy/helm/templates/normalize.yaml
+++ b/deploy/helm/templates/normalize.yaml
@@ -39,6 +39,12 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["create", "get", "list", "watch", "delete"]
+  # run_job polls read_namespaced_job_status, which reads the jobs/status
+  # subresource — RBAC treats it separately from "jobs", so it needs its own
+  # grant or every normalize Job 403s on the first status poll.
+  - apiGroups: ["batch"]
+    resources: ["jobs/status"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -6,7 +6,7 @@ CHART_DIR="${ROOT_DIR}/deploy/helm"
 
 release="serge"
 namespace="serge"
-values_file="${CHART_DIR}/env/prod.yaml"
+values_files=()
 secret_file=""
 expected_context=""
 dry_run=0
@@ -20,7 +20,8 @@ Usage: deploy/scripts/deploy.sh [options]
 Options:
   -n, --namespace NAME       Kubernetes namespace (default: serge)
   -r, --release NAME         Helm release name (default: serge)
-  -f, --values FILE          Helm values file (default: deploy/helm/env/prod.yaml)
+  -f, --values FILE          Helm values file; repeat to layer overlays, later
+                             files win (default: deploy/helm/env/prod.yaml)
       --secret-file FILE     Apply a local Secret manifest before deploying
       --context NAME         Require this kubectl context before deploying
       --from-head            Pin image.tag to HEAD's sha-<commit>, waiting for
@@ -42,7 +43,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -f|--values)
-      values_file="$2"
+      values_files+=("$2")
       shift 2
       ;;
     --secret-file)
@@ -88,10 +89,22 @@ if [[ ! -d "${CHART_DIR}" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${values_file}" ]]; then
-  echo "values file not found: ${values_file}" >&2
-  exit 1
+if [[ "${#values_files[@]}" -eq 0 ]]; then
+  values_files=("${CHART_DIR}/env/prod.yaml")
 fi
+
+for vf in "${values_files[@]}"; do
+  if [[ ! -f "${vf}" ]]; then
+    echo "values file not found: ${vf}" >&2
+    exit 1
+  fi
+done
+
+# Assemble helm's repeated -f flags once; later files override earlier ones.
+helm_values_args=()
+for vf in "${values_files[@]}"; do
+  helm_values_args+=(-f "${vf}")
+done
 
 # --from-head: derive HEAD's image tag, wait for CI to publish it, then pin it
 # in the values file. The CI tag format mirrors docker/metadata-action's
@@ -136,12 +149,15 @@ if [[ "${from_head}" -eq 1 ]]; then
     esac
   done
 
-  # Pin the tag in the values file (portable in-place edit). Only the single
-  # image.tag line is touched.
+  # Pin the tag in the primary values file (portable in-place edit). Only the
+  # single image.tag line is touched. image.tag lives in the base values file
+  # (prod.yaml), so we edit the first -f file; overlays layered after it do not
+  # carry serge's image.tag.
+  primary_values="${values_files[0]}"
   tmp_values="$(mktemp)"
-  sed -E "s|^([[:space:]]*tag:[[:space:]]*).*|\1${image_tag}|" "${values_file}" > "${tmp_values}"
-  mv "${tmp_values}" "${values_file}"
-  echo "Pinned image.tag: ${image_tag} in ${values_file}"
+  sed -E "s|^([[:space:]]*tag:[[:space:]]*).*|\1${image_tag}|" "${primary_values}" > "${tmp_values}"
+  mv "${tmp_values}" "${primary_values}"
+  echo "Pinned image.tag: ${image_tag} in ${primary_values}"
 fi
 
 current_context="$(kubectl config current-context)"
@@ -153,10 +169,10 @@ fi
 echo "Context: ${current_context}"
 echo "Namespace: ${namespace}"
 echo "Release: ${release}"
-echo "Values: ${values_file}"
+echo "Values: ${values_files[*]}"
 
 if [[ "${dry_run}" -eq 1 ]]; then
-  helm template "${release}" "${CHART_DIR}" -n "${namespace}" -f "${values_file}"
+  helm template "${release}" "${CHART_DIR}" -n "${namespace}" "${helm_values_args[@]}"
   exit 0
 fi
 
@@ -188,7 +204,7 @@ fi
 
 helm upgrade --install "${release}" "${CHART_DIR}" \
   -n "${namespace}" \
-  -f "${values_file}" \
+  "${helm_values_args[@]}" \
   --wait \
   --timeout 10m
 

--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -271,10 +271,17 @@ class GitHubClient:
         head: str,
         base: str,
         body: str,
+        draft: bool = False,
     ) -> dict:
         r = self.session.post(
             f"https://api.github.com/repos/{owner}/{repo}/pulls",
-            json={"title": title, "head": head, "base": base, "body": body},
+            json={
+                "title": title,
+                "head": head,
+                "base": base,
+                "body": body,
+                "draft": draft,
+            },
             timeout=60,
         )
         if not r.ok:
@@ -283,6 +290,34 @@ class GitHubClient:
                 response=r,
             )
         return r.json()
+
+    def mark_pull_request_ready(self, node_id: str) -> None:
+        """Transition a draft PR to ready-for-review via the GraphQL
+        ``markPullRequestReadyForReview`` mutation. The REST ``PATCH /pulls``
+        endpoint cannot flip ``draft``, so this is the only way. The
+        draft->ready transition is what fires the ``ready_for_review`` webhook
+        that downstream reviewer-assignment workflows listen for. ``node_id``
+        is the GraphQL global ID returned in the create-PR response."""
+        query = (
+            "mutation($id: ID!) { markPullRequestReadyForReview(input: "
+            "{pullRequestId: $id}) { pullRequest { id isDraft } } }"
+        )
+        r = self.session.post(
+            "https://api.github.com/graphql",
+            json={"query": query, "variables": {"id": node_id}},
+            timeout=60,
+        )
+        if not r.ok:
+            raise requests.HTTPError(
+                f"{r.status_code} marking PR ready for review: {r.text}",
+                response=r,
+            )
+        errors = (r.json() or {}).get("errors")
+        if errors:
+            raise requests.HTTPError(
+                f"GraphQL errors marking PR ready for review: {errors}",
+                response=r,
+            )
 
     def count_branch_commits_by_author(
         self, owner: str, repo: str, branch: str, *, author_email: str, cap: int = 100

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -887,20 +887,42 @@ def _run_agentic_loop(
     # `{"type": "json_object"}`, accepting only `"json_schema"`). The
     # force message already instructs "single JSON object only", and
     # _extract_json parses the result forgivingly.
-    chat = llm.complete(
-        messages,
-        max_tokens=cfg.llm_max_tokens,
-        chunk_callback=chunk_cb,
-        extra=final_extra,
-    )
-    metrics.turns += 1
-    metrics.latency_seconds += chat.latency_seconds
-    if chat.prompt_tokens is not None:
-        metrics.prompt_tokens += chat.prompt_tokens
-    if chat.completion_tokens is not None:
-        metrics.completion_tokens += chat.completion_tokens
-    _emit_metrics(emit, metrics)
-    return chat, metrics
+    while True:
+        chat = llm.complete(
+            messages,
+            max_tokens=cfg.llm_max_tokens,
+            chunk_callback=chunk_cb,
+            extra=final_extra,
+        )
+        metrics.turns += 1
+        metrics.latency_seconds += chat.latency_seconds
+        if chat.prompt_tokens is not None:
+            metrics.prompt_tokens += chat.prompt_tokens
+        if chat.completion_tokens is not None:
+            metrics.completion_tokens += chat.completion_tokens
+        _emit_metrics(emit, metrics)
+
+        # The verification gate must run on the forced final answer too —
+        # exhausting the tool budget must not silently bypass validation (for
+        # /tasks this is the normalize gate; skipping it here is how
+        # un-normalized patches reach an opened PR). Corrections on this path
+        # are tool-less: the model fixes its diff from the normalizer's
+        # feedback, which needs no browsing.
+        if validate is None:
+            return chat, metrics
+        feedback = validate(chat)
+        if feedback is None or validation_retries >= max_validation_retries:
+            return chat, metrics
+        validation_retries += 1
+        if emit is not None:
+            emit(
+                "log",
+                f"Patch validation failed (correction "
+                f"{validation_retries}/{max_validation_retries}); "
+                "asking the model to fix it (no tools)",
+            )
+        messages.append({"role": "assistant", "content": chat.content or None})
+        messages.append({"role": "user", "content": feedback})
 
 
 def _wrap_chunk_cb(

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -690,6 +690,11 @@ def _commit_changes(
     )
     gh.create_ref(owner, repo, f"refs/heads/{branch}", commit_sha)
     emit_fn("log", f"Created branch {branch} at {commit_sha[:8]}")
+    # Open as a draft, then immediately mark ready-for-review. The
+    # draft->ready transition is what fires the `ready_for_review` webhook that
+    # reviewer-assignment workflows (e.g. transformers' assign-reviewers.yml)
+    # listen for; a PR born non-draft never emits that event and gets no
+    # reviewers routed to it.
     pr = gh.create_pull_request(
         owner,
         repo,
@@ -697,8 +702,12 @@ def _commit_changes(
         head=branch,
         base=req.base_ref,
         body=body,
+        draft=True,
     )
-    emit_fn("log", f"Opened PR #{pr.get('number')}: {pr.get('html_url')}")
+    gh.mark_pull_request_ready(pr["node_id"])
+    emit_fn(
+        "log", f"Opened PR #{pr.get('number')} (draft->ready): {pr.get('html_url')}"
+    )
     if req.slack_notify_pr_created:
         post_task_pr_created_notification(
             token=cfg.slack_bot_token,

--- a/tests/test_github_client_gitdata.py
+++ b/tests/test_github_client_gitdata.py
@@ -78,12 +78,35 @@ class GitDataMethodsTests(unittest.TestCase):
             payload={"number": 7, "html_url": "u"}
         )
         pr = self.gh.create_pull_request(
-            "o", "r", title="t", head="serge/fix-1", base="main", body="b"
+            "o", "r", title="t", head="serge/fix-1", base="main", body="b", draft=True
         )
         self.assertEqual(pr["number"], 7)
         body = self.gh.session.post.call_args.kwargs["json"]
         self.assertEqual(body["head"], "serge/fix-1")
         self.assertEqual(body["base"], "main")
+        self.assertTrue(body["draft"])
+
+    def test_mark_pull_request_ready(self):
+        self.gh.session.post.return_value = _resp(
+            payload={
+                "data": {
+                    "markPullRequestReadyForReview": {"pullRequest": {"isDraft": False}}
+                }
+            }
+        )
+        self.gh.mark_pull_request_ready("PR_node_1")
+        body = self.gh.session.post.call_args.kwargs["json"]
+        self.assertEqual(body["variables"]["id"], "PR_node_1")
+        self.assertIn("markPullRequestReadyForReview", body["query"])
+
+    def test_mark_pull_request_ready_graphql_errors(self):
+        import requests
+
+        self.gh.session.post.return_value = _resp(
+            payload={"errors": [{"message": "not found"}]}
+        )
+        with self.assertRaises(requests.HTTPError):
+            self.gh.mark_pull_request_ready("PR_node_1")
 
     def test_count_branch_commits_by_author(self):
         self.gh.session.get.return_value = _resp(

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -448,6 +448,63 @@ class ValidationGateTests(unittest.TestCase):
         self.assertEqual(chat.content, '{"patch": "v1"}')
         self.assertEqual(len(llm.calls), 1)
 
+    def test_force_final_path_still_validates(self) -> None:
+        """Regression: exhausting the tool budget must NOT bypass the
+        verification gate. The forced final answer has to go through
+        ``validate`` (with tool-less corrections) exactly like an in-budget
+        final answer, or un-normalized patches reach an opened PR."""
+        cfg = _CfgStub(llm_max_input_tokens=1_500_000)
+        # Turn 1: a tool call that pushes cumulative input tokens over the cap,
+        # forcing the loop into its tool-less final-answer tail. Turns 2/3 are
+        # the forced final answer + its tool-less correction.
+        results = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 1_200_000, "completion_tokens": 50},
+                tool_calls=[ToolCall(id="t0", name="noop", arguments="{}")],
+            ),
+            ChatResult(
+                content='{"patch": "v1"}',
+                usage={"prompt_tokens": 400_000, "completion_tokens": 30},
+            ),
+            ChatResult(
+                content='{"patch": "v2"}',
+                usage={"prompt_tokens": 400_000, "completion_tokens": 30},
+            ),
+        ]
+        llm = _FakeLLM(results)
+        seen: list[str] = []
+
+        def validate(chat: ChatResult) -> str | None:
+            seen.append(chat.content)
+            return "normalizer failed, fix it" if chat.content == '{"patch": "v1"}' else None
+
+        chat, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "go"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+            prior_prompt_tokens=400_000,
+            validate=validate,
+            max_validation_retries=2,
+        )
+        # The forced final answer WAS validated, and its rejection drove a
+        # tool-less correction that was then accepted.
+        self.assertEqual(seen, ['{"patch": "v1"}', '{"patch": "v2"}'])
+        self.assertEqual(chat.content, '{"patch": "v2"}')
+        # Turn 1 (tool) + forced final v1 + tool-less correction v2.
+        self.assertEqual(len(llm.calls), 3)
+        # Both forced-final calls run without tools.
+        self.assertNotIn("tools", llm.calls[1])
+        self.assertNotIn("tools", llm.calls[2])
+        # The normalizer feedback re-entered the same conversation.
+        self.assertTrue(
+            any(
+                m.get("role") == "user" and m.get("content") == "normalizer failed, fix it"
+                for m in llm.calls[2]["messages"]
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -120,14 +120,22 @@ class _FakeGH:
         self.updated_refs.append((ref, sha))
         return {}
 
-    def create_pull_request(self, owner, repo, *, title, head, base, body):
+    def create_pull_request(self, owner, repo, *, title, head, base, body, draft=False):
         self.created_pr = {
             "title": title,
             "head": head,
             "base": base,
             "body": body,
+            "draft": draft,
         }
-        return {"number": 99, "html_url": "https://github.com/o/r/pull/99"}
+        return {
+            "number": 99,
+            "html_url": "https://github.com/o/r/pull/99",
+            "node_id": "PR_node_99",
+        }
+
+    def mark_pull_request_ready(self, node_id):
+        self.marked_ready = node_id
 
 
 class BuildTaskRequestTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes that make the Kubernetes `/tasks` normalize gate actually work, plus
supporting deploy tooling and a task-PR reviewer-routing fix. Found during the
first live run of the K8s normalize backend, where the gate turned out to be a
silent no-op (patches committed un-normalized → PRs failing CI code-quality).

## Commits

1. **Fix normalize gate: validate forced-final answers + grant `jobs/status` RBAC** (`717cb07`)
   - `reviewbot/reviewer.py`: `_run_agentic_loop` only validated the *in-budget*
     final answer; when the tool budget was exhausted it returned the
     force-final answer **without** calling `validate()`. Large-repo tasks
     reliably exhaust the budget, so the gate was always skipped. The forced
     final answer now goes through the same `validate()` + retry gate
     (corrections are tool-less — the model fixes its diff from the normalizer
     feedback). Regression test added.
   - `deploy/helm/templates/normalize.yaml`: the `serge-normalize` Role granted
     `batch/jobs` but not the `jobs/status` subresource, so `run_job`'s
     `read_namespaced_job_status` 403'd immediately and the gate fell back to
     accepting the patch un-normalized. Grants `jobs/status: get`.

2. **`deploy.sh`: allow repeated `-f` to layer values overlays** (`c8b057f`)
   Lets `-f prod.yaml -f normalize.example.yaml` layer the normalize backend;
   `--from-head` pins `image.tag` in the first `-f` file.

3. **Open task PRs as draft, then mark ready-for-review** (`d607895`)
   A non-draft PR never emits the `ready_for_review` webhook that
   reviewer-assignment workflows listen for. Opens draft, then transitions via
   the GraphQL `markPullRequestReadyForReview` mutation.

4. **bump** (`66f1d24`)

## A third live-run issue (already applied to the cluster, out of band)

The overlay pointed at a private `ghcr.io/huggingface/transformers-quality`;
the correct image is the public Docker Hub `huggingface/transformers-quality`
that transformers CI builds. That + the RBAC grant are already live on the
cluster (Helm rev 16). The `reviewer.py` fix in this PR still needs a rebuilt
image + redeploy to take effect in prod.

## Testing

- `pytest tests/` → **325 passed**.
- New `test_force_final_path_still_validates` regression test.

AI-assisted (Claude Code); changes reviewed and to be validated end-to-end after rebuild+redeploy.