### PR TITLE
Recover truncated LLM final answers instead of failing the task

### DIFF
--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -643,6 +643,20 @@ _DEFAULT_FORCE_FINAL_MESSAGE = (
     "fences, no extra commentary. Do not request any more tools."
 )
 
+# A final answer that stops with finish_reason="length" ran out of output
+# budget mid-JSON — almost always because reasoning consumed it (the model
+# provider caps completion tokens, so raising max_tokens does not help). Rather
+# than fail the whole task, re-ask for the JSON only with reasoning minimised so
+# the answer fits. Bounded so a pathological model can't loop forever.
+_MAX_TRUNCATION_RETRIES = 2
+_TRUNCATION_RECOVERY_MESSAGE = (
+    "Your previous reply was cut off at the model's output-token limit before "
+    "you produced the complete JSON object — the reasoning used up the budget. "
+    "Reply again with ONLY the final JSON object the task requires: no "
+    "analysis, no explanation, no <think> block, no markdown fences. Keep it "
+    "minimal so the whole answer fits within the output limit."
+)
+
 
 def _run_agentic_loop(
     llm: ChatCompletionClient,
@@ -717,6 +731,10 @@ def _run_agentic_loop(
     iteration = 0
     blind_tool_turns = 0
     validation_retries = 0
+    truncation_retries = 0
+    # Set for one turn to recover a truncated final answer: disable tools and
+    # force minimal reasoning so the whole output budget goes to the JSON.
+    force_json_only = False
     while True:
         iteration += 1
         if iteration > ABSOLUTE_ITER_CEILING:
@@ -770,16 +788,17 @@ def _run_agentic_loop(
         if emit is not None:
             emit("step", f"llm:{label}")
             emit("log", f"LLM turn (blind={label})")
+        turn_tools = None if force_json_only else tools_arg
+        turn_effort = "low" if force_json_only else cfg.llm_reasoning_effort
         chat = llm.complete(
             messages,
             max_tokens=cfg.llm_max_tokens,
-            tools=tools_arg,
-            tool_choice="auto" if tools_arg else None,
+            tools=turn_tools,
+            tool_choice="auto" if turn_tools else None,
             chunk_callback=chunk_cb,
-            extra={"reasoning_effort": cfg.llm_reasoning_effort}
-            if cfg.llm_reasoning_effort
-            else None,
+            extra={"reasoning_effort": turn_effort} if turn_effort else None,
         )
+        force_json_only = False
         metrics.turns += 1
         metrics.latency_seconds += chat.latency_seconds
         if chat.prompt_tokens is not None:
@@ -789,6 +808,28 @@ def _run_agentic_loop(
         _emit_metrics(emit, metrics)
 
         if not chat.tool_calls:
+            # Salvage a truncated final answer before anything else: the model
+            # ran out of output budget mid-JSON (reasoning ate it). Re-ask for
+            # the JSON only, tool-less and low-reasoning, instead of returning
+            # unparseable content that fails the whole task.
+            if (
+                chat.finish_reason == "length"
+                and truncation_retries < _MAX_TRUNCATION_RETRIES
+            ):
+                truncation_retries += 1
+                if emit is not None:
+                    emit(
+                        "log",
+                        "Final answer hit the output-token limit "
+                        f"(recovery {truncation_retries}/{_MAX_TRUNCATION_RETRIES}); "
+                        "re-asking for the JSON only",
+                    )
+                messages.append({"role": "assistant", "content": chat.content or None})
+                messages.append(
+                    {"role": "user", "content": _TRUNCATION_RECOVERY_MESSAGE}
+                )
+                force_json_only = True
+                continue
             if validate is None:
                 return chat, metrics
             # Verification gate: let the caller check the final answer (for

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -4,6 +4,7 @@ from reviewbot.llm_client import ChatResult, ToolCall
 from reviewbot.patch import parse_patch
 from reviewbot.tools import ToolEnv
 from reviewbot.reviewer import (
+    _MAX_TRUNCATION_RETRIES,
     _UnparseableLLMOutput,
     _assistant_tool_call_dict,
     _build_annotated_diff_chunks,
@@ -504,6 +505,73 @@ class ValidationGateTests(unittest.TestCase):
                 for m in llm.calls[2]["messages"]
             )
         )
+
+
+class TruncationRecoveryTests(unittest.TestCase):
+    """A final answer truncated at the provider's output-token limit
+    (finish_reason='length') is re-asked as JSON-only with tools off and
+    minimal reasoning, instead of failing the whole task."""
+
+    def test_truncated_final_answer_is_retried_json_only(self) -> None:
+        cfg = _CfgStub()
+        results = [
+            # Turn 1: a final answer cut off at the output limit (reasoning ate
+            # the budget), leaving the JSON incomplete.
+            ChatResult(
+                content='{"patch": "half of a diff th',
+                usage={"prompt_tokens": 10, "completion_tokens": 16384},
+                finish_reason="length",
+            ),
+            # Turn 2 (recovery): the complete JSON.
+            ChatResult(
+                content='{"patch": "v2"}',
+                usage={"prompt_tokens": 20, "completion_tokens": 30},
+                finish_reason="stop",
+            ),
+        ]
+        llm = _FakeLLM(results)
+        chat, _ = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "go"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        # The complete answer from the recovery turn is returned.
+        self.assertEqual(chat.content, '{"patch": "v2"}')
+        self.assertEqual(len(llm.calls), 2)
+        # Turn 1 had tools; the recovery turn disabled them and forced low
+        # reasoning so the whole output budget goes to the JSON.
+        self.assertIsNotNone(llm.calls[0]["tools"])
+        self.assertIsNone(llm.calls[1]["tools"])
+        self.assertEqual(llm.calls[1]["extra"], {"reasoning_effort": "low"})
+        # The recovery instruction re-entered the same conversation.
+        self.assertTrue(
+            any(
+                m.get("role") == "user"
+                and "output-token limit" in str(m.get("content"))
+                for m in llm.calls[1]["messages"]
+            )
+        )
+
+    def test_truncation_recovery_is_bounded(self) -> None:
+        cfg = _CfgStub()
+        # Always truncated: recovery must give up after _MAX_TRUNCATION_RETRIES
+        # and return the last answer rather than loop forever.
+        always_trunc = ChatResult(
+            content='{"patch": "nope',
+            usage={"prompt_tokens": 10, "completion_tokens": 16384},
+            finish_reason="length",
+        )
+        llm = _FakeLLM([always_trunc])
+        chat, _ = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "go"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        # Initial answer + _MAX_TRUNCATION_RETRIES recovery attempts.
+        self.assertEqual(len(llm.calls), 1 + _MAX_TRUNCATION_RETRIES)
+        self.assertEqual(chat.finish_reason, "length")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Tasks were hard-failing with *"LLM response was truncated before it produced valid review JSON"*. Root cause, verified on live tasks (`00d7410b…`, `10adb392…`):

- `moonshotai/Kimi-K2.7-Code` on the HF Router caps completion at **16384** tokens.
- These tasks stop with `finish_reason=length` at exactly 16384 output tokens, in a single turn with **0 tool calls** — the model spends the whole output budget on reasoning and never closes the JSON.
- **Raising `LLM_MAX_TOKENS` does not help**: we already request `49152`, well above the provider's hard cap. The budget just needs to go to the JSON, not reasoning.

## Fix

`_run_agentic_loop` now recovers a truncated final answer instead of returning unparseable content:

- On a non-tool final answer with `finish_reason == "length"`, re-ask (bounded by `_MAX_TRUNCATION_RETRIES = 2`) with a JSON-only instruction, **tools disabled**, and **reasoning forced low** — so the entire 16384-token budget goes to the JSON.
- Falls back to returning the last answer after the bound (no infinite loop).

## Tests

`test_truncated_final_answer_is_retried_json_only` (recovery re-ask is tool-less + low-reasoning + re-enters the conversation) and `test_truncation_recovery_is_bounded`. Full suite: **330 passed**.

## Not covered (follow-ups noted separately)

- A second failure mode seen on `46927`: `finish_reason=tool_calls` after tool-budget exhaustion → unparseable forced-final. Different path; not addressed here.
- Reasoning/`<think>` output isn't persisted to task history, so failures are hard to diagnose in the UI.

AI-assisted (Claude Code); to be validated end-to-end after rebuild+redeploy.