### PR TITLE
Speed up standalone task checkouts on EFS to avoid clone timeouts

### DIFF
--- a/reviewbot/clone_cache.py
+++ b/reviewbot/clone_cache.py
@@ -355,6 +355,14 @@ class CloneCache:
             auth_args = ["-c", f"http.extraHeader=Authorization: Basic {basic}"]
         redact = (token or "", basic)
 
+        # A standalone checkout is a physical ``git clone --no-hardlinks`` copy
+        # onto the (network) worktree volume; for a large repo on EFS that copy
+        # dominates and, under concurrent load, times out. Fetch only the branch
+        # tip so far fewer objects are copied — the normalizer runs on the
+        # worktree contents, not on history (single-branch already has no
+        # merge-base, so the checkers check all files regardless).
+        fetch_depth = 1 if standalone else depth
+
         lock = self._lock_for(bare)
         with lock:
             try:
@@ -366,10 +374,10 @@ class CloneCache:
                     "core.symlinks=false",
                     "fetch",
                     "--depth",
-                    str(depth),
+                    str(fetch_depth),
                     url,
                     f"+refs/heads/{ref}:{local_branch}",
-                    timeout=180,
+                    timeout=300,
                     redact=redact,
                 )
                 os.utime(bare, None)
@@ -396,7 +404,9 @@ class CloneCache:
                         ],
                         check=True,
                         capture_output=True,
-                        timeout=180,
+                        # Physical object copy onto EFS for a large repo; needs
+                        # generous headroom over the network filesystem.
+                        timeout=600,
                         env=self._env,
                     )
                     # Name the checked-out branch `main`: the transformers


### PR DESCRIPTION
## Problem

Some tasks fail at the checkout step with `could not check out …`. Root cause from serge logs:

```
git clone --local --no-hardlinks … timed out after 180 seconds
```

The kubernetes backend uses a **standalone** checkout (`git clone --local --no-hardlinks`) so the sandbox can bind-mount a self-contained worktree with its own `.git`. For `transformers`, physically copying the object store onto the **EFS** worktree PVC (network filesystem) dominates and, under concurrent load, exceeds the 180s timeout. The branch is fine — the copy is just too slow. (Intermittent: lighter-loaded tasks finish in time.)

## Fix

- **Shallow fetch (`--depth 1`) for standalone checkouts** — far fewer objects to copy. Safe: the normalizer works on the worktree contents, and a single-branch clone already has no merge-base, so the checkers check all files regardless.
- **Raise the standalone clone timeout to 600s** for headroom over EFS.

Review flow (linked worktree, `standalone=False`) is unchanged — it keeps the configured depth and the instant hardlinked worktree.

## Tests

`pytest tests/` → **330 passed** (clone-cache tests included).

## Deeper follow-up (not here)

Every K8s task pays this full copy-to-EFS cost, capping throughput. A shared read-only base + per-task overlay (or reflink/CoW FS) would remove it — larger change, noted for later.

AI-assisted (Claude Code).