### PR TITLE
CI: build the per-task runner + egress-proxy images for Phase 3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,3 +90,44 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-to: type=gha,mode=max
           cache-from: type=gha
+
+  # The serge-egress forward proxy image (docker/Dockerfile.egress-proxy): a
+  # self-built tinyproxy on the Debian base, used as the allowlisting egress
+  # gateway for the per-task pods when taskExecution.kubernetes is enabled.
+  # Built in-house to avoid depending on an unofficial Docker Hub image; point
+  # taskExecution.kubernetes.egress.image at ghcr.io/<repo>-egress:sha-<commit>.
+  build-and-push-egress-proxy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}-egress
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build and push egress-proxy image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.egress-proxy
+          push: true
+          platforms: 'linux/amd64'
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max
+          cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,3 +49,44 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-to: type=gha,mode=max
           cache-from: type=gha
+
+  # The per-task runner image (docker/Dockerfile.task-runner): the target repo's
+  # toolchain image (transformers-quality) with serge layered on top, run as one
+  # pod per /tasks request when taskExecution.kubernetes is enabled. Published
+  # separately from the thin serge app image above; point
+  # taskExecution.kubernetes.image at ghcr.io/<repo>-task-runner:sha-<commit>.
+  build-and-push-task-runner:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}-task-runner
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build and push task-runner image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.task-runner
+          push: true
+          platforms: 'linux/amd64'
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max
+          cache-from: type=gha

--- a/deploy/helm/templates/egress-proxy.yaml
+++ b/deploy/helm/templates/egress-proxy.yaml
@@ -36,7 +36,8 @@ data:
     # Allowlist: deny every host except those matching the filter regexes.
     FilterDefaultDeny Yes
     Filter "/etc/tinyproxy/filter"
-    FilterExtended On
+    # ERE (posix extended regex) — the allowDomains use `(^|\.)…$` anchors.
+    FilterType ere
     FilterCaseSensitive Off
     PidFile "/tmp/tinyproxy.pid"
     LogLevel Info

--- a/docker/Dockerfile.egress-proxy
+++ b/docker/Dockerfile.egress-proxy
@@ -1,0 +1,30 @@
+# serge-egress: a minimal, self-built tinyproxy image for the per-task pod
+# network firewall (SERGE_PERTASK_POD_PLAN.md, "Network firewall").
+#
+# Built from the official Debian base + the distro-maintained `tinyproxy`
+# package so we own the supply chain rather than pulling an unofficial Docker
+# Hub image. Debian's security team ships updates for the package.
+#
+# serge's Helm chart supplies the runtime config (tinyproxy.conf + the allowlist
+# filter) via a read-only ConfigMap mounted at /etc/tinyproxy and runs:
+#   tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf
+# The pod runs non-root with a read-only root filesystem and all capabilities
+# dropped; only /tmp (the PidFile dir) is writable. This image therefore just
+# provides the `tinyproxy` binary and a numeric non-root UID — no baked config.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tinyproxy ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    # Drop the packaged default config: the chart mounts its own at
+    # /etc/tinyproxy, logs go to stdout under `-d`, and the PidFile is /tmp.
+    && rm -f /etc/tinyproxy/tinyproxy.conf
+
+# Numeric non-root UID so the pod's runAsNonRoot admission check passes without
+# the chart pinning runAsUser (65532 = the distroless "nonroot" convention).
+# tinyproxy needs no /etc/passwd entry to run.
+USER 65532:65532
+
+# k8s overrides these via the chart's `command`; kept for plain `docker run`.
+ENTRYPOINT ["tinyproxy"]
+CMD ["-d"]


### PR DESCRIPTION
## What

Adds CI builds for the two images the pod-per-task execution model (PR #35)
needs but nothing built yet, plus a small chart fix:

1. **`build-and-push-task-runner`** → `ghcr.io/<repo>-task-runner:sha-<commit>`
   from `docker/Dockerfile.task-runner` (the `transformers-quality` toolchain +
   serge). This is `taskExecution.kubernetes.image`.
2. **`build-and-push-egress-proxy`** → `ghcr.io/<repo>-egress:sha-<commit>` from
   the new `docker/Dockerfile.egress-proxy` (tinyproxy on `debian:bookworm-slim`,
   the distro-maintained package). This is `taskExecution.kubernetes.egress.image`.
   Built in-house to avoid an unofficial Docker Hub tinyproxy image at the
   network security boundary.
3. Chart: switch `tinyproxy.conf` from the deprecated `FilterExtended On` to
   `FilterType ere` (identical ERE semantics, no deprecation warning).

## Why

The thin serge app image (`python:3.11-slim` + bubblewrap + git) can't run the
in-pod normalizer (`make style` / checkers) — that's what the old separate
normalize Job's toolchain image provided (Phase 4 deleted that path). And the
egress allowlist proxy needs a tinyproxy image. Both are required before
`taskExecution.kubernetes` can be enabled on the cluster.

## Verification

The egress image was smoke-tested locally under the pod's exact securityContext
(non-root UID 65532, read-only rootfs, all caps dropped, no-new-privileges):

- CONNECT `github.com` → 200, `router.huggingface.co` → 404 (tunnel ok) — allowed
- CONNECT `example.com` → **403 blocked**
- CONNECT `github.com.attacker.com` → **403 blocked** (the `$` anchor defeats suffix spoofing)

`helm lint` + `helm template` pass with `taskExecution.kubernetes.enabled=true`.

## After merge

`ghcr.io/huggingface/serge-task-runner:sha-<merge>` and
`ghcr.io/huggingface/serge-egress:sha-<merge>` exist and can be wired into the
prod values to enable Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)