### PR TITLE
prod: enable pod-per-task execution (Phase 3)

### DIFF
--- a/SERGE_PERTASK_POD_PLAN.md
+++ b/SERGE_PERTASK_POD_PLAN.md
@@ -1,14 +1,20 @@
 # Plan: one pod per task (whole LLM loop + normalize in-pod)
 
-Status: **All four phases built (2026-07-02).** Phase 1 proven locally; Phases
-2–3 (launcher behind `TASK_EXECUTION`, docker + kubernetes backends, callback
-ingest, `serge-egress` Helm infra) and Phase 4 (deleted the dead normalize-Job
-code + Helm) landed with tests + `helm lint`. The runner-pod config-propagation
-gap found during Phase 4 is **fixed** (see "Closed" below). **Only remaining
-item: live-cluster verification of Phase 3** — deploy with
-`taskExecution.kubernetes.enabled=true` and confirm git clone + LLM succeed, a
-blocked host fails, the callback reaches serge, and the per-job Secret is GC'd.
-Captured 2026-07-02.
+Status: **All four phases built + deployed to prod (2026-07-02, release rev 19,
+image `sha-0f77376`).** Phase 1 proven locally; Phases 2–3 (launcher behind
+`TASK_EXECUTION`, docker + kubernetes backends, callback ingest, `serge-egress`
+Helm infra) and Phase 4 (deleted the dead normalize-Job code + Helm) landed with
+tests + `helm lint`. The runner-pod config-propagation gap found during Phase 4
+is **fixed** (see "Closed" below).
+
+**Phase 3 live-cluster verification — network firewall DONE (2026-07-02).** From
+a real task-labeled pod (`serge.io/task-pod=true`) on prod: DNS resolves; git
+clone + `github.com` + `router.huggingface.co` succeed through the `serge-egress`
+proxy; `example.com` is 403-blocked; **direct egress bypassing the proxy is
+blocked** (the VPC-CNI NetworkPolicy is genuinely enforced); the serge callback
+Service is reachable via the NO_PROXY bypass. **Remaining: a full end-to-end task
+run** (real launcher → per-job Secret + Job → callback event stream → PR publish
+→ owner-referenced Secret GC) — deferred because it opens a real PR + spends LLM.
 **Supersedes** `SERGE_PERTASK_AGENT_POD_PROPOSAL.md`, whose recommendation ("do
 not merge normalize into the agent pod, to preserve the deny-egress isolation")
 is reversed by an explicit operator decision: the per-task pod may reach the
@@ -84,13 +90,20 @@ own isolated Job.
 
 **Remaining (not code — verification / hardening):**
 
-- **Phase 3 live verify.** On-cluster: `helm upgrade` with
-  `taskExecution.kubernetes.enabled=true`, then confirm git clone + LLM succeed
-  and a blocked host fails (`curl https://example.com` must fail) from inside a
-  task pod. Also confirm the callback reaches serge and the per-job Secret is
-  GC'd. Validate on real infra: the tinyproxy image + config, and whether
-  kube-dns egress should be tightened to ClusterIP injection (the stricter
-  no-DNS stance — currently a documented residual risk).
+- **Phase 3 full e2e (task run).** The network firewall is verified (above); what
+  remains is a real `/tasks` submission on prod to exercise the launcher →
+  per-job Secret + Job → callback event stream → PR publish, and confirm the
+  owner-referenced Secret is **GC'd** after the Job finishes. Deferred: it opens
+  a real PR + spends LLM, so it needs a safe target repo/issue + go-ahead.
+- **Wiz image trust (follow-up).** The three ghcr images (`serge`,
+  `serge-task-runner`, `serge-egress`) fail the "Default image trust admission
+  policy (Wiz CI/CD scan)" — currently **AUDIT-only** (non-blocking). Get them
+  into the Wiz scan pipeline before the policy is enforced, or deploys will break.
+- **Config now in git.** The normalize command + `REVIEW_RULES_PATH` etc. that
+  the retired normalize-Job took from an ad-hoc (never-committed) source now live
+  in `deploy/helm/env/prod.yaml` `envVars`, so the deploy is reproducible.
+- Open question still open: whether kube-dns egress should be tightened to
+  ClusterIP injection (the stricter no-DNS stance — documented residual risk).
 - A full-success **container** e2e (opening a real PR) needs either real creds or
   a `GITHUB_API_URL` override on `GitHubClient` (it hardcodes `api.github.com`) —
   see follow-ups.

--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -9,9 +9,15 @@
 
 image:
   # Bump to a newer sha-<commit> (pushed by CI on merge to main) or use latest.
-  tag: sha-eab6420
+  tag: sha-0f77376
 
 replicas: 1
+
+# serge creates the per-task Job + per-job Secret and reads the egress proxy's
+# ClusterIP, so it needs its own ServiceAccount + Role (rendered by the chart
+# when taskExecution.kubernetes is enabled).
+serviceAccount:
+  create: true
 
 # Sensitive env: create this Secret in the target namespace beforehand
 # (GITHUB_APP_ID, GITHUB_PRIVATE_KEY, GITHUB_WEBHOOK_SECRET,
@@ -56,6 +62,14 @@ envVars:
   TOOL_MAX_ITERATIONS: "30"
   TASK_LLM_MAX_TOKENS: "49152"
   TASK_TOOL_MAX_ITERATIONS: "30"
+  # Normalize gate for /tasks. In the pod-per-task model the runner runs this
+  # command in-process (formerly the separate normalize Job). Unset = gate is
+  # skipped entirely, so it MUST be set. Argv is shlex-split; bash -lc runs the
+  # repo's own normalizer. Mirrors the retired normalize.kubernetes settings.
+  TASK_NORMALIZE_COMMAND: "bash -lc 'make style && python utils/checkers.py ruff_check,ruff_format,init_isort,sort_auto_mappings,types,modeling_structure,auto_mappings,imports,import_complexity,copies,modular_conversion,doc_toc,modeling_rules_doc,docstrings,dummies,repo,inits,pipeline_typing,config_docstrings,config_attributes,doctest_list,update_metadata,deps_table --fix --keep-going'"
+  TASK_NORMALIZE_TIMEOUT: "1800"
+  TASK_NORMALIZE_MAX_RETRIES: "2"
+  REVIEW_RULES_PATH: ".ai/AGENTS.md"
   MENTION_TRIGGER: "@askserge"
   REVIEW_EVENT: "COMMENT"
   TASK_API_ENABLED: "1"
@@ -78,3 +92,23 @@ resources:
   limits:
     cpu: "1"
     memory: 1Gi
+
+# Pod-per-task execution (SERGE_PERTASK_POD_PLAN.md). serge launches one runner
+# pod per /tasks request; the pod runs the whole agent loop + in-process
+# normalize and streams results back over an authenticated callback. All pod
+# egress is forced through the serge-egress allowlist proxy (git + HF LLM only).
+taskExecution:
+  kubernetes:
+    enabled: true
+    # transformers toolchain + serge (docker/Dockerfile.task-runner).
+    image: ghcr.io/huggingface/serge-task-runner:sha-0f77376
+    # Wall-clock cap per task (matches the old in-process worker budget).
+    timeout: 3600
+    # The in-pod normalizer (make style / checkers over transformers) is
+    # memory-hungry; mirror the retired normalize Job's 6Gi.
+    memory: "6Gi"
+    # Schedule task pods on the same CastAI node template as serge.
+    nodeSelector: "scheduling.cast.ai/node-template=default-by-castai"
+    egress:
+      # Self-built tinyproxy (docker/Dockerfile.egress-proxy).
+      image: ghcr.io/huggingface/serge-egress:sha-0f77376


### PR DESCRIPTION
## What

Enables `taskExecution.kubernetes` in the prod overlay and captures the config in
git. **Already deployed** as serge release **rev 19** (image `sha-0f77376`); this
PR makes that state reproducible from `main`.

- `image.tag` → `sha-0f77376`; `serviceAccount.create=true` (serge needs its own
  SA + Role to create the per-task Job + Secret and read the egress ClusterIP).
- `taskExecution.kubernetes`: enabled, task-runner + self-built egress images,
  6Gi pod memory, CastAI nodeSelector.
- Move the normalize-gate config into `envVars` (`TASK_NORMALIZE_COMMAND`,
  `REVIEW_RULES_PATH=.ai/AGENTS.md`, timeout, max retries). These previously came
  from an **ad-hoc, never-committed** `normalize.kubernetes` block; in the
  pod-per-task model the runner reads them from serge's env, and **unset means the
  normalize gate is silently skipped** — so committing them matters.

## Phase 3 verification (live, prod)

From a real task-labeled pod (`serge.io/task-pod=true`):

- ✅ DNS resolves; `git clone` + `github.com` + `router.huggingface.co` succeed
  through the `serge-egress` proxy
- ✅ `example.com` → **403 blocked**
- ✅ **direct egress bypassing the proxy → blocked** (VPC-CNI NetworkPolicy
  genuinely enforced, not just proxy config)
- ✅ serge callback Service reachable via the NO_PROXY bypass

Remaining (not in this PR): a full e2e `/tasks` run to exercise the callback event
stream + per-job Secret GC + PR publish (opens a real PR + spends LLM).

## Note

The three ghcr images fail the Wiz "image trust" admission policy — currently
**AUDIT-only** (non-blocking). Follow-up: get them into the Wiz scan pipeline
before it's enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)