### PR TITLE
fix: route in-pod git checkout through the egress proxy

### DIFF
--- a/reviewbot/clone_cache.py
+++ b/reviewbot/clone_cache.py
@@ -103,6 +103,17 @@ class CloneCache:
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_ASKPASS": "/bin/false",
         }
+        # Pass through egress-proxy config. git subprocesses run with this
+        # curated env, so without these the fetch ignores the pod's proxy and
+        # tries direct egress — which the per-task-pod NetworkPolicy blocks,
+        # hanging the fetch until its timeout. No-op on host/dev runs (unset).
+        for _proxy_var in (
+            "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+            "https_proxy", "http_proxy", "no_proxy",
+        ):
+            _proxy_val = os.environ.get(_proxy_var)
+            if _proxy_val:
+                self._env[_proxy_var] = _proxy_val
         os.makedirs(self._repos_dir, exist_ok=True)
         os.makedirs(self._worktrees_dir, exist_ok=True)
 

--- a/tests/test_clone_cache.py
+++ b/tests/test_clone_cache.py
@@ -156,5 +156,38 @@ class CloneCacheTests(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(co.path, ".ai")))
 
 
+class CloneCacheProxyEnvTests(unittest.TestCase):
+    """The git subprocess env must carry the egress-proxy vars, or in-pod
+    fetches ignore the proxy and hit the (blocked) direct egress path."""
+
+    def test_proxy_vars_passed_through(self) -> None:
+        from unittest import mock
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        with mock.patch.dict(
+            os.environ,
+            {
+                "HTTPS_PROXY": "http://egress:3128",
+                "NO_PROXY": ".svc.cluster.local",
+            },
+            clear=False,
+        ):
+            cache = CloneCache(os.path.join(tmp.name, "cache"))
+        self.assertEqual(cache._env.get("HTTPS_PROXY"), "http://egress:3128")
+        self.assertEqual(cache._env.get("NO_PROXY"), ".svc.cluster.local")
+
+    def test_unset_proxy_vars_absent(self) -> None:
+        from unittest import mock
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ["PATH"] = "/usr/bin"
+            cache = CloneCache(os.path.join(tmp.name, "cache"))
+        self.assertNotIn("HTTPS_PROXY", cache._env)
+        self.assertNotIn("HTTP_PROXY", cache._env)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Live Phase 3 verification (pod-per-task on prod) showed every task erroring at
checkout — `could not check out <repo>@main` — after a ~5-minute hang, on both a
small repo and transformers-test-ci (where the Serge App is installed, ruling
out auth).

## Root cause

`CloneCache._env` is a curated environment used for all its git subprocesses and
it dropped `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY`. The per-task pod's NetworkPolicy
blocks **all** direct egress except the allowlisting `serge-egress` proxy, so the
`git fetch` (timeout=300s) tried a direct connection to github.com, hung, and
timed out — exactly the observed ~5-min failure. (A manual `git clone` in the pod
worked because it inherited the pod's `HTTPS_PROXY`.)

## Fix

Pass the proxy env vars through into `CloneCache._env`. No-op on host/dev runs
where they're unset. Added unit tests for present/absent cases.

## Test
- `pytest tests/test_clone_cache.py tests/test_clone_cache_tasks.py tests/test_task_runner.py` — all pass.
- Will re-run the live e2e against transformers-test-ci after the runner image rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)