### PR TITLE
prod: bump images to sha-da3caca (checkout proxy fix)

### DIFF
--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -9,7 +9,7 @@
 
 image:
   # Bump to a newer sha-<commit> (pushed by CI on merge to main) or use latest.
-  tag: sha-0f77376
+  tag: sha-da3caca
 
 replicas: 1
 
@@ -101,7 +101,7 @@ taskExecution:
   kubernetes:
     enabled: true
     # transformers toolchain + serge (docker/Dockerfile.task-runner).
-    image: ghcr.io/huggingface/serge-task-runner:sha-0f77376
+    image: ghcr.io/huggingface/serge-task-runner:sha-da3caca
     # Wall-clock cap per task (matches the old in-process worker budget).
     timeout: 3600
     # The in-pod normalizer (make style / checkers over transformers) is
@@ -111,4 +111,4 @@ taskExecution:
     nodeSelector: "scheduling.cast.ai/node-template=default-by-castai"
     egress:
       # Self-built tinyproxy (docker/Dockerfile.egress-proxy).
-      image: ghcr.io/huggingface/serge-egress:sha-0f77376
+      image: ghcr.io/huggingface/serge-egress:sha-da3caca


### PR DESCRIPTION
Deployed as rev 20. Picks up the CloneCache egress-proxy passthrough fix (#39) so in-pod task checkout routes through serge-egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)