### PR TITLE
CI: run serge-task-test on the in-VPC runner (aws-general-8-plus)

### DIFF
--- a/.github/workflows/serge-task-test.yml
+++ b/.github/workflows/serge-task-test.yml
@@ -47,7 +47,9 @@ permissions:
 
 jobs:
   run-task:
-    runs-on: aws-general-8-plus
+    # In-VPC self-hosted runner group; reaches the internal ALB directly.
+    runs-on:
+      group: aws-general-8-plus
     steps:
       - name: Mint OIDC token and POST /tasks
         env:

--- a/.github/workflows/serge-task-test.yml
+++ b/.github/workflows/serge-task-test.yml
@@ -2,10 +2,11 @@ name: Serge task (test the /tasks flow)
 
 # Manually-triggered exerciser for serge's write-capable /tasks endpoint.
 #
-# It mints a GitHub Actions OIDC token (audience = serge), joins the VPN via
-# Tailscale so the internal https://serge.huggingface.tech is reachable, and
-# POSTs an instruction + context to /tasks. serge then opens a fix PR (new_pr)
-# or pushes a follow-up commit onto an existing serge fix branch (existing_pr).
+# Runs on the in-VPC self-hosted runner (aws-general-8-plus), which can reach
+# the internal https://serge.huggingface.tech ALB directly — no VPN/Tailscale.
+# It mints a GitHub Actions OIDC token (audience = serge) and POSTs an
+# instruction + context to /tasks. serge then opens a fix PR (new_pr) or pushes
+# a follow-up commit onto an existing serge fix branch (existing_pr).
 #
 # Prerequisites (one-time):
 #   - The Serge GitHub App on this repo holds Contents:write + Pull Requests:write.
@@ -46,20 +47,8 @@ permissions:
 
 jobs:
   run-task:
-    runs-on: ubuntu-latest
+    runs-on: aws-general-8-plus
     steps:
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@v4.1.2
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID_AI_REVIEW }}
-          oauth-secret: ${{ secrets.TS_AUDIENCE_AI_REVIEW }}
-          tags: tag:ci
-          # --accept-routes installs the VPC subnet route advertised by the
-          # in-cluster subnet router so the runner can reach the internal ALB's
-          # private IP. Single flag: the action's `args` doesn't cleanly split
-          # multiple space-separated flags. DNS already resolves publicly.
-          args: --accept-routes
-
       - name: Mint OIDC token and POST /tasks
         env:
           SERGE_URL: https://serge.huggingface.tech

--- a/.github/workflows/serge-task-test.yml
+++ b/.github/workflows/serge-task-test.yml
@@ -54,7 +54,10 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID_AI_REVIEW }}
           oauth-secret: ${{ secrets.TS_AUDIENCE_AI_REVIEW }}
           tags: tag:ci
-          args: --accept-dns=false
+          # --accept-routes is required so the runner installs the subnet route
+          # advertised for the VPC and can reach the internal ALB's private IP.
+          # (DNS stays public: serge.huggingface.tech resolves fine already.)
+          args: --accept-dns=false --accept-routes
 
       - name: Mint OIDC token and POST /tasks
         env:

--- a/.github/workflows/serge-task-test.yml
+++ b/.github/workflows/serge-task-test.yml
@@ -54,10 +54,11 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID_AI_REVIEW }}
           oauth-secret: ${{ secrets.TS_AUDIENCE_AI_REVIEW }}
           tags: tag:ci
-          # --accept-routes is required so the runner installs the subnet route
-          # advertised for the VPC and can reach the internal ALB's private IP.
-          # (DNS stays public: serge.huggingface.tech resolves fine already.)
-          args: --accept-dns=false --accept-routes
+          # --accept-routes installs the VPC subnet route advertised by the
+          # in-cluster subnet router so the runner can reach the internal ALB's
+          # private IP. Single flag: the action's `args` doesn't cleanly split
+          # multiple space-separated flags. DNS already resolves publicly.
+          args: --accept-routes
 
       - name: Mint OIDC token and POST /tasks
         env:


### PR DESCRIPTION
The serge-task-test exerciser ran on ubuntu-latest + Tailscale, which couldn't reach the internal ALB. Switch it to the in-VPC self-hosted runner group (reaches the ALB directly), matching ai-review.yml. Verified end-to-end during Phase 3 live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)