### PR TITLE
Require @askserge to be the first word to trigger a review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -32,13 +32,15 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
-        contains(github.event.comment.body, '@askserge') &&
+        (startsWith(trim(github.event.comment.body), '@askserge ') ||
+        trim(github.event.comment.body) == '@askserge') &&
         (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR')
       ) || (
         github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@askserge') &&
+        (startsWith(trim(github.event.comment.body), '@askserge ') ||
+        trim(github.event.comment.body) == '@askserge') &&
         (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR')

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: 'false'
   mention_trigger:
-    description: 'Phrase that must appear in a comment to trigger a review.'
+    description: 'Phrase that triggers reviews. Must be the first word of the comment.'
     required: false
     default: '@askserge'
   review_event:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ environment variables in server modes.
 
 | Env var | Action input | Default | Description |
 | ------- | ------------ | ------- | ----------- |
-| `MENTION_TRIGGER` | `mention_trigger` | `@askserge` | Phrase that triggers reviews. |
+| `MENTION_TRIGGER` | `mention_trigger` | `@askserge` | Trigger phrase; must be the first word of the comment. |
 | `REVIEW_EVENT` | `review_event` | `COMMENT` | Fallback review event when the model omits one. |
 | `MAX_DIFF_CHARS` | `max_diff_chars` | `200000` | Maximum diff characters sent to the LLM. |
 | `REVIEW_RULES_PATH` | `review_rules_path` | `.ai/review-rules.md` | Rules file read from the target repo default branch. |

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -28,7 +28,8 @@ permissions:
 jobs:
   review:
     if: |
-      contains(github.event.comment.body, '@askserge') &&
+      (startsWith(trim(github.event.comment.body), '@askserge ') ||
+       trim(github.event.comment.body) == '@askserge') &&
       (github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'COLLABORATOR')
@@ -51,11 +52,14 @@ reproducible behavior.
 
 ## Triggering Reviews
 
-Comment on an open PR:
+Comment on an open PR with `@askserge` as the **first word**:
 
 ```text
 @askserge please review
 ```
+
+Mentioning `@askserge` elsewhere in the comment (for example when asking a
+maintainer how to trigger a re-review) does **not** start a review.
 
 You can add instructions after the trigger:
 

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -71,7 +71,7 @@ GitHub sends comment events to `POST /webhook`. A review starts only when:
 
 - the event is `issue_comment` or `pull_request_review_comment`;
 - the action is `created`;
-- the comment contains the configured trigger, default `@askserge`;
+- the comment starts with the configured trigger, default `@askserge` (first word);
 - the author association is `MEMBER`, `OWNER`, or `COLLABORATOR`;
 - the PR is open.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ Check that:
 
 - the event is `issue_comment` or `pull_request_review_comment`;
 - the comment was newly created;
-- the comment contains `MENTION_TRIGGER`, default `@askserge`;
+- the comment **starts with** `MENTION_TRIGGER`, default `@askserge` (first word);
 - the commenter is a `MEMBER`, `OWNER`, or `COLLABORATOR`;
 - the issue comment is on an open PR, not a plain issue.
 

--- a/reviewbot/triggers.py
+++ b/reviewbot/triggers.py
@@ -3,6 +3,18 @@ from typing import Optional
 from .reviewer import InlineCommentContext, ReviewRequest
 
 
+def _comment_starts_with_trigger(body: str, mention_trigger: str) -> bool:
+    """True when ``mention_trigger`` is the first word of ``body``.
+
+    Avoids accidental triggers when a comment merely *discusses* the trigger
+    phrase (e.g. "ask a maintainer to post @askserge to re-review").
+    """
+    stripped = (body or "").lstrip()
+    if not stripped:
+        return False
+    return stripped.split(None, 1)[0] == mention_trigger
+
+
 def build_review_request(
     event_name: str,
     payload: dict,
@@ -26,7 +38,7 @@ def build_review_request(
         return None
 
     comment = payload.get("comment") or {}
-    if mention_trigger not in (comment.get("body") or ""):
+    if not _comment_starts_with_trigger(comment.get("body") or "", mention_trigger):
         return None
     if comment.get("author_association") not in ("MEMBER", "OWNER", "COLLABORATOR"):
         return None

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -134,6 +134,57 @@ class TriggerTests(unittest.TestCase):
         assert req is not None
         self.assertIsNone(req.inline)
 
+    def test_build_review_request_accepts_trigger_after_leading_whitespace(
+        self,
+    ) -> None:
+        payload = {
+            "action": "created",
+            "comment": {
+                "body": "  @askserge please review",
+                "author_association": "MEMBER",
+                "id": 123,
+                "user": {"login": "reviewer"},
+            },
+            "issue": {
+                "pull_request": {
+                    "url": "https://api.github.com/repos/acme/project/pulls/7"
+                },
+                "state": "open",
+                "number": 7,
+            },
+            "repository": {"full_name": "acme/project"},
+        }
+
+        req = build_review_request("issue_comment", payload, "@askserge")
+
+        self.assertIsNotNone(req)
+
+    def test_build_review_request_rejects_mid_comment_trigger(self) -> None:
+        payload = {
+            "action": "created",
+            "comment": {
+                "body": (
+                    "Right, a maintainer need to trigger a new review with "
+                    "@askserge and it would review again"
+                ),
+                "author_association": "MEMBER",
+                "id": 123,
+                "user": {"login": "reviewer"},
+            },
+            "issue": {
+                "pull_request": {
+                    "url": "https://api.github.com/repos/acme/project/pulls/7"
+                },
+                "state": "open",
+                "number": 7,
+            },
+            "repository": {"full_name": "acme/project"},
+        }
+
+        req = build_review_request("issue_comment", payload, "@askserge")
+
+        self.assertIsNone(req)
+
     def test_build_review_request_rejects_non_matching_trigger(self) -> None:
         payload = {
             "action": "created",


### PR DESCRIPTION
## Summary
- Require the mention trigger (`@askserge` by default) to be the **first word** of a comment, not merely present anywhere in the body
- Prevents accidental reviews when someone discusses how to trigger a re-review (e.g. "ask a maintainer to post @askserge")
- Align workflow `if` gates and docs with the new behavior

Fixes #44

## Test plan
- [x] `pytest tests/test_triggers.py` passes (8 tests, including new mid-comment rejection case)
- [ ] Comment `@askserge please review` on a PR → review starts
- [ ] Comment mentioning `@askserge` mid-sentence → no review triggered