### PR TITLE
Fix transformers /tasks failures: bigger budget, empty-answer salvage, and chat-message run logs

### DIFF
--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -9,7 +9,7 @@
 
 image:
   # Bump to a newer sha-<commit> (pushed by CI on merge to main) or use latest.
-  tag: sha-09bcf3a
+  tag: sha-bc6c73d
 
 replicas: 1
 
@@ -112,7 +112,7 @@ taskExecution:
     # draft on the terminal callback. false = reviews run in-process in serge.
     reviewPods: true
     # transformers toolchain + serge (docker/Dockerfile.task-runner).
-    image: ghcr.io/huggingface/serge-task-runner:sha-09bcf3a
+    image: ghcr.io/huggingface/serge-task-runner:sha-bc6c73d
     # Wall-clock cap per task (matches the old in-process worker budget).
     timeout: 3600
     # The in-pod normalizer (make style / checkers over transformers) is
@@ -122,4 +122,4 @@ taskExecution:
     nodeSelector: "scheduling.cast.ai/node-template=default-by-castai"
     egress:
       # Self-built tinyproxy (docker/Dockerfile.egress-proxy).
-      image: ghcr.io/huggingface/serge-egress:sha-09bcf3a
+      image: ghcr.io/huggingface/serge-egress:sha-bc6c73d

--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -61,7 +61,14 @@ envVars:
   LLM_MAX_TOKENS: "49152"
   TOOL_MAX_ITERATIONS: "30"
   TASK_LLM_MAX_TOKENS: "49152"
-  TASK_TOOL_MAX_ITERATIONS: "30"
+  # Tasks run in STRICT budget mode (every tool call counts, not just blind
+  # turns — see reviewer._run_tool_loop), to preserve output budget for the
+  # final patch JSON. 30 was too tight for a repo the size of transformers:
+  # the agent spent the whole budget exploring and never emitted a patch, so
+  # the forced tool-free final turn returned empty/unparseable output. Give
+  # large-repo fixes room to converge. Higher = more exploration but larger
+  # per-turn context (cost + latency); tune against the target repo.
+  TASK_TOOL_MAX_ITERATIONS: "80"
   # Normalize gate for /tasks. In the pod-per-task model the runner runs this
   # command in-process (formerly the separate normalize Job). Unset = gate is
   # skipped entirely, so it MUST be set. Argv is shlex-split; bash -lc runs the

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -501,8 +501,7 @@ class Config:
                 os.environ.get("TASK_K8S_NODE_SELECTOR") or ""
             ).strip()
             or None,
-            task_egress_name=(os.environ.get("TASK_EGRESS_NAME") or "").strip()
-            or None,
+            task_egress_name=(os.environ.get("TASK_EGRESS_NAME") or "").strip() or None,
             slack_bot_token=(
                 os.environ.get("SLACK_CIFEEDBACK_BOT_TOKEN")
                 or os.environ.get("CI_SLACK_BOT_TOKEN")

--- a/reviewbot/review_runner.py
+++ b/reviewbot/review_runner.py
@@ -35,9 +35,7 @@ def build_review_request(spec: RunnerSpec) -> ReviewRequest:
     only the fields the dataclass declares. ``inline`` (webhook follow-up
     context) is left at its default — UI reviews never carry it."""
     fields = {f.name for f in dataclasses.fields(ReviewRequest)}
-    kwargs = {
-        k: v for k, v in spec.request.items() if k in fields and k != "inline"
-    }
+    kwargs = {k: v for k, v in spec.request.items() if k in fields and k != "inline"}
     return ReviewRequest(**kwargs)
 
 

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -868,7 +868,9 @@ def _run_agentic_loop(
                 truncation_retries += 1
                 _emit_final_salvage(emit, chat, truncation_retries)
                 messages.append({"role": "assistant", "content": chat.content or None})
-                messages.append({"role": "user", "content": _final_recovery_message(chat)})
+                messages.append(
+                    {"role": "user", "content": _final_recovery_message(chat)}
+                )
                 force_json_only = True
                 continue
             if validate is None:

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -656,6 +656,41 @@ _TRUNCATION_RECOVERY_MESSAGE = (
     "analysis, no explanation, no <think> block, no markdown fences. Keep it "
     "minimal so the whole answer fits within the output limit."
 )
+# An empty final answer (blank content, usually finish_reason=None) means the
+# model returned nothing parseable — often the provider truncated the stream on
+# a very large context. Re-ask once, tool-free, for just the JSON — same
+# recovery path as the length-truncation case, bounded by the same retry cap.
+_EMPTY_ANSWER_RECOVERY_MESSAGE = (
+    "Your previous reply was empty — no JSON object came through. Reply now "
+    "with ONLY the final JSON object the task requires: no analysis, no "
+    "explanation, no <think> block, no markdown fences."
+)
+
+
+def _needs_final_salvage(chat: ChatResult) -> bool:
+    """True when a tool-free final answer should be re-asked rather than
+    parsed: it either hit the output-token limit (``finish_reason="length"``)
+    or came back with blank content (commonly ``finish_reason=None`` when the
+    provider truncates the stream on a very large context)."""
+    return chat.finish_reason == "length" or not (chat.content or "").strip()
+
+
+def _final_recovery_message(chat: ChatResult) -> str:
+    blank = not (chat.content or "").strip()
+    return _EMPTY_ANSWER_RECOVERY_MESSAGE if blank else _TRUNCATION_RECOVERY_MESSAGE
+
+
+def _emit_final_salvage(
+    emit: Optional[Callable[[str, str], None]], chat: ChatResult, attempt: int
+) -> None:
+    if emit is None:
+        return
+    what = "empty" if not (chat.content or "").strip() else "truncated"
+    emit(
+        "log",
+        f"Final answer was {what} (finish_reason={chat.finish_reason}); re-asking "
+        f"for the JSON only (recovery {attempt}/{_MAX_TRUNCATION_RETRIES})",
+    )
 
 
 def _run_agentic_loop(
@@ -819,26 +854,21 @@ def _run_agentic_loop(
         )
 
         if not chat.tool_calls:
-            # Salvage a truncated final answer before anything else: the model
-            # ran out of output budget mid-JSON (reasoning ate it). Re-ask for
-            # the JSON only, tool-less and low-reasoning, instead of returning
-            # unparseable content that fails the whole task.
+            # Salvage a truncated OR empty final answer before anything else:
+            # the model either ran out of output budget mid-JSON
+            # (finish_reason="length", reasoning ate it) or returned nothing
+            # parseable at all (blank content — commonly finish_reason=None when
+            # the provider truncates a huge-context stream). Re-ask for the JSON
+            # only, tool-less and low-reasoning, instead of returning content
+            # that just fails the parse.
             if (
-                chat.finish_reason == "length"
+                _needs_final_salvage(chat)
                 and truncation_retries < _MAX_TRUNCATION_RETRIES
             ):
                 truncation_retries += 1
-                if emit is not None:
-                    emit(
-                        "log",
-                        "Final answer hit the output-token limit "
-                        f"(recovery {truncation_retries}/{_MAX_TRUNCATION_RETRIES}); "
-                        "re-asking for the JSON only",
-                    )
+                _emit_final_salvage(emit, chat, truncation_retries)
                 messages.append({"role": "assistant", "content": chat.content or None})
-                messages.append(
-                    {"role": "user", "content": _TRUNCATION_RECOVERY_MESSAGE}
-                )
+                messages.append({"role": "user", "content": _final_recovery_message(chat)})
                 force_json_only = True
                 continue
             if validate is None:
@@ -954,6 +984,25 @@ def _run_agentic_loop(
         if chat.completion_tokens is not None:
             metrics.completion_tokens += chat.completion_tokens
         _emit_metrics(emit, metrics)
+        _emit_chat_message(
+            emit,
+            "assistant",
+            content=chat.content,
+            reasoning_chars=chat.reasoning_chars,
+            finish_reason=chat.finish_reason,
+        )
+
+        # Salvage an empty/truncated forced-final answer before validating or
+        # returning it. This is the exact failure the budget-exhausted path used
+        # to die on: an empty completion (finish_reason=None) went straight to
+        # the parser and surfaced as "LLM returned unparseable output". Re-ask
+        # for the JSON only instead (bounded by _MAX_TRUNCATION_RETRIES).
+        if _needs_final_salvage(chat) and truncation_retries < _MAX_TRUNCATION_RETRIES:
+            truncation_retries += 1
+            _emit_final_salvage(emit, chat, truncation_retries)
+            messages.append({"role": "assistant", "content": chat.content or None})
+            messages.append({"role": "user", "content": _final_recovery_message(chat)})
+            continue
 
         # The verification gate must run on the forced final answer too —
         # exhausting the tool budget must not silently bypass validation (for

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -806,6 +806,17 @@ def _run_agentic_loop(
         if chat.completion_tokens is not None:
             metrics.completion_tokens += chat.completion_tokens
         _emit_metrics(emit, metrics)
+        # Log what the model emitted this turn (content + finish_reason +
+        # tool-call names). Captures the empty final turn behind
+        # "unparseable output" failures.
+        _emit_chat_message(
+            emit,
+            "assistant",
+            content=chat.content,
+            reasoning_chars=chat.reasoning_chars,
+            finish_reason=chat.finish_reason,
+            tool_calls=chat.tool_calls,
+        )
 
         if not chat.tool_calls:
             # Salvage a truncated final answer before anything else: the model
@@ -901,6 +912,7 @@ def _run_agentic_loop(
                     "content": result,
                 }
             )
+            _emit_chat_message(emit, "tool", content=result, tool_name=tc.name)
 
     # Iteration budget hit — force a final answer with tools disabled.
     # Only reachable when ``tool_max_iterations > 0`` and the model
@@ -1031,6 +1043,62 @@ def _emit_metrics(
         }
     )
     emit("metrics", payload)
+
+
+# Per-message log cap. Assistant turns are small (the model's own output),
+# but tool results can be large (a grepped file); truncate so the run log
+# stays debuggable without bloating the SQLite job store with the full
+# 500k-token context that already lives in the prompt.
+_LOG_MSG_MAX_CHARS = 2000
+
+
+def _emit_chat_message(
+    emit: Optional[Callable[[str, str], None]],
+    role: str,
+    *,
+    content: Optional[str] = None,
+    reasoning_chars: int = 0,
+    finish_reason: Optional[str] = None,
+    tool_calls: Optional[list[ToolCall]] = None,
+    tool_name: Optional[str] = None,
+) -> None:
+    """Record one chat turn in the run log as a ``message`` event.
+
+    Captures what the model actually emitted each turn — content,
+    reasoning length, finish_reason, tool-call names/args — plus truncated
+    tool results. Deliberately does NOT re-store the giant diff/user
+    context (it is the same every turn and already accounted for in the
+    metrics). This is what makes "LLM returned unparseable output"
+    failures diagnosable: the empty final turn (content="",
+    finish_reason=None) shows up here. Best-effort — never raises into the
+    agent loop."""
+    if emit is None:
+        return
+    payload: dict[str, Any] = {"role": role}
+    if content:
+        payload["content"] = (
+            content
+            if len(content) <= _LOG_MSG_MAX_CHARS
+            else content[:_LOG_MSG_MAX_CHARS]
+            + f"… [+{len(content) - _LOG_MSG_MAX_CHARS} chars truncated]"
+        )
+    if reasoning_chars:
+        payload["reasoning_chars"] = reasoning_chars
+    if finish_reason is not None:
+        payload["finish_reason"] = finish_reason
+    if tool_calls:
+        payload["tool_calls"] = [
+            {"name": tc.name, "arguments": _summarize_args_str(tc.arguments)}
+            for tc in tool_calls
+        ]
+    if tool_name:
+        payload["name"] = tool_name
+    try:
+        # kind "chat" (not "message"): "message" is the SSE default event type,
+        # which would double-fire the browser's onmessage handler.
+        emit("chat", json.dumps(payload))
+    except Exception:  # never let logging break a run
+        log.debug("failed to emit chat message", exc_info=True)
 
 
 def _assistant_tool_call_dict(tc: ToolCall) -> dict[str, Any]:

--- a/reviewbot/static/review.js
+++ b/reviewbot/static/review.js
@@ -168,6 +168,40 @@
   const consolePending = [];
   let consoleFlushScheduled = false;
 
+  // A `message` event carries a JSON payload of what the model emitted that
+  // turn (see reviewer._emit_chat_message). Render it as a readable line.
+  function formatMessageEvent(text) {
+    let m;
+    try {
+      m = JSON.parse(text);
+    } catch (_) {
+      return text;
+    }
+    if (!m || typeof m !== "object") return text;
+    if (m.role === "tool") {
+      return `tool ⟵ ${m.name || "?"}: ${m.content || ""}`;
+    }
+    const parts = [];
+    if (m.content) parts.push(m.content);
+    if (Array.isArray(m.tool_calls) && m.tool_calls.length) {
+      parts.push(
+        "→ " +
+          m.tool_calls.map((t) => `${t.name}(${t.arguments || ""})`).join(", "),
+      );
+    }
+    if (!m.content && !(m.tool_calls && m.tool_calls.length)) {
+      parts.push("(no content)");
+    }
+    const meta = [];
+    if (m.finish_reason != null && m.finish_reason !== "stop") {
+      meta.push(`finish=${m.finish_reason}`);
+    }
+    if (m.reasoning_chars) meta.push(`reasoning=${m.reasoning_chars}c`);
+    let s = `${m.role || "assistant"}: ${parts.join(" ")}`;
+    if (meta.length) s += ` [${meta.join(", ")}]`;
+    return s;
+  }
+
   function flushConsole() {
     consoleFlushScheduled = false;
     if (consolePending.length === 0) return;
@@ -179,8 +213,10 @@
       let prefix = streamed || consoleAtLineStart ? "" : "\n";
       if (kind === "log") prefix += "› ";
       else if (kind === "tool") prefix += "⚙ ";
+      else if (kind === "chat") prefix += "💬 ";
       else if (kind === "error") prefix += "✗ ";
-      const body = prefix + text + (streamed ? "" : "\n");
+      const shown = kind === "chat" ? formatMessageEvent(text) : text;
+      const body = prefix + shown + (streamed ? "" : "\n");
       span.textContent = body;
       frag.appendChild(span);
       consoleAtLineStart = body.endsWith("\n");
@@ -669,6 +705,13 @@
         appendConsole("tool", JSON.parse(ev.data));
       } catch {
         appendConsole("tool", ev.data);
+      }
+    });
+    es.addEventListener("chat", (ev) => {
+      try {
+        appendConsole("chat", JSON.parse(ev.data));
+      } catch {
+        appendConsole("chat", ev.data);
       }
     });
     es.addEventListener("reasoning", (ev) => {

--- a/reviewbot/static/review.js
+++ b/reviewbot/static/review.js
@@ -170,6 +170,37 @@
 
   // A `message` event carries a JSON payload of what the model emitted that
   // turn (see reviewer._emit_chat_message). Render it as a readable line.
+  function formatAssistantContent(content) {
+    if (!content) return "";
+    let o;
+    try {
+      o = JSON.parse(content);
+    } catch (_) {
+      return content;
+    }
+    if (!o || typeof o !== "object") return content;
+    // Task patch answer: {title, body, patch}.
+    if ("patch" in o || "title" in o) {
+      const out = [];
+      if (o.title) out.push(`📝 ${o.title}`);
+      if (o.body) out.push(String(o.body));
+      const patch = String(o.patch || "").trim();
+      out.push(
+        patch
+          ? `⟶ patch: ${patch.split("\n").length} lines`
+          : "⟶ no patch (no change proposed)",
+      );
+      return "\n   " + out.join("\n   ");
+    }
+    // Review answer: {summary, event, comments}.
+    if ("summary" in o || "comments" in o) {
+      const n = Array.isArray(o.comments) ? o.comments.length : 0;
+      const ev = o.event ? ` [${o.event}]` : "";
+      return `\n   ${o.summary || ""}${ev}\n   ⟶ ${n} inline comment${n === 1 ? "" : "s"}`;
+    }
+    return content;
+  }
+
   function formatMessageEvent(text) {
     let m;
     try {
@@ -179,27 +210,25 @@
     }
     if (!m || typeof m !== "object") return text;
     if (m.role === "tool") {
-      return `tool ⟵ ${m.name || "?"}: ${m.content || ""}`;
-    }
-    const parts = [];
-    if (m.content) parts.push(m.content);
-    if (Array.isArray(m.tool_calls) && m.tool_calls.length) {
-      parts.push(
-        "→ " +
-          m.tool_calls.map((t) => `${t.name}(${t.arguments || ""})`).join(", "),
-      );
-    }
-    if (!m.content && !(m.tool_calls && m.tool_calls.length)) {
-      parts.push("(no content)");
+      const first = String(m.content || "").split("\n")[0].slice(0, 140);
+      return `tool ⟵ ${m.name || "?"}: ${first}`;
     }
     const meta = [];
     if (m.finish_reason != null && m.finish_reason !== "stop") {
       meta.push(`finish=${m.finish_reason}`);
     }
     if (m.reasoning_chars) meta.push(`reasoning=${m.reasoning_chars}c`);
-    let s = `${m.role || "assistant"}: ${parts.join(" ")}`;
-    if (meta.length) s += ` [${meta.join(", ")}]`;
-    return s;
+    const metaStr = meta.length ? ` [${meta.join(", ")}]` : "";
+    const calls =
+      Array.isArray(m.tool_calls) && m.tool_calls.length
+        ? " → " +
+          m.tool_calls
+            .map((t) => `${t.name}(${String(t.arguments || "").slice(0, 80)})`)
+            .join(", ")
+        : "";
+    const body = formatAssistantContent(m.content);
+    if (!body && !calls) return `assistant: (thinking…)${metaStr}`;
+    return `assistant:${body ? " " + body : ""}${calls}${metaStr}`;
   }
 
   function flushConsole() {

--- a/reviewbot/static/review.js
+++ b/reviewbot/static/review.js
@@ -210,8 +210,12 @@
     }
     if (!m || typeof m !== "object") return text;
     if (m.role === "tool") {
-      const first = String(m.content || "").split("\n")[0].slice(0, 140);
-      return `tool ⟵ ${m.name || "?"}: ${first}`;
+      // Don't dump the (often large) tool output into the console; just note
+      // the tool and a size hint. Full result is in stored history.
+      const c = String(m.content || "");
+      const lines = c ? c.split("\n").length : 0;
+      const size = lines ? ` (${lines} line${lines === 1 ? "" : "s"})` : "";
+      return `tool ⟵ ${m.name || "?"}${size}`;
     }
     const meta = [];
     if (m.finish_reason != null && m.finish_reason !== "stop") {

--- a/reviewbot/static/styles.css
+++ b/reviewbot/static/styles.css
@@ -37,7 +37,7 @@ body {
 }
 
 main {
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 24px 16px 80px;
 }

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -84,7 +84,26 @@
 
     const es = new EventSource(`${apiBase}/stream`);
     es.onmessage = (e) => { try { append(JSON.parse(e.data)); } catch { append(e.data); } };
-    ["step", "tool", "error", "log"].forEach(kind => {
+    // A `message` event is a JSON payload of what the model emitted that turn
+    // (reviewer._emit_chat_message); render it as one readable line.
+    function fmtMessage(txt) {
+      let m;
+      try { m = JSON.parse(txt); } catch (_) { return txt; }
+      if (!m || typeof m !== "object") return txt;
+      if (m.role === "tool") return `tool ⟵ ${m.name || "?"}: ${m.content || ""}`;
+      const parts = [];
+      if (m.content) parts.push(m.content);
+      if (Array.isArray(m.tool_calls) && m.tool_calls.length)
+        parts.push("→ " + m.tool_calls.map(t => `${t.name}(${t.arguments || ""})`).join(", "));
+      if (!m.content && !(m.tool_calls && m.tool_calls.length)) parts.push("(no content)");
+      const meta = [];
+      if (m.finish_reason != null && m.finish_reason !== "stop") meta.push(`finish=${m.finish_reason}`);
+      if (m.reasoning_chars) meta.push(`reasoning=${m.reasoning_chars}c`);
+      let s = `${m.role || "assistant"}: ${parts.join(" ")}`;
+      if (meta.length) s += ` [${meta.join(", ")}]`;
+      return s;
+    }
+    ["step", "tool", "error", "log", "chat"].forEach(kind => {
       es.addEventListener(kind, (e) => {
         // The browser also fires a native "error" event (no .data) on a
         // dropped connection; ignore those here — es.onerror handles them.
@@ -99,6 +118,7 @@
           b.className = "error";
           b.style.whiteSpace = "pre-wrap";
         }
+        if (kind === "chat") { append(`💬 ${fmtMessage(txt)}`); return; }
         append(kind === "log" ? txt : `[${kind}] ${txt}`);
       });
     });

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -84,24 +84,49 @@
 
     const es = new EventSource(`${apiBase}/stream`);
     es.onmessage = (e) => { try { append(JSON.parse(e.data)); } catch { append(e.data); } };
-    // A `message` event is a JSON payload of what the model emitted that turn
-    // (reviewer._emit_chat_message); render it as one readable line.
+    // A `chat` event is a JSON payload of what the model emitted that turn
+    // (reviewer._emit_chat_message); render it human-readably.
+    function fmtAssistantContent(content) {
+      if (!content) return "";
+      let o;
+      try { o = JSON.parse(content); } catch (_) { return content; }
+      if (!o || typeof o !== "object") return content;
+      // Task patch answer: {title, body, patch}.
+      if ("patch" in o || "title" in o) {
+        const out = [];
+        if (o.title) out.push(`📝 ${o.title}`);
+        if (o.body) out.push(String(o.body));
+        const patch = String(o.patch || "").trim();
+        out.push(patch ? `⟶ patch: ${patch.split("\n").length} lines`
+                        : "⟶ no patch (no change proposed)");
+        return "\n   " + out.join("\n   ");
+      }
+      // Review answer: {summary, event, comments}.
+      if ("summary" in o || "comments" in o) {
+        const n = Array.isArray(o.comments) ? o.comments.length : 0;
+        const ev = o.event ? ` [${o.event}]` : "";
+        return `\n   ${o.summary || ""}${ev}\n   ⟶ ${n} inline comment${n === 1 ? "" : "s"}`;
+      }
+      return content;
+    }
     function fmtMessage(txt) {
       let m;
       try { m = JSON.parse(txt); } catch (_) { return txt; }
       if (!m || typeof m !== "object") return txt;
-      if (m.role === "tool") return `tool ⟵ ${m.name || "?"}: ${m.content || ""}`;
-      const parts = [];
-      if (m.content) parts.push(m.content);
-      if (Array.isArray(m.tool_calls) && m.tool_calls.length)
-        parts.push("→ " + m.tool_calls.map(t => `${t.name}(${t.arguments || ""})`).join(", "));
-      if (!m.content && !(m.tool_calls && m.tool_calls.length)) parts.push("(no content)");
+      if (m.role === "tool") {
+        const first = String(m.content || "").split("\n")[0].slice(0, 140);
+        return `tool ⟵ ${m.name || "?"}: ${first}`;
+      }
       const meta = [];
       if (m.finish_reason != null && m.finish_reason !== "stop") meta.push(`finish=${m.finish_reason}`);
       if (m.reasoning_chars) meta.push(`reasoning=${m.reasoning_chars}c`);
-      let s = `${m.role || "assistant"}: ${parts.join(" ")}`;
-      if (meta.length) s += ` [${meta.join(", ")}]`;
-      return s;
+      const metaStr = meta.length ? ` [${meta.join(", ")}]` : "";
+      const calls = Array.isArray(m.tool_calls) && m.tool_calls.length
+        ? " → " + m.tool_calls.map(t => `${t.name}(${String(t.arguments || "").slice(0, 80)})`).join(", ")
+        : "";
+      const body = fmtAssistantContent(m.content);
+      if (!body && !calls) return `assistant: (thinking…)${metaStr}`;
+      return `assistant:${body ? " " + body : ""}${calls}${metaStr}`;
     }
     ["step", "tool", "error", "log", "chat"].forEach(kind => {
       es.addEventListener(kind, (e) => {

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -114,8 +114,12 @@
       try { m = JSON.parse(txt); } catch (_) { return txt; }
       if (!m || typeof m !== "object") return txt;
       if (m.role === "tool") {
-        const first = String(m.content || "").split("\n")[0].slice(0, 140);
-        return `tool ⟵ ${m.name || "?"}: ${first}`;
+        // Don't dump the (often large) tool output into the console; just
+        // note the tool and a size hint. Full result is in stored history.
+        const c = String(m.content || "");
+        const lines = c ? c.split("\n").length : 0;
+        const size = lines ? ` (${lines} line${lines === 1 ? "" : "s"})` : "";
+        return `tool ⟵ ${m.name || "?"}${size}`;
       }
       const meta = [];
       if (m.finish_reason != null && m.finish_reason !== "stop") meta.push(`finish=${m.finish_reason}`);

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -96,7 +96,9 @@ CREATE INDEX IF NOT EXISTS idx_provider_configs_repo
 
 
 # Kinds of SSE events worth persisting. Token/reasoning chunks blow up
-# the DB on big PRs and are useless after the fact.
+# the DB on big PRs and are useless after the fact. "chat" (per-turn
+# assistant content + tool I/O, already truncated in reviewer) IS kept:
+# it is what makes "unparseable output"-class failures diagnosable.
 PERSIST_EVENT_KINDS = frozenset(
     {
         "log",
@@ -105,6 +107,7 @@ PERSIST_EVENT_KINDS = frozenset(
         "error",
         "done",
         "metrics",
+        "chat",
     }
 )
 

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -340,6 +340,11 @@ class Job:
     # opened the EventSource.
     history: list[dict[str, Any]] = field(default_factory=list)
     history_lock: threading.Lock = field(default_factory=threading.Lock)
+    # Monotonic per-event id, stamped in _push_event and emitted as the SSE
+    # `id:` field. On reconnect the browser sends Last-Event-ID; the stream
+    # skips replay events at/below it so a dropped-and-reconnected client
+    # doesn't re-render the whole transcript (the "doubled lines" bug).
+    event_seq: int = 0
     # Running tally of "noisy" (token/reasoning) entries currently in
     # history. Lets _push_event do bounded-FIFO eviction in O(1) average
     # instead of scanning the full history on every streaming chunk.
@@ -852,8 +857,10 @@ def _push_event(job: Job, kind: str, text: str) -> None:
     """Thread-safe push from the worker thread into the job's queue.
     Also appends to the replay buffer so late SSE subscribers get the
     full transcript."""
-    event = {"kind": kind, "text": text, "ts": time.time()}
     with job.history_lock:
+        seq = job.event_seq
+        job.event_seq += 1
+        event = {"kind": kind, "text": text, "ts": time.time(), "seq": seq}
         job.history.append(event)
         if kind in _NOISY_KINDS:
             job.noisy_history_count += 1
@@ -3301,12 +3308,16 @@ async def review_stream(
         # the page. The draft is what matters once the job is done; the
         # remaining structural events still show clone/fetch/llm/tool
         # progress so the console isn't blank.
+        last_id = _last_event_id(request)
         finished = job.status in ("done", "error", "discarded", "published")
         with job.history_lock:
             if finished:
                 replay = [e for e in job.history if e["kind"] not in _NOISY_KINDS]
             else:
                 replay = list(job.history)
+        if last_id is not None:
+            # Reconnect: only replay events the client hasn't seen.
+            replay = [e for e in replay if e.get("seq", -1) > last_id]
         for event in replay:
             yield _sse_format(event)
         # If the job already finished while we were replaying, stop here.
@@ -3340,14 +3351,31 @@ async def review_stream(
     )
 
 
+def _last_event_id(request: Request) -> Optional[int]:
+    """The browser sends Last-Event-ID automatically when EventSource
+    reconnects. Return it as an int so the stream can resume just past it
+    instead of replaying the whole transcript (which doubled the console)."""
+    raw = request.headers.get("last-event-id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _sse_format(event: dict[str, Any]) -> str:
     kind = event.get("kind", "log")
     text = event.get("text", "")
+    seq = event.get("seq")
+    # The `id:` lets the browser resume via Last-Event-ID after a dropped
+    # connection instead of replaying from the top (the doubled-lines bug).
+    id_line = f"id: {seq}\n" if seq is not None else ""
     # Use SSE event= for non-default kinds; "log" stays the default
     # message event so the browser handler doesn't need to special-case.
     if kind == "log":
-        return f"data: {_json_inline(text)}\n\n"
-    return f"event: {kind}\ndata: {_json_inline(text)}\n\n"
+        return f"{id_line}data: {_json_inline(text)}\n\n"
+    return f"{id_line}event: {kind}\ndata: {_json_inline(text)}\n\n"
 
 
 def _json_inline(s: str) -> str:
@@ -3502,12 +3530,16 @@ async def task_stream(
     job = _get_task_job(request, owner, repo, job_id)
 
     async def generator():
+        last_id = _last_event_id(request)
         finished = job.status in ("done", "error", "discarded", "published")
         with job.history_lock:
             if finished:
                 replay = [e for e in job.history if e["kind"] not in _NOISY_KINDS]
             else:
                 replay = list(job.history)
+        if last_id is not None:
+            # Reconnect: only replay events the client hasn't seen.
+            replay = [e for e in replay if e.get("seq", -1) > last_id]
         for event in replay:
             yield _sse_format(event)
         if finished:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -35,7 +35,9 @@ class EmitChatMessageTests(unittest.TestCase):
             content="looking at the diff",
             reasoning_chars=42,
             finish_reason="tool_calls",
-            tool_calls=[ToolCall(id="t0", name="read_file", arguments='{"path":"a.py"}')],
+            tool_calls=[
+                ToolCall(id="t0", name="read_file", arguments='{"path":"a.py"}')
+            ],
         )
         self.assertEqual(len(events), 1)
         kind, text = events[0]
@@ -75,19 +77,25 @@ class EmitChatMessageTests(unittest.TestCase):
 class FinalSalvageTests(unittest.TestCase):
     def test_empty_content_needs_salvage(self) -> None:
         # The production failure: empty completion, finish_reason=None.
-        self.assertTrue(_needs_final_salvage(ChatResult(content="", finish_reason=None)))
+        self.assertTrue(
+            _needs_final_salvage(ChatResult(content="", finish_reason=None))
+        )
         self.assertTrue(
             _needs_final_salvage(ChatResult(content="   \n", finish_reason=None))
         )
 
     def test_length_truncation_needs_salvage(self) -> None:
         self.assertTrue(
-            _needs_final_salvage(ChatResult(content='{"partial', finish_reason="length"))
+            _needs_final_salvage(
+                ChatResult(content='{"partial', finish_reason="length")
+            )
         )
 
     def test_good_answer_does_not_need_salvage(self) -> None:
         self.assertFalse(
-            _needs_final_salvage(ChatResult(content='{"ok": true}', finish_reason="stop"))
+            _needs_final_salvage(
+                ChatResult(content='{"ok": true}', finish_reason="stop")
+            )
         )
 
     def test_recovery_message_varies_by_cause(self) -> None:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -12,6 +12,8 @@ from reviewbot.reviewer import (
     _build_annotated_diff_chunks,
     _content_preview,
     _emit_chat_message,
+    _final_recovery_message,
+    _needs_final_salvage,
     _extract_json,
     _merge_chunk_event,
     _merge_chunk_summaries,
@@ -68,6 +70,34 @@ class EmitChatMessageTests(unittest.TestCase):
 
     def test_none_emit_is_a_noop(self) -> None:
         _emit_chat_message(None, "assistant", content="hi")  # must not raise
+
+
+class FinalSalvageTests(unittest.TestCase):
+    def test_empty_content_needs_salvage(self) -> None:
+        # The production failure: empty completion, finish_reason=None.
+        self.assertTrue(_needs_final_salvage(ChatResult(content="", finish_reason=None)))
+        self.assertTrue(
+            _needs_final_salvage(ChatResult(content="   \n", finish_reason=None))
+        )
+
+    def test_length_truncation_needs_salvage(self) -> None:
+        self.assertTrue(
+            _needs_final_salvage(ChatResult(content='{"partial', finish_reason="length"))
+        )
+
+    def test_good_answer_does_not_need_salvage(self) -> None:
+        self.assertFalse(
+            _needs_final_salvage(ChatResult(content='{"ok": true}', finish_reason="stop"))
+        )
+
+    def test_recovery_message_varies_by_cause(self) -> None:
+        empty = _final_recovery_message(ChatResult(content="", finish_reason=None))
+        truncated = _final_recovery_message(
+            ChatResult(content='{"partial', finish_reason="length")
+        )
+        self.assertIn("empty", empty)
+        self.assertIn("cut off", truncated)
+        self.assertNotEqual(empty, truncated)
 
 
 class AssistantToolCallDictTests(unittest.TestCase):

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,20 +1,73 @@
+import json
 import unittest
 
 from reviewbot.llm_client import ChatResult, ToolCall
 from reviewbot.patch import parse_patch
 from reviewbot.tools import ToolEnv
 from reviewbot.reviewer import (
+    _LOG_MSG_MAX_CHARS,
     _MAX_TRUNCATION_RETRIES,
     _UnparseableLLMOutput,
     _assistant_tool_call_dict,
     _build_annotated_diff_chunks,
     _content_preview,
+    _emit_chat_message,
     _extract_json,
     _merge_chunk_event,
     _merge_chunk_summaries,
     _run_agentic_loop,
     _summarize_rejected_comments,
 )
+
+
+class EmitChatMessageTests(unittest.TestCase):
+    def _capture(self):
+        events: list[tuple[str, str]] = []
+        return events, (lambda kind, text: events.append((kind, text)))
+
+    def test_assistant_turn_records_content_and_tool_calls(self) -> None:
+        events, emit = self._capture()
+        _emit_chat_message(
+            emit,
+            "assistant",
+            content="looking at the diff",
+            reasoning_chars=42,
+            finish_reason="tool_calls",
+            tool_calls=[ToolCall(id="t0", name="read_file", arguments='{"path":"a.py"}')],
+        )
+        self.assertEqual(len(events), 1)
+        kind, text = events[0]
+        # "chat", NOT "message": "message" is the SSE default event type.
+        self.assertEqual(kind, "chat")
+        payload = json.loads(text)
+        self.assertEqual(payload["role"], "assistant")
+        self.assertEqual(payload["content"], "looking at the diff")
+        self.assertEqual(payload["reasoning_chars"], 42)
+        self.assertEqual(payload["finish_reason"], "tool_calls")
+        self.assertEqual(payload["tool_calls"][0]["name"], "read_file")
+
+    def test_empty_final_turn_is_still_logged(self) -> None:
+        # The exact failure mode we need visible: an empty completion with
+        # finish_reason=None must produce a record (with no content key).
+        events, emit = self._capture()
+        _emit_chat_message(emit, "assistant", content="", finish_reason=None)
+        self.assertEqual(len(events), 1)
+        payload = json.loads(events[0][1])
+        self.assertEqual(payload["role"], "assistant")
+        self.assertNotIn("content", payload)
+        self.assertNotIn("finish_reason", payload)
+
+    def test_long_tool_result_is_truncated(self) -> None:
+        events, emit = self._capture()
+        big = "x" * (_LOG_MSG_MAX_CHARS + 500)
+        _emit_chat_message(emit, "tool", content=big, tool_name="grep")
+        payload = json.loads(events[0][1])
+        self.assertEqual(payload["name"], "grep")
+        self.assertLess(len(payload["content"]), len(big))
+        self.assertIn("truncated", payload["content"])
+
+    def test_none_emit_is_a_noop(self) -> None:
+        _emit_chat_message(None, "assistant", content="hi")  # must not raise
 
 
 class AssistantToolCallDictTests(unittest.TestCase):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -110,6 +110,50 @@ class JobStoreTests(unittest.TestCase):
             self.assertEqual(entries[0]["prompt_tokens"], 999)
             self.assertEqual(entries[0]["completion_tokens"], 222)
 
+    def test_persists_chat_events_but_drops_token_stream(self) -> None:
+        # "chat" events (assistant turns + tool I/O) must survive to the
+        # stored history so unparseable-output failures stay debuggable;
+        # token/reasoning chunks must still be dropped.
+        with tempfile.TemporaryDirectory() as tmp:
+            db = os.path.join(tmp, "jobs.db")
+            store = JobStore(db)
+            store.insert_job(
+                id="j3",
+                user="bob",
+                target_owner="o",
+                target_repo="r",
+                target_number=3,
+                trigger_comment="x",
+                llm_provider="hf",
+                llm_api_base="https://router.huggingface.co/v1",
+                llm_model="moonshotai/Kimi-K2.6",
+                created_at=3.0,
+                status="running",
+            )
+            history = [
+                {"kind": "chat", "text": json.dumps({"role": "assistant"})},
+                {"kind": "tool", "text": "read_file(...)"},
+                {"kind": "token", "text": "noise"},
+                {"kind": "reasoning", "text": "noise"},
+            ]
+            store.save_terminal(
+                "j3",
+                status="error",
+                error="boom",
+                raw_llm_output=None,
+                draft=None,
+                history=history,
+            )
+            conn = sqlite3.connect(db)
+            raw = conn.execute(
+                "SELECT history_json FROM jobs WHERE id = ?", ("j3",)
+            ).fetchone()[0]
+            kinds = [e["kind"] for e in json.loads(raw)]
+            self.assertIn("chat", kinds)
+            self.assertIn("tool", kinds)
+            self.assertNotIn("token", kinds)
+            self.assertNotIn("reasoning", kinds)
+
     def test_persists_generated_and_published_review(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             store = JobStore(os.path.join(tmp, "jobs.db"))

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -800,8 +800,9 @@ class TaskLauncherTests(unittest.TestCase):
         )
         from reviewbot.store import encode_draft
 
-        with patch.object(webapp, "_persist_terminal"), patch.object(
-            webapp, "_notify_task_finished"
+        with (
+            patch.object(webapp, "_persist_terminal"),
+            patch.object(webapp, "_notify_task_finished"),
         ):
             client = TestClient(webapp.app)
             r = client.post(


### PR DESCRIPTION
## Why

Every recent `huggingface/transformers` `/tasks` job was failing with *"LLM returned unparseable output (finish_reason=None)"* — 20/20 in a row. Investigation showed two compounding causes, and fixing them surfaced a logging gap and some UI rough edges. This PR bundles the whole fix.

## Root cause

1. **Budget too small.** Tasks run in *strict* mode (every tool call counts). 30 tool calls wasn't enough for a repo the size of transformers — the agent spent its whole budget exploring and never emitted a patch.
2. **No salvage for empty final answers.** When the budget was exhausted, serge forced one tool-free final turn and handed its output straight to the parser. That turn came back **empty with `finish_reason=None`** (the provider truncating a huge-context stream), so it surfaced as "unparseable output". The existing salvage only handled `finish_reason="length"`.

## Changes

- **Salvage empty / `None`-finish final answers** (`reviewer.py`): both final-answer paths now re-ask once for the JSON only when the answer is empty or hit the output-token limit, bounded by `_MAX_TRUNCATION_RETRIES`.
- **Raise the task tool budget 30 → 80** (`prod.yaml`) so large-repo fixes can converge.
- **Log chat messages in the run transcript**: `_run_agentic_loop` emits a `chat` event per turn (assistant content, reasoning length, `finish_reason`, tool-call names/args) plus truncated tool results — so unparseable-output-class failures are debuggable after the fact. `chat`, not `message` (the SSE default type). Persisted via `PERSIST_EVENT_KINDS` (token/reasoning still dropped).
- **Web UI**: assistant patch/review answers render human-readably (📝 title + body + "patch: N lines", or summary + inline-comment count) instead of raw JSON; tool results collapse to a single line with a size hint (full content stays in stored history); fixed doubled console lines on SSE reconnect via `seq` + `Last-Event-ID` resumption; widened the shared page container 960 → 1200px.
