### PR TITLE
CI: fix a few issues and revert debug flag

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -32,15 +32,15 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.issue.state == 'open' &&
-        (startsWith(trim(github.event.comment.body), '@askserge ') ||
-        trim(github.event.comment.body) == '@askserge') &&
+        (startsWith(github.event.comment.body, '@askserge ') ||
+        github.event.comment.body == '@askserge') &&
         (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR')
       ) || (
         github.event_name == 'pull_request_review_comment' &&
-        (startsWith(trim(github.event.comment.body), '@askserge ') ||
-        trim(github.event.comment.body) == '@askserge') &&
+        (startsWith(github.event.comment.body, '@askserge ') ||
+        github.event.comment.body == '@askserge') &&
         (github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,28 @@ permissions:
   contents: read
 
 jobs:
+  # Lint the workflow files themselves first. actionlint statically checks
+  # ${{ }} expressions (incl. that functions like startsWith/contains exist),
+  # which catches errors that otherwise only surface as a startup failure with
+  # zero jobs run — e.g. the invalid trim() that broke ai-review.yml.
+  actionlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.11/scripts/download-actionlint.bash) 1.7.11
+        shell: bash
+
+      - name: Lint workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+
   test:
+    needs: actionlint
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +55,7 @@ jobs:
         run: make test
 
   helm:
+    needs: actionlint
     runs-on: ubuntu-latest
 
     steps:

--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -106,10 +106,6 @@ envVars:
   MENTION_TRIGGER: "@askserge"
   REVIEW_EVENT: "COMMENT"
   TASK_API_ENABLED: "1"
-  # DEBUG (temporary): run only the first N /tasks per burst so a manual
-  # retrigger of the nightly triage is a short crash-repro cycle, not the whole
-  # batch. Remove once the runner-startup crash is diagnosed.
-  TASK_DEBUG_MAX_TASKS: "3"
   # Refuse to run PR-author subprocesses unless bubblewrap is available.
   # Requires the node to allow unprivileged user namespaces; if pods fail
   # to run reviews, switch to "auto".

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -28,8 +28,8 @@ permissions:
 jobs:
   review:
     if: |
-      (startsWith(trim(github.event.comment.body), '@askserge ') ||
-       trim(github.event.comment.body) == '@askserge') &&
+      (startsWith(github.event.comment.body, '@askserge ') ||
+       github.event.comment.body == '@askserge') &&
       (github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'COLLABORATOR')


### PR DESCRIPTION
Three related changes.

## 1. Drop the `TASK_DEBUG_MAX_TASKS` debug cap

Removes the temporary `TASK_DEBUG_MAX_TASKS: "3"` cap (and comment) from `deploy/helm/env/prod.yaml`. Added alongside runner crash self-reporting (#50) to keep manual triage retriggers short — its comment said *"Remove once the runner-startup crash is diagnosed."* Now the nightly triage runs the full batch again instead of only the first 3. The mechanism in `reviewbot/webapp.py` stays (unset = no cap) as a debug knob.

## 2. Fix `ai-review.yml` startup failure

`trim()` is **not** a valid GitHub Actions expression function, so its use in the job `if:` (added in #45) made the workflow fail to compile — a **startup failure with zero jobs run**, e.g. [run 28783571654](https://github.com/huggingface/serge/actions/runs/28783571654). Dropped it; `startsWith(comment.body, '@askserge ')` already enforces "@askserge as the first word", so #45's intent is preserved (only leading-whitespace tolerance is lost). Same fix applied to the workflow example in `docs/github-action.md`.

## 3. Lint workflows in CI so this can't recur

Adds an `actionlint` job to `tests.yml` that the `test` and `helm` jobs depend on (runs first, gates the rest). actionlint statically validates `${{ }}` expressions — including that called functions exist — so an invalid function like `trim()` fails the PR check with a clear message instead of silently producing a zero-job startup failure. Pinned to actionlint v1.7.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)