### PR TITLE
admin: add "Test" button to validate a provider token can run inference

### DIFF
--- a/reviewbot/static/admin.js
+++ b/reviewbot/static/admin.js
@@ -213,9 +213,19 @@
       tr.appendChild(tdUpdated);
 
       const tdActions = document.createElement("td");
+      const testBtn = document.createElement("button");
+      testBtn.type = "button";
+      testBtn.className = "secondary";
+      testBtn.textContent = "Test";
+      testBtn.title = "Run a tiny inference call with this token to check it works.";
+      const result = document.createElement("span");
+      result.className = "test-result";
+      result.style.marginLeft = "8px";
+      testBtn.addEventListener("click", () => testConfig(cfg, testBtn, result));
       const editBtn = document.createElement("button");
       editBtn.type = "button";
       editBtn.className = "secondary";
+      editBtn.style.marginLeft = "8px";
       editBtn.textContent = "Edit";
       editBtn.addEventListener("click", () => startEdit(cfg));
       const delBtn = document.createElement("button");
@@ -224,8 +234,10 @@
       delBtn.style.marginLeft = "8px";
       delBtn.textContent = "Delete";
       delBtn.addEventListener("click", () => deleteConfig(cfg));
+      tdActions.appendChild(testBtn);
       tdActions.appendChild(editBtn);
       tdActions.appendChild(delBtn);
+      tdActions.appendChild(result);
       tr.appendChild(tdActions);
 
       tbody.appendChild(tr);
@@ -246,6 +258,48 @@
       renderConfigs(data.configs || []);
     } catch (err) {
       showError(`Could not load configs — ${err.message}`);
+    }
+  }
+
+  async function testConfig(cfg, btn, result) {
+    clearError();
+    btn.disabled = true;
+    const prev = btn.textContent;
+    btn.textContent = "Testing…";
+    result.textContent = "";
+    result.removeAttribute("title");
+    try {
+      const r = await fetch(
+        `/admin/providers/${encodeURIComponent(cfg.id)}/test`,
+        { method: "POST" },
+      );
+      if (!r.ok) {
+        // Transport/auth failure (e.g. 404 config_not_found), not a token verdict.
+        showError(`Could not test — ${await errorMessage(r)}`);
+        result.textContent = "✗";
+        result.style.color = "var(--danger, #c0392b)";
+        return;
+      }
+      const data = await r.json();
+      if (data.ok) {
+        result.textContent = `✓ OK${data.model ? ` (${data.model})` : ""}`;
+        result.style.color = "var(--ok, #2e7d32)";
+        result.title = data.message || "Token is valid.";
+      } else {
+        // A bad token is an expected outcome — surface the provider's own
+        // error (the 403 / rate-limit / auth text) prominently.
+        result.textContent = "✗ failed";
+        result.style.color = "var(--danger, #c0392b)";
+        result.title = data.error || "Token check failed.";
+        showError(`Token check failed — ${data.error || "unknown error"}`);
+      }
+    } catch (err) {
+      showError(`Could not test — ${err.message}`);
+      result.textContent = "✗";
+      result.style.color = "var(--danger, #c0392b)";
+    } finally {
+      btn.disabled = false;
+      btn.textContent = prev;
     }
   }
 

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -66,7 +66,7 @@ from .launcher import (
 )
 from .errors import format_github_http_error as _format_github_http_error
 from .errors import format_llm_error as _format_llm_error
-from .llm_client import LLMResponseError
+from .llm_client import ChatCompletionClient, LLMResponseError
 from .oidc import OIDCError, verify_token
 from .reviewer import (
     DraftComment,
@@ -2756,6 +2756,55 @@ def admin_delete_provider(request: Request, config_id: str) -> JSONResponse:
         raise HTTPException(status_code=404, detail="config_not_found")
     log.info("user %s deleted provider config %s", user, config_id)
     return JSONResponse({"status": "deleted"})
+
+
+@app.post("/admin/providers/{config_id}/test")
+def admin_test_provider(request: Request, config_id: str) -> JSONResponse:
+    """Exercise a saved provider config end-to-end so an admin can confirm the
+    token actually works *before* a review fails on it.
+
+    Resolves the endpoint/model/billing exactly as a real review would, then
+    makes one tiny chat-completion with the stored key (and, for HF, the
+    ``X-HF-Bill-To`` org header). A ``/models`` GET is not enough: the common
+    failure is a token that lists models fine but lacks permission to *call*
+    Inference Providers on behalf of the org — that only shows on a real
+    completion. Returns ``{ok: true, model}`` on success, or ``{ok: false,
+    error}`` carrying the provider's own message (e.g. the 403 "insufficient
+    permissions … on behalf of org …") so the fix is obvious. Always HTTP 200
+    — ``ok`` is the verdict; a bad token is an expected result, not a server
+    error."""
+    _require_same_origin(request)
+    user = _require_user(request)
+    row = _store.get_provider_config(config_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="config_not_found")
+    provider = row["provider"]
+    api_base = _api_base_for_provider(provider, custom_base=row.get("api_base"))
+    model = (
+        (row.get("default_model") or "").strip()
+        or _LLM_PROVIDER_DEFAULT_MODELS.get(provider)
+        or None
+    )
+    bill_to = _llm_bill_to_for_provider(provider)
+    client = ChatCompletionClient(
+        api_base, row["api_key"], model=model, bill_to=bill_to, stream=False
+    )
+    log.info("user %s testing provider config %s (%s)", user, config_id, provider)
+    try:
+        # max_tokens=1: we only need the request to be *accepted*; the auth/
+        # permission failure (401/403) fires before any tokens are generated.
+        client.complete(
+            [{"role": "user", "content": "ping"}], max_tokens=1, temperature=0.0
+        )
+    except LLMResponseError as exc:
+        return JSONResponse({"ok": False, "error": _format_llm_error(exc)})
+    except Exception as exc:  # noqa: BLE001 — surface any dial/timeout/discovery failure
+        return JSONResponse({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+    resolved = client.model or model or ""
+    message = "Token is valid and can run inference"
+    if bill_to:
+        message += f" (billed to {bill_to})"
+    return JSONResponse({"ok": True, "model": resolved, "message": message + "."})
 
 
 # --- debug-only task cap -----------------------------------------------------

--- a/tests/test_webapp_admin.py
+++ b/tests/test_webapp_admin.py
@@ -86,5 +86,111 @@ class WebappAdminViewTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
 
+class ProviderTestEndpointTests(unittest.TestCase):
+    """POST /admin/providers/{id}/test makes one tiny inference call with the
+    stored key and reports the verdict, so an admin can catch a bad token
+    before a review fails on it."""
+
+    def _build(self):
+        sys.modules.pop("reviewbot.webapp", None)
+        env = {
+            "DEV_NO_AUTH": "1",
+            "GITHUB_APP_ID": "123",
+            "GITHUB_PRIVATE_KEY": "dummy-private-key",
+            "GITHUB_WEBHOOK_SECRET": "webhook-secret",
+            "LLM_API_KEY": "llm-token",
+            "LLM_BILL_TO": "huggingface",
+            "WEB_STORE_PATH": os.path.join(self.tmpdir, "jobs.db"),
+            "WEB_CLONE_CACHE_DIR": os.path.join(self.tmpdir, "clones"),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            webapp = importlib.import_module("reviewbot.webapp")
+        return webapp, TestClient(webapp.app)
+
+    def setUp(self) -> None:
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    def _insert_config(self, webapp, config_id="cfg-1"):
+        webapp._store.insert_provider_config(
+            id=config_id,
+            provider="hf",
+            api_key="hf-token",
+            api_base=None,
+            default_model="zai-org/GLM-5.2",
+            repo_pattern="huggingface/*",
+            allowed_users=[],
+            allowed_orgs=["huggingface"],
+            created_by="dev",
+        )
+        return config_id
+
+    def test_missing_config_is_404(self):
+        webapp, client = self._build()
+        r = client.post(
+            "/admin/providers/nope/test", headers={"Origin": "http://testserver"}
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_valid_token_reports_ok(self):
+        webapp, client = self._build()
+        cfg_id = self._insert_config(webapp)
+
+        class _FakeClient:
+            def __init__(self, api_base, api_key, *, model=None, bill_to=None, **kw):
+                # The billing org must be forwarded so the test reproduces the
+                # exact permission a real review needs.
+                assert bill_to == "huggingface"
+                self.model = model
+
+            def complete(self, messages, **kw):
+                return object()
+
+        with patch.object(webapp, "ChatCompletionClient", _FakeClient):
+            r = client.post(
+                f"/admin/providers/{cfg_id}/test",
+                headers={"Origin": "http://testserver"},
+            )
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["model"], "zai-org/GLM-5.2")
+        self.assertIn("huggingface", data["message"])
+
+    def test_bad_token_surfaces_provider_error(self):
+        from reviewbot.llm_client import LLMResponseError
+
+        webapp, client = self._build()
+        cfg_id = self._insert_config(webapp)
+        exc = LLMResponseError(
+            403,
+            "Forbidden",
+            "https://router.huggingface.co/v1/chat/completions",
+            '{"error":"insufficient permissions to call Inference Providers '
+            'on behalf of org huggingface"}',
+        )
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                self.model = kw.get("model")
+
+            def complete(self, messages, **kw):
+                raise exc
+
+        with patch.object(webapp, "ChatCompletionClient", _FakeClient):
+            r = client.post(
+                f"/admin/providers/{cfg_id}/test",
+                headers={"Origin": "http://testserver"},
+            )
+        # A bad token is a verdict, not a server error.
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertFalse(data["ok"])
+        self.assertIn("403", data["error"])
+        self.assertIn("Inference Providers", data["error"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

A GLM-5.2 review of `huggingface/peft#3395` failed with (once PR #55 made it legible):

```
LLM endpoint returned 403 Forbidden: {"error":"This authentication method does not
have sufficient permissions to call Inference Providers on behalf of org huggingface"}
```

The HF token can list models fine but lacks permission to **call Inference Providers on behalf of the org**. Nothing on the Settings page let an admin catch that ahead of time — you only found out when a review died.

## What

New endpoint **`POST /admin/providers/{id}/test`** that exercises a saved config end-to-end:

- Resolves endpoint / model / billing **exactly as a real review would** (`_api_base_for_provider`, `default_model` → provider default, `X-HF-Bill-To` for HF).
- Makes **one tiny `max_tokens=1` chat-completion** with the stored key. A `/models` GET would *not* catch this failure class — the missing permission only shows on a real inference call, and `max_tokens=1` keeps it cheap (the 401/403 fires before any generation).
- Returns `{ok: true, model}` on success, or `{ok: false, error}` carrying the provider's own message. Always **HTTP 200** — a bad token is a verdict, not a server error.

Settings page gets a per-row **Test** button with inline ✓/✗ feedback; failures also surface the provider's error text in the banner, so the fix (grant the token the *Inference Providers* permission / authorize it for the org) is obvious.

## Tests

`tests/test_webapp_admin.py::ProviderTestEndpointTests` — valid token → `ok` + model + billing org echoed; a 403 → `ok:false` with the provider message intact; missing config → 404. Full suite **401 passed**, ruff clean.

## Note

Depends on the error-surfacing fix from #55 (already merged) for the runner path, but this endpoint is independent and works on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)