### PR TITLE
Verify serge patches on GPU before opening a PR (opt-in)

### DIFF
--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -256,6 +256,24 @@ class Config:
     # serge keeps the proxy's allowlist in sync with the configured LLM
     # provider hosts (see webapp._sync_egress_allowlist). "" = never touch it.
     task_egress_name: Optional[str] = None
+    # --- GPU verify loop (opt-in) ------------------------------------------
+    # When enabled, a new_pr task runs its targeted @slow tests on GPU (via the
+    # serge-verify-caller.yml workflow_dispatch in the target repo) after the
+    # candidate branch/commit is created but BEFORE the PR is opened, and only
+    # opens the PR when the verdict is `fixed`. Default off = unchanged behavior.
+    # Requires the serge GitHub App to be granted `Actions: read and write`.
+    verify_on_gpu: bool = False
+    verify_workflow_file: str = "serge-verify-caller.yml"
+    # Ref the caller workflow lives on (its file must exist here to dispatch).
+    verify_ref: str = "main"
+    # transformers-ci ref the workflow installs the verdict tool from.
+    verify_transformersci_ref: str = "main"
+    # Also run the full tests/models/<model> slow suite on both trees.
+    verify_run_collateral: bool = False
+    # Runner group used when the failure group carries no [single|multi-gpu] tag.
+    verify_machine_type: str = "aws-g5-12xlarge-cache"
+    verify_poll_timeout: int = 2400
+    verify_poll_interval: int = 30
     # Optional Slack notification for PRs created by the /tasks flow.
     # Defaults to the org-level CI feedback Slack secrets; the transformers CI
     # names remain supported as fallbacks.
@@ -503,6 +521,20 @@ class Config:
             ).strip()
             or None,
             task_egress_name=(os.environ.get("TASK_EGRESS_NAME") or "").strip() or None,
+            verify_on_gpu=_bool_env("VERIFY_ON_GPU", False),
+            verify_workflow_file=(
+                os.environ.get("VERIFY_WORKFLOW_FILE") or "serge-verify-caller.yml"
+            ).strip(),
+            verify_ref=(os.environ.get("VERIFY_REF") or "main").strip(),
+            verify_transformersci_ref=(
+                os.environ.get("VERIFY_TRANSFORMERSCI_REF") or "main"
+            ).strip(),
+            verify_run_collateral=_bool_env("VERIFY_RUN_COLLATERAL", False),
+            verify_machine_type=(
+                os.environ.get("VERIFY_MACHINE_TYPE") or "aws-g5-12xlarge-cache"
+            ).strip(),
+            verify_poll_timeout=_int_env("VERIFY_POLL_TIMEOUT", 2400),
+            verify_poll_interval=_int_env("VERIFY_POLL_INTERVAL", 30),
             slack_bot_token=(
                 os.environ.get("SLACK_CIFEEDBACK_BOT_TOKEN")
                 or os.environ.get("CI_SLACK_BOT_TOKEN")

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -274,6 +274,9 @@ class Config:
     verify_machine_type: str = "aws-g5-12xlarge-cache"
     verify_poll_timeout: int = 2400
     verify_poll_interval: int = 30
+    # Extra LLM rounds after the first when GPU verify says the patch didn't fix
+    # the tests: re-prompt with the fresh tracebacks. 0 = verify once, no retry.
+    verify_max_rounds: int = 2
     # Optional Slack notification for PRs created by the /tasks flow.
     # Defaults to the org-level CI feedback Slack secrets; the transformers CI
     # names remain supported as fallbacks.
@@ -535,6 +538,7 @@ class Config:
             ).strip(),
             verify_poll_timeout=_int_env("VERIFY_POLL_TIMEOUT", 2400),
             verify_poll_interval=_int_env("VERIFY_POLL_INTERVAL", 30),
+            verify_max_rounds=_int_env("VERIFY_MAX_ROUNDS", 2),
             slack_bot_token=(
                 os.environ.get("SLACK_CIFEEDBACK_BOT_TOKEN")
                 or os.environ.get("CI_SLACK_BOT_TOKEN")

--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -262,6 +262,87 @@ class GitHubClient:
             )
         return r.json()
 
+    def delete_ref(self, owner: str, repo: str, ref: str) -> None:
+        """Delete a ref. ``ref`` is the short form without ``refs/``, e.g.
+        ``heads/serge/fix-abc``. Used to tear down a candidate branch whose GPU
+        verification did not confirm the fix, so no dangling branch is left."""
+        r = self.session.delete(
+            f"https://api.github.com/repos/{owner}/{repo}/git/refs/{ref}",
+            timeout=30,
+        )
+        # 404 = already gone; treat as success so cleanup is idempotent.
+        if not r.ok and r.status_code != 404:
+            raise requests.HTTPError(
+                f"{r.status_code} deleting ref {ref} on {owner}/{repo}: {r.text}",
+                response=r,
+            )
+
+    # --- GitHub Actions (serge GPU verify loop) --------------------------------
+    # These require the serge GitHub App to be granted `Actions: read and write`.
+
+    def dispatch_workflow(
+        self,
+        owner: str,
+        repo: str,
+        workflow_file: str,
+        *,
+        ref: str,
+        inputs: dict[str, Any],
+    ) -> None:
+        """Trigger a ``workflow_dispatch``. ``workflow_file`` is the filename on
+        ``ref`` (e.g. ``serge-verify-caller.yml``). Returns 204 with no body and
+        no run id — correlate the resulting run via a ``run-name`` echoing a
+        unique input (see :func:`list_workflow_runs`)."""
+        r = self.session.post(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflow_file}/dispatches",
+            json={"ref": ref, "inputs": inputs},
+            timeout=30,
+        )
+        if not r.ok:
+            raise requests.HTTPError(
+                f"{r.status_code} dispatching {workflow_file} on {owner}/{repo}: {r.text}",
+                response=r,
+            )
+
+    def list_workflow_runs(
+        self,
+        owner: str,
+        repo: str,
+        workflow_file: str,
+        *,
+        event: Optional[str] = None,
+        per_page: int = 30,
+    ) -> list[dict]:
+        params: dict[str, Any] = {"per_page": per_page}
+        if event:
+            params["event"] = event
+        r = self.session.get(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflow_file}/runs",
+            params=params,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return (r.json() or {}).get("workflow_runs", [])
+
+    def list_run_artifacts(self, owner: str, repo: str, run_id: int) -> list[dict]:
+        r = self.session.get(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+            params={"per_page": 100},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return (r.json() or {}).get("artifacts", [])
+
+    def download_artifact_zip(self, owner: str, repo: str, artifact_id: int) -> bytes:
+        """Download an artifact's zip. GitHub returns a 302 to a signed blob
+        URL; ``requests`` follows it and the zip bytes come back in ``.content``."""
+        r = self.session.get(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
+            timeout=120,
+        )
+        r.raise_for_status()
+        return r.content
+
     def create_pull_request(
         self,
         owner: str,

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -66,6 +66,14 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "llm_max_input_tokens",
     "tool_max_iterations",
     "tool_max_iterations_strict",
+    "verify_on_gpu",
+    "verify_workflow_file",
+    "verify_ref",
+    "verify_transformersci_ref",
+    "verify_run_collateral",
+    "verify_machine_type",
+    "verify_poll_timeout",
+    "verify_poll_interval",
 )
 
 

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -74,6 +74,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "verify_machine_type",
     "verify_poll_timeout",
     "verify_poll_interval",
+    "verify_max_rounds",
 )
 
 

--- a/reviewbot/task_runner.py
+++ b/reviewbot/task_runner.py
@@ -49,8 +49,7 @@ from .tasks import (
     TaskRequest,
     TaskResult,
     format_pr_files_diff,
-    prepare_task,
-    publish_task,
+    prepare_and_publish_candidate,
     resolve_existing_pr,
     task_candidate_requests,
 )
@@ -309,22 +308,14 @@ def run(spec: RunnerSpec) -> int:
                     "log",
                     f"Starting candidate {index}/{len(candidate_reqs)} in a fresh LLM cycle",
                 )
-            plan = prepare_task(
-                worker_cfg,
-                candidate_req,
-                checkout=checkout,
-                clone_cache=clone_cache,
-                existing_diff=existing_diff,
-                chunk_callback=emit,
-            )
             try:
-                attempt_result = publish_task(
+                attempt_result = prepare_and_publish_candidate(
                     worker_cfg,
                     gh,
                     candidate_req,
-                    plan,
                     checkout=checkout,
                     clone_cache=clone_cache,
+                    existing_diff=existing_diff,
                     job_id=spec.job_id,
                     emit=emit,
                 )

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -41,7 +41,7 @@ from .reviewer import (
     _UnparseableLLMOutput,
 )
 from .slack_tool import post_task_pr_created_notification
-from .verify import VerifyOutcome, run_gpu_verify
+from .verify import VerifyOutcome, run_gpu_verify, should_retry
 
 log = logging.getLogger(__name__)
 
@@ -131,6 +131,11 @@ class TaskResult:
     url: Optional[str] = None
     commit_sha: Optional[str] = None
     changed_files: list[str] = field(default_factory=list)
+    # Set when the GPU verify gate ran (see verify.py). ``verify_verdict`` drives
+    # the retry-with-tracebacks loop; ``verify_tracebacks`` is the feedback fed
+    # to the next LLM round. Not persisted in ``to_json`` (tracebacks are large).
+    verify_verdict: Optional[str] = None
+    verify_tracebacks: dict[str, str] = field(default_factory=dict)
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -142,6 +147,7 @@ class TaskResult:
             "url": self.url,
             "commit_sha": self.commit_sha,
             "changed_files": self.changed_files,
+            "verify_verdict": self.verify_verdict,
         }
 
 
@@ -703,18 +709,19 @@ def _make_verify_gate(
     plan: TaskPlan,
     job_id: str,
     emit_fn: Callable[[str, str], None],
-) -> Optional[Callable[[str, str], "tuple[bool, str]"]]:
-    """Build the pre-PR GPU verify gate, or ``None`` when disabled/inapplicable.
+) -> Optional[Callable[[str, str], VerifyOutcome]]:
+    """Build the pre-PR GPU verify gate, or ``None`` when disabled.
 
-    Returns a callback ``(base_sha, candidate_sha) -> (open_pr, message)``: it
-    runs the targeted tests on GPU and only permits the PR when the verdict is
-    `fixed`. Only wired for ``new_pr`` (follow-up commits on an existing PR keep
-    the current behavior)."""
-    if not cfg.verify_on_gpu or req.mode != "new_pr":
+    Returns a callback ``(base_sha, candidate_sha) -> VerifyOutcome``: it runs
+    the targeted tests on GPU (baseline must be red, candidate should be green).
+    The caller (:func:`_commit_changes`) opens the PR / keeps the follow-up
+    commit only when ``outcome.is_fixed``. Wired for both ``new_pr`` and
+    ``existing_pr``."""
+    if not cfg.verify_on_gpu:
         return None
     block = _select_failure_block(req, plan)
 
-    def _gate(base_sha: str, candidate_sha: str) -> tuple[bool, str]:
+    def _gate(base_sha: str, candidate_sha: str) -> VerifyOutcome:
         outcome = run_gpu_verify(
             gh,
             owner=req.owner,
@@ -734,8 +741,12 @@ def _make_verify_gate(
         )
         if outcome.is_fixed:
             emit_fn("log", f"GPU verify: fixed ✓ ({outcome.run_url or 'run'})")
-            return True, ""
-        return False, _verify_failure_message(outcome)
+        else:
+            emit_fn(
+                "log",
+                f"GPU verify: {outcome.verdict} — not accepting ({outcome.run_url or ''})",
+            )
+        return outcome
 
     return _gate
 
@@ -750,10 +761,15 @@ def _commit_changes(
     body: str,
     job_id: str,
     emit_fn: Callable[[str, str], None],
-    verify: Optional[Callable[[str, str], "tuple[bool, str]"]] = None,
+    verify: Optional[Callable[[str, str], VerifyOutcome]] = None,
 ) -> TaskResult:
     """Commit a set of worktree changes via the Git Data API and open/update
-    a PR. ``changes`` must be non-empty. Never pushes to a non-serge branch."""
+    a PR. ``changes`` must be non-empty. Never pushes to a non-serge branch.
+
+    When ``verify`` is given (opt-in GPU gate), the candidate commit is created
+    and made fetchable, the tests are run on GPU, and the PR is opened / the
+    follow-up commit is kept only on a ``fixed`` verdict; otherwise the branch is
+    torn down (new_pr) or rolled back to its previous head (existing_pr)."""
     changed_files = [c.path for c in changes]
     emit_fn(
         "log",
@@ -777,8 +793,34 @@ def _commit_changes(
             tree_sha=tree_sha,
             parents=[parent_sha],
         )
+        # Move the branch forward so the candidate commit is fetchable by the
+        # verify workflow, then gate. On a non-fixed verdict, roll the branch
+        # back to its previous head so the follow-up commit is undone.
         gh.update_ref(owner, repo, f"heads/{head_branch}", commit_sha)
         emit_fn("log", f"Pushed commit {commit_sha[:8]} to {head_branch}")
+        if verify is not None:
+            outcome = verify(parent_sha, commit_sha)
+            if not outcome.is_fixed:
+                try:
+                    gh.update_ref(
+                        owner, repo, f"heads/{head_branch}", parent_sha, force=True
+                    )
+                except Exception:  # noqa: BLE001 — best-effort rollback
+                    emit_fn(
+                        "log", f"Could not roll {head_branch} back to {parent_sha[:8]}"
+                    )
+                emit_fn(
+                    "log", "GPU verify did not confirm the fix; follow-up reverted."
+                )
+                return TaskResult(
+                    mode=req.mode,
+                    no_change=True,
+                    pr_number=req.pr_number,
+                    commit_sha=commit_sha,
+                    message=_verify_failure_message(outcome),
+                    verify_verdict=outcome.verdict,
+                    verify_tracebacks=outcome.tracebacks,
+                )
         return TaskResult(
             mode=req.mode,
             pr_number=req.pr_number,
@@ -808,8 +850,8 @@ def _commit_changes(
     # opening the PR. `parent_sha` is the baseline-red reference. On a non-`fixed`
     # verdict, tear the branch down and return without a PR.
     if verify is not None:
-        open_pr, message = verify(parent_sha, commit_sha)
-        if not open_pr:
+        outcome = verify(parent_sha, commit_sha)
+        if not outcome.is_fixed:
             try:
                 gh.delete_ref(owner, repo, f"heads/{branch}")
             except Exception:  # noqa: BLE001 — cleanup is best-effort
@@ -819,7 +861,9 @@ def _commit_changes(
                 mode=req.mode,
                 no_change=True,
                 commit_sha=commit_sha,
-                message=message,
+                message=_verify_failure_message(outcome),
+                verify_verdict=outcome.verdict,
+                verify_tracebacks=outcome.tracebacks,
             )
 
     # Open as a draft, then immediately mark ready-for-review. The
@@ -951,3 +995,91 @@ def publish_task(
         emit_fn=_emit,
         verify=_make_verify_gate(cfg, gh, req, plan, job_id, _emit),
     )
+
+
+def _format_verify_feedback(result: TaskResult) -> str:
+    """Markdown feedback for the next LLM round: the failures the previous
+    candidate's GPU verify still produced."""
+    lines = [
+        "## Your previous patch did NOT fix the tests (GPU verification)",
+        "",
+        f"A previous candidate was run on GPU; the verdict was "
+        f"`{result.verify_verdict}`. With that patch applied, the targeted tests "
+        "below still fail. Produce a NEW patch that makes them pass — do not "
+        "repeat the same change; use the tracebacks to find the real cause.",
+        "",
+    ]
+    for nodeid, tb in list(result.verify_tracebacks.items())[:5]:
+        lines.append(f"### {nodeid}")
+        lines.append("```")
+        lines.append((tb or "")[-2000:])
+        lines.append("```")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _with_verify_feedback(req: TaskRequest, feedback: str) -> TaskRequest:
+    """A copy of ``req`` with GPU-verify feedback appended to its context, so the
+    next LLM round sees the failures its previous patch still produced."""
+    return dataclasses.replace(req, context=f"{req.context}\n\n{feedback}")
+
+
+def prepare_and_publish_candidate(
+    cfg: Config,
+    gh: GitHubClient,
+    candidate_req: TaskRequest,
+    *,
+    checkout: Checkout,
+    clone_cache: CloneCache,
+    existing_diff: Optional[str],
+    job_id: str,
+    emit: Callable[[str, str], None],
+) -> TaskResult:
+    """Prepare (LLM) then publish one candidate group.
+
+    When the opt-in GPU verify gate rejects the patch with a retryable verdict
+    (``not_fixed``/``broke_others``), re-prepare with the fresh tracebacks
+    appended and re-publish, up to ``cfg.verify_max_rounds`` extra rounds. This
+    is the single place the retry loop lives, so both the in-process worker and
+    the per-task pod get it by calling this instead of prepare_task+publish_task.
+
+    Publishing exceptions (e.g. a patch that won't apply, ``TaskError`` 422)
+    propagate unchanged so the caller's candidate loop can move on."""
+    rounds = cfg.verify_max_rounds if cfg.verify_on_gpu else 0
+    req_i = candidate_req
+    result: Optional[TaskResult] = None
+    for attempt in range(rounds + 1):
+        if attempt > 0:
+            # Start each retry from a pristine worktree.
+            clone_cache.reset_worktree(checkout)
+        plan = prepare_task(
+            cfg,
+            req_i,
+            checkout=checkout,
+            clone_cache=clone_cache,
+            existing_diff=existing_diff,
+            chunk_callback=emit,
+        )
+        result = publish_task(
+            cfg,
+            gh,
+            req_i,
+            plan,
+            checkout=checkout,
+            clone_cache=clone_cache,
+            job_id=job_id,
+            emit=emit,
+        )
+        if attempt < rounds and should_retry(result.verify_verdict or ""):
+            emit(
+                "log",
+                f"GPU verify: {result.verify_verdict}; re-prompting with tracebacks "
+                f"(round {attempt + 2}/{rounds + 1})",
+            )
+            req_i = _with_verify_feedback(
+                candidate_req, _format_verify_feedback(result)
+            )
+            continue
+        return result
+    assert result is not None  # rounds >= 0 guarantees at least one iteration
+    return result

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -698,7 +698,7 @@ def _verify_failure_message(outcome: VerifyOutcome) -> str:
     if outcome.detail:
         lines.append(outcome.detail)
     for nodeid, tb in list(outcome.tracebacks.items())[:5]:
-        lines.append(f"\n### {nodeid}\n```\n{tb[-1500:]}\n```")
+ lines.append(f"\n### {nodeid}\n```\n{(tb or '')[-1500:]}\n```")
     return "\n".join(lines)
 
 

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -41,6 +41,7 @@ from .reviewer import (
     _UnparseableLLMOutput,
 )
 from .slack_tool import post_task_pr_created_notification
+from .verify import VerifyOutcome, run_gpu_verify
 
 log = logging.getLogger(__name__)
 
@@ -610,6 +611,22 @@ def _failure_blocks(context: str) -> list[list[str]]:
     return blocks
 
 
+def _select_failure_block(req: TaskRequest, plan: TaskPlan) -> list[str]:
+    """The single failure block most relevant to the produced patch (scored by
+    word overlap with the patch/title/body). Shared by the PR-body decorator and
+    the GPU verify gate, so both target the same group's node-ids."""
+    blocks = _failure_blocks(req.context)
+    if not blocks:
+        return []
+    haystack = f"{plan.title}\n{plan.body}\n{plan.patch}".lower()
+
+    def _score(block: list[str]) -> int:
+        words = set(re.findall(r"[a-z0-9_]{5,}", "\n".join(block).lower()))
+        return sum(1 for word in words if word in haystack)
+
+    return max(blocks, key=_score)
+
+
 def _selected_failure_context(req: TaskRequest, plan: TaskPlan) -> str:
     heading = ""
     for line in req.context.splitlines():
@@ -617,17 +634,10 @@ def _selected_failure_context(req: TaskRequest, plan: TaskPlan) -> str:
             heading = line.removeprefix("## Serge candidate failure group ").strip()
             break
 
-    blocks = _failure_blocks(req.context)
-    if not blocks:
+    selected = _select_failure_block(req, plan)
+    if not selected:
         return ""
 
-    haystack = f"{plan.title}\n{plan.body}\n{plan.patch}".lower()
-
-    def _score(block: list[str]) -> int:
-        words = set(re.findall(r"[a-z0-9_]{5,}", "\n".join(block).lower()))
-        return sum(1 for word in words if word in haystack)
-
-    selected = max(blocks, key=_score)
     lines = ["## Original CI failure", ""]
     if heading:
         lines.append(f"- Failure group: `{heading}`")
@@ -657,6 +667,79 @@ def _decorate_body(cfg: Config, plan: TaskPlan, req: TaskRequest) -> str:
     return body
 
 
+def _verify_failure_message(outcome: VerifyOutcome) -> str:
+    """Human/next-run explanation when GPU verify does not confirm the fix."""
+    reasons = {
+        "not_fixed": "the patch did not turn the targeted tests green",
+        "already_passing": (
+            "a targeted test was NOT failing on the pre-patch baseline "
+            "(self-healed or flaky) — nothing to fix"
+        ),
+        "broke_others": "the patch broke other tests in the model's suite",
+        "error": "a targeted test could not be verified (missing/skipped/collection error)",
+        "no_targets": "no test node-ids were found in the failure group",
+        "dispatch_failed": "the GPU verify workflow could not be dispatched",
+        "timeout": "the GPU verify workflow did not finish in time",
+        "no_result": "the GPU verify workflow produced no result artifact",
+    }
+    reason = reasons.get(outcome.verdict, outcome.verdict)
+    lines = [
+        f"GPU verification did not confirm the fix (`{outcome.verdict}`): {reason}.",
+        "No PR was opened.",
+    ]
+    if outcome.run_url:
+        lines.append(f"Verify run: {outcome.run_url}")
+    if outcome.detail:
+        lines.append(outcome.detail)
+    for nodeid, tb in list(outcome.tracebacks.items())[:5]:
+        lines.append(f"\n### {nodeid}\n```\n{tb[-1500:]}\n```")
+    return "\n".join(lines)
+
+
+def _make_verify_gate(
+    cfg: Config,
+    gh: GitHubClient,
+    req: TaskRequest,
+    plan: TaskPlan,
+    job_id: str,
+    emit_fn: Callable[[str, str], None],
+) -> Optional[Callable[[str, str], "tuple[bool, str]"]]:
+    """Build the pre-PR GPU verify gate, or ``None`` when disabled/inapplicable.
+
+    Returns a callback ``(base_sha, candidate_sha) -> (open_pr, message)``: it
+    runs the targeted tests on GPU and only permits the PR when the verdict is
+    `fixed`. Only wired for ``new_pr`` (follow-up commits on an existing PR keep
+    the current behavior)."""
+    if not cfg.verify_on_gpu or req.mode != "new_pr":
+        return None
+    block = _select_failure_block(req, plan)
+
+    def _gate(base_sha: str, candidate_sha: str) -> tuple[bool, str]:
+        outcome = run_gpu_verify(
+            gh,
+            owner=req.owner,
+            repo=req.repo,
+            base_sha=base_sha,
+            commit_sha=candidate_sha,
+            block_lines=block,
+            correlation_id=job_id,
+            workflow_file=cfg.verify_workflow_file,
+            ref=cfg.verify_ref,
+            default_machine_type=cfg.verify_machine_type,
+            run_collateral=cfg.verify_run_collateral,
+            transformersci_ref=cfg.verify_transformersci_ref,
+            poll_timeout=cfg.verify_poll_timeout,
+            poll_interval=cfg.verify_poll_interval,
+            emit=emit_fn,
+        )
+        if outcome.is_fixed:
+            emit_fn("log", f"GPU verify: fixed ✓ ({outcome.run_url or 'run'})")
+            return True, ""
+        return False, _verify_failure_message(outcome)
+
+    return _gate
+
+
 def _commit_changes(
     cfg: Config,
     gh: GitHubClient,
@@ -667,6 +750,7 @@ def _commit_changes(
     body: str,
     job_id: str,
     emit_fn: Callable[[str, str], None],
+    verify: Optional[Callable[[str, str], "tuple[bool, str]"]] = None,
 ) -> TaskResult:
     """Commit a set of worktree changes via the Git Data API and open/update
     a PR. ``changes`` must be non-empty. Never pushes to a non-serge branch."""
@@ -719,6 +803,25 @@ def _commit_changes(
     )
     gh.create_ref(owner, repo, f"refs/heads/{branch}", commit_sha)
     emit_fn("log", f"Created branch {branch} at {commit_sha[:8]}")
+
+    # GPU verify gate (opt-in): run the targeted tests on the candidate before
+    # opening the PR. `parent_sha` is the baseline-red reference. On a non-`fixed`
+    # verdict, tear the branch down and return without a PR.
+    if verify is not None:
+        open_pr, message = verify(parent_sha, commit_sha)
+        if not open_pr:
+            try:
+                gh.delete_ref(owner, repo, f"heads/{branch}")
+            except Exception:  # noqa: BLE001 — cleanup is best-effort
+                emit_fn("log", f"Could not delete branch {branch} after failed verify")
+            emit_fn("log", "GPU verify did not confirm the fix; no PR opened.")
+            return TaskResult(
+                mode=req.mode,
+                no_change=True,
+                commit_sha=commit_sha,
+                message=message,
+            )
+
     # Open as a draft, then immediately mark ready-for-review. The
     # draft->ready transition is what fires the `ready_for_review` webhook that
     # reviewer-assignment workflows (e.g. transformers' assign-reviewers.yml)
@@ -846,4 +949,5 @@ def publish_task(
         body=_decorate_body(cfg, plan, req),
         job_id=job_id,
         emit_fn=_emit,
+        verify=_make_verify_gate(cfg, gh, req, plan, job_id, _emit),
     )

--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -1,0 +1,243 @@
+"""GPU verification of a serge candidate patch before a PR is opened.
+
+serge produces a candidate patch for a CI failure group and commits it to a
+scratch branch, but it does not run the tests — they are ``@slow``/``[multi-gpu]``
+and never run in normal PR CI, so a no-op patch (e.g. transformers#47150) looks
+plausible and merges clean. This module closes that loop: it triggers the
+``serge-verify-caller.yml`` ``workflow_dispatch`` in the target repo (which runs
+the targeted node-ids on GPU on the pre-patch baseline then serge's candidate),
+polls the run, downloads the verdict artifact, and reports whether the patch
+actually turned the tests red -> green.
+
+The verdict is computed workflow-side by transformers-ci's ``serge-verify-verdict``
+console script; this module only orchestrates dispatch + poll + parse. It is
+gated behind ``cfg.verify_on_gpu`` (default off) — when disabled serge behaves
+exactly as before.
+
+See docs/plans/serge-gpu-verify-loop.md in transformers-ci-playbooks.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import time
+import zipfile
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from .github_client import GitHubClient
+
+# The first backtick-quoted token on a failure bullet is the pytest node-id, e.g.
+#   - `tests/models/whisper/..py::WhisperModelIntegrationTests::test_x` [multi-gpu] (output_mismatch, seen 7/7)
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+_MODEL_RE = re.compile(r"tests/models/([^/]+)/")
+
+_MULTI_GPU = "aws-g5-12xlarge-cache"
+_SINGLE_GPU = "aws-g5-4xlarge-cache"
+
+# Verdicts produced workflow-side (serge-verify-verdict). Only `fixed` opens a PR.
+FIXED = "fixed"
+# Orchestration-level verdicts produced here when the workflow can't be run/read.
+NO_TARGETS = "no_targets"
+DISPATCH_FAILED = "dispatch_failed"
+TIMEOUT = "timeout"
+NO_RESULT = "no_result"
+
+
+@dataclass
+class VerifyOutcome:
+    verdict: str
+    run_url: Optional[str] = None
+    result: Optional[dict] = None
+    tracebacks: dict[str, str] = field(default_factory=dict)
+    detail: str = ""
+
+    @property
+    def is_fixed(self) -> bool:
+        return self.verdict == FIXED
+
+
+def _looks_like_nodeid(token: str) -> bool:
+    return "::" in token and token.split("::", 1)[0].endswith(".py")
+
+
+def extract_verify_targets(
+    block_lines: list[str], default_machine_type: str
+) -> tuple[list[str], str, str]:
+    """From one failure group's bullet lines, return
+    ``(node_ids, model, machine_type)``.
+
+    node_ids are the backtick-quoted pytest ids; model is the ``tests/models/
+    <model>`` folder (``""`` if none); machine_type is ``aws-g5-12xlarge-cache``
+    if any bullet is tagged ``[multi-gpu]`` (the superset), else
+    ``aws-g5-4xlarge-cache`` for ``[single-gpu]``, else ``default_machine_type``."""
+    node_ids: list[str] = []
+    seen: set[str] = set()
+    machine: Optional[str] = None
+    for line in block_lines:
+        m = _BACKTICK_RE.search(line)
+        if m:
+            nid = m.group(1).strip()
+            if _looks_like_nodeid(nid) and nid not in seen:
+                seen.add(nid)
+                node_ids.append(nid)
+        low = line.lower()
+        if "[multi-gpu]" in low:
+            machine = "multi"
+        elif "[single-gpu]" in low and machine is None:
+            machine = "single"
+
+    model = ""
+    for nid in node_ids:
+        mm = _MODEL_RE.search(nid)
+        if mm:
+            model = mm.group(1)
+            break
+
+    if machine == "multi":
+        machine_type = _MULTI_GPU
+    elif machine == "single":
+        machine_type = _SINGLE_GPU
+    else:
+        machine_type = default_machine_type
+    return node_ids, model, machine_type
+
+
+def parse_verify_result_zip(zip_bytes: bytes) -> Optional[dict]:
+    """Extract and parse ``verify-result.json`` from an artifact zip."""
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        return None
+    for name in zf.namelist():
+        if name.endswith("verify-result.json"):
+            try:
+                return json.loads(zf.read(name))
+            except (ValueError, KeyError):
+                return None
+    return None
+
+
+def _find_run(runs: list[dict], correlation_id: str) -> Optional[dict]:
+    """The caller sets ``run-name`` to echo our correlation id, so we match on
+    the run's name/display_title rather than head_sha (a workflow_dispatch run's
+    head_sha is the ref, not serge's candidate commit)."""
+    for run in runs:
+        haystack = f"{run.get('name', '')} {run.get('display_title', '')}"
+        if correlation_id in haystack:
+            return run
+    return None
+
+
+def run_gpu_verify(
+    gh: GitHubClient,
+    *,
+    owner: str,
+    repo: str,
+    base_sha: str,
+    commit_sha: str,
+    block_lines: list[str],
+    correlation_id: str,
+    workflow_file: str,
+    ref: str,
+    default_machine_type: str,
+    run_collateral: bool,
+    transformersci_ref: str,
+    poll_timeout: float,
+    poll_interval: float,
+    emit: Optional[Callable[[str, str], None]] = None,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> VerifyOutcome:
+    """Dispatch the verify workflow for one failure group, wait for it, and
+    return the verdict. Never raises for the expected failure modes — it returns
+    a ``VerifyOutcome`` whose ``verdict`` the caller gates on."""
+
+    def _emit(kind: str, text: str) -> None:
+        if emit is not None:
+            emit(kind, text)
+
+    node_ids, model, machine_type = extract_verify_targets(
+        block_lines, default_machine_type
+    )
+    if not node_ids:
+        _emit("log", "GPU verify: no node-ids found in the failure group; skipping.")
+        return VerifyOutcome(NO_TARGETS, detail="no node-ids parsed from failure group")
+
+    inputs: dict[str, Any] = {
+        "base_sha": base_sha,
+        "commit_sha": commit_sha,
+        "test_nodeids": " ".join(node_ids),
+        "model": model,
+        "machine_type": machine_type,
+        "run_collateral": "true" if (run_collateral and model) else "false",
+        "transformersci_ref": transformersci_ref,
+        "correlation_id": correlation_id,
+    }
+    _emit(
+        "log",
+        f"GPU verify: dispatching {workflow_file} on {machine_type} for "
+        f"{len(node_ids)} test(s) [{model or 'no-model'}]",
+    )
+    try:
+        gh.dispatch_workflow(owner, repo, workflow_file, ref=ref, inputs=inputs)
+    except Exception as exc:  # noqa: BLE001 — surface as a verdict, never crash publish
+        return VerifyOutcome(DISPATCH_FAILED, detail=str(exc)[:500])
+
+    deadline = monotonic() + poll_timeout
+    run: Optional[dict] = None
+    while monotonic() < deadline:
+        sleep(poll_interval)
+        try:
+            runs = gh.list_workflow_runs(
+                owner, repo, workflow_file, event="workflow_dispatch"
+            )
+        except Exception as exc:  # noqa: BLE001
+            _emit("log", f"GPU verify: run listing failed ({exc}); retrying")
+            continue
+        found = _find_run(runs, correlation_id)
+        if found is not None:
+            run = found
+            if found.get("status") == "completed":
+                break
+
+    if run is None:
+        return VerifyOutcome(
+            TIMEOUT, detail="verify run never appeared / never completed"
+        )
+    run_url = run.get("html_url")
+    if run.get("status") != "completed":
+        return VerifyOutcome(
+            TIMEOUT, run_url=run_url, detail="verify run did not complete in time"
+        )
+
+    result = _fetch_verdict(gh, owner, repo, int(run["id"]))
+    if result is None:
+        return VerifyOutcome(
+            NO_RESULT, run_url=run_url, detail="no verify-result artifact"
+        )
+    return VerifyOutcome(
+        verdict=result.get("verdict", NO_RESULT),
+        run_url=run_url,
+        result=result,
+        tracebacks=result.get("tracebacks") or {},
+    )
+
+
+def _fetch_verdict(
+    gh: GitHubClient, owner: str, repo: str, run_id: int
+) -> Optional[dict]:
+    try:
+        artifacts = gh.list_run_artifacts(owner, repo, run_id)
+    except Exception:  # noqa: BLE001
+        return None
+    for art in artifacts:
+        if str(art.get("name", "")).startswith("serge-verify-result"):
+            try:
+                zip_bytes = gh.download_artifact_zip(owner, repo, int(art["id"]))
+            except Exception:  # noqa: BLE001
+                return None
+            return parse_verify_result_zip(zip_bytes)
+    return None

--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -39,11 +39,24 @@ _SINGLE_GPU = "aws-g5-4xlarge-cache"
 
 # Verdicts produced workflow-side (serge-verify-verdict). Only `fixed` opens a PR.
 FIXED = "fixed"
+NOT_FIXED = "not_fixed"
+BROKE_OTHERS = "broke_others"
+ALREADY_PASSING = "already_passing"
+ERROR = "error"
 # Orchestration-level verdicts produced here when the workflow can't be run/read.
 NO_TARGETS = "no_targets"
 DISPATCH_FAILED = "dispatch_failed"
 TIMEOUT = "timeout"
 NO_RESULT = "no_result"
+
+# Verdicts where re-prompting the LLM with the fresh failures is worth another
+# round. `already_passing` (nothing to fix), infra errors and `error` are NOT
+# retried — another LLM turn can't change them.
+_RETRYABLE = frozenset({NOT_FIXED, BROKE_OTHERS})
+
+
+def should_retry(verdict: str) -> bool:
+    return verdict in _RETRYABLE
 
 
 @dataclass

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -86,8 +86,7 @@ from .tasks import (
     TaskRequest,
     build_task_request,
     format_pr_files_diff,
-    prepare_task,
-    publish_task,
+    prepare_and_publish_candidate,
     resolve_existing_pr,
     task_candidate_requests,
 )
@@ -1200,22 +1199,14 @@ def _run_task_worker(job: Job, worker_cfg: Config, req: TaskRequest) -> None:
                     "log",
                     f"Starting candidate {index}/{len(candidate_reqs)} in a fresh LLM cycle",
                 )
-            plan = prepare_task(
-                worker_cfg,
-                candidate_req,
-                checkout=checkout,
-                clone_cache=_clone_cache,
-                existing_diff=existing_diff,
-                chunk_callback=emit,
-            )
             try:
-                attempt_result = publish_task(
+                attempt_result = prepare_and_publish_candidate(
                     worker_cfg,
                     gh,
                     candidate_req,
-                    plan,
                     checkout=checkout,
                     clone_cache=_clone_cache,
+                    existing_diff=existing_diff,
                     job_id=job.id,
                     emit=emit,
                 )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,208 @@
+import io
+import json
+import zipfile
+
+from reviewbot import verify
+
+
+def _zip_with(result: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("verify-result.json", json.dumps(result))
+    return buf.getvalue()
+
+
+class FakeGH:
+    def __init__(self, *, runs=None, artifacts=None, zip_bytes=None, dispatch_exc=None):
+        self.dispatched = []
+        self._runs = runs or []
+        self._artifacts = artifacts or []
+        self._zip = zip_bytes
+        self._dispatch_exc = dispatch_exc
+
+    def dispatch_workflow(self, owner, repo, wf, *, ref, inputs):
+        if self._dispatch_exc is not None:
+            raise self._dispatch_exc
+        self.dispatched.append((owner, repo, wf, ref, inputs))
+
+    def list_workflow_runs(self, owner, repo, wf, *, event=None, per_page=30):
+        return self._runs
+
+    def list_run_artifacts(self, owner, repo, run_id):
+        return self._artifacts
+
+    def download_artifact_zip(self, owner, repo, artifact_id):
+        return self._zip
+
+
+WHISPER = "tests/models/whisper/test_modeling_whisper.py"
+CLS = "WhisperModelIntegrationTests"
+BLOCK = [
+    f"- `{WHISPER}::{CLS}::test_small_token_timestamp_generation` [multi-gpu] (output_mismatch, seen 7/7)",
+    f"- `{WHISPER}::{CLS}::test_tiny_generation` [multi-gpu] (output_mismatch)",
+]
+
+
+class Clock:
+    def __init__(self, seq):
+        self.seq = list(seq)
+        self.i = 0
+
+    def __call__(self):
+        v = self.seq[min(self.i, len(self.seq) - 1)]
+        self.i += 1
+        return v
+
+
+# ---- extract_verify_targets --------------------------------------------------
+
+
+def test_extract_targets_nodeids_model_multi_gpu():
+    nodeids, model, machine = verify.extract_verify_targets(BLOCK, "default-mt")
+    assert nodeids == [
+        f"{WHISPER}::{CLS}::test_small_token_timestamp_generation",
+        f"{WHISPER}::{CLS}::test_tiny_generation",
+    ]
+    assert model == "whisper"
+    assert machine == "aws-g5-12xlarge-cache"
+
+
+def test_extract_targets_single_gpu():
+    block = [f"- `{WHISPER}::{CLS}::test_x` [single-gpu] (other)"]
+    _, _, machine = verify.extract_verify_targets(block, "default-mt")
+    assert machine == "aws-g5-4xlarge-cache"
+
+
+def test_extract_targets_no_tag_uses_default():
+    block = [f"- `{WHISPER}::{CLS}::test_x` (output_mismatch)"]
+    _, _, machine = verify.extract_verify_targets(block, "default-mt")
+    assert machine == "default-mt"
+
+
+def test_extract_targets_ignores_non_nodeid_backticks():
+    block = ["- `output_mismatch` some prose", "  - `not a nodeid`"]
+    nodeids, model, _ = verify.extract_verify_targets(block, "mt")
+    assert nodeids == []
+    assert model == ""
+
+
+# ---- parse_verify_result_zip -------------------------------------------------
+
+
+def test_parse_zip_roundtrip():
+    data = verify.parse_verify_result_zip(_zip_with({"verdict": "fixed"}))
+    assert data == {"verdict": "fixed"}
+
+
+def test_parse_zip_bad_bytes():
+    assert verify.parse_verify_result_zip(b"not a zip") is None
+
+
+# ---- run_gpu_verify ----------------------------------------------------------
+
+
+def _run(gh, **overrides):
+    kwargs = dict(
+        owner="huggingface",
+        repo="transformers",
+        base_sha="base",
+        commit_sha="cand",
+        block_lines=BLOCK,
+        correlation_id="corr-123",
+        workflow_file="serge-verify-caller.yml",
+        ref="main",
+        default_machine_type="aws-g5-12xlarge-cache",
+        run_collateral=False,
+        transformersci_ref="main",
+        poll_timeout=100,
+        poll_interval=0,
+        sleep=lambda _s: None,
+        monotonic=Clock([0, 0]),
+    )
+    kwargs.update(overrides)
+    return verify.run_gpu_verify(gh, **kwargs)
+
+
+def test_run_verify_fixed():
+    gh = FakeGH(
+        runs=[
+            {
+                "id": 5,
+                "name": "serge verify whisper [corr-123]",
+                "status": "completed",
+                "html_url": "u",
+            }
+        ],
+        artifacts=[{"id": 9, "name": "serge-verify-result-aws-g5-12xlarge-cache"}],
+        zip_bytes=_zip_with({"verdict": "fixed", "tracebacks": {}}),
+    )
+    out = _run(gh)
+    assert out.is_fixed
+    assert out.run_url == "u"
+    # dispatched with the parsed node-ids + model
+    (_o, _r, wf, ref, inputs) = gh.dispatched[0]
+    assert wf == "serge-verify-caller.yml" and ref == "main"
+    assert inputs["model"] == "whisper"
+    assert inputs["correlation_id"] == "corr-123"
+    assert "test_tiny_generation" in inputs["test_nodeids"]
+
+
+def test_run_verify_not_fixed_passes_through_tracebacks():
+    gh = FakeGH(
+        runs=[
+            {"id": 5, "name": "x [corr-123]", "status": "completed", "html_url": "u"}
+        ],
+        artifacts=[{"id": 9, "name": "serge-verify-result-x"}],
+        zip_bytes=_zip_with({"verdict": "not_fixed", "tracebacks": {"t": "boom"}}),
+    )
+    out = _run(gh)
+    assert out.verdict == "not_fixed"
+    assert out.tracebacks == {"t": "boom"}
+
+
+def test_run_verify_no_targets_skips_dispatch():
+    gh = FakeGH()
+    out = _run(gh, block_lines=["- no node ids here"])
+    assert out.verdict == verify.NO_TARGETS
+    assert gh.dispatched == []
+
+
+def test_run_verify_dispatch_failed():
+    gh = FakeGH(dispatch_exc=RuntimeError("403 no actions:write"))
+    out = _run(gh)
+    assert out.verdict == verify.DISPATCH_FAILED
+    assert "403" in out.detail
+
+
+def test_run_verify_timeout_when_run_never_completes():
+    gh = FakeGH(
+        runs=[
+            {"id": 5, "name": "x [corr-123]", "status": "in_progress", "html_url": "u"}
+        ]
+    )
+    # deadline = 0 + 1; enter once (t=0), then t=100 exits the loop still in_progress
+    out = _run(gh, poll_timeout=1, monotonic=Clock([0, 0, 100]))
+    assert out.verdict == verify.TIMEOUT
+    assert out.run_url == "u"
+
+
+def test_run_verify_no_result_artifact():
+    gh = FakeGH(
+        runs=[
+            {"id": 5, "name": "x [corr-123]", "status": "completed", "html_url": "u"}
+        ],
+        artifacts=[],
+    )
+    out = _run(gh)
+    assert out.verdict == verify.NO_RESULT
+
+
+def test_run_verify_correlation_id_mismatch_times_out():
+    # A concurrent run for a different task must not be picked up.
+    gh = FakeGH(
+        runs=[
+            {"id": 5, "name": "serge verify whisper [other-id]", "status": "completed"}
+        ]
+    )
+    out = _run(gh, poll_timeout=1, monotonic=Clock([0, 0, 100]))
+    assert out.verdict == verify.TIMEOUT

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -1,0 +1,149 @@
+import types
+
+from reviewbot import tasks, verify
+
+
+def _cfg(on_gpu: bool, rounds: int = 2):
+    return types.SimpleNamespace(verify_on_gpu=on_gpu, verify_max_rounds=rounds)
+
+
+def _req(context="original context"):
+    return tasks.TaskRequest(
+        owner="huggingface",
+        repo="transformers",
+        base_ref="main",
+        instruction="fix it",
+        context=context,
+    )
+
+
+class _FakeCloneCache:
+    def __init__(self):
+        self.resets = 0
+
+    def reset_worktree(self, checkout):
+        self.resets += 1
+
+
+def _install(monkeypatch, results):
+    """Make prepare_task a no-op and publish_task pop from `results`, recording
+    the context each round saw. Returns the recorder."""
+    seen_contexts = []
+
+    def fake_prepare(cfg, req, **kwargs):
+        seen_contexts.append(req.context)
+        return tasks.TaskPlan(title="t", body="b", patch="p")
+
+    def fake_publish(cfg, gh, req, plan, **kwargs):
+        return results.pop(0)
+
+    monkeypatch.setattr(tasks, "prepare_task", fake_prepare)
+    monkeypatch.setattr(tasks, "publish_task", fake_publish)
+    return seen_contexts
+
+
+def _call(cfg, seen_cache=None):
+    cc = seen_cache or _FakeCloneCache()
+    result = tasks.prepare_and_publish_candidate(
+        cfg,
+        gh=object(),
+        candidate_req=_req(),
+        checkout=object(),
+        clone_cache=cc,
+        existing_diff=None,
+        job_id="job1234",
+        emit=lambda *_a: None,
+    )
+    return result, cc
+
+
+def _res(verdict=None, no_change=False, tracebacks=None):
+    return tasks.TaskResult(
+        mode="new_pr",
+        no_change=no_change,
+        verify_verdict=verdict,
+        verify_tracebacks=tracebacks or {},
+    )
+
+
+def test_should_retry():
+    assert verify.should_retry("not_fixed")
+    assert verify.should_retry("broke_others")
+    assert not verify.should_retry("already_passing")
+    assert not verify.should_retry("fixed")
+    assert not verify.should_retry("timeout")
+    assert not verify.should_retry("")
+
+
+def test_no_retry_when_disabled(monkeypatch):
+    # verify off => single attempt even if a verdict is present.
+    seen = _install(monkeypatch, [_res(verdict="not_fixed", no_change=True)])
+    result, cc = _call(_cfg(on_gpu=False))
+    assert result.verify_verdict == "not_fixed"
+    assert len(seen) == 1
+    assert cc.resets == 0
+
+
+def test_retries_then_fixes(monkeypatch):
+    seen = _install(
+        monkeypatch,
+        [
+            _res(verdict="not_fixed", no_change=True, tracebacks={"t1": "boom1"}),
+            _res(verdict="not_fixed", no_change=True, tracebacks={"t2": "boom2"}),
+            _res(verdict="fixed"),
+        ],
+    )
+    result, cc = _call(_cfg(on_gpu=True, rounds=2))
+    assert result.verify_verdict == "fixed"
+    assert len(seen) == 3  # first + 2 retries
+    assert cc.resets == 2  # reset before each retry, not the first
+    # Round 2 saw round 1's traceback; round 3 saw round 2's traceback.
+    assert "boom1" in seen[1]
+    assert "boom2" in seen[2]
+    # Feedback is appended to the ORIGINAL context (does not compound).
+    assert seen[2].startswith("original context")
+
+
+def test_retries_exhausted_returns_last(monkeypatch):
+    _install(
+        monkeypatch,
+        [_res(verdict="not_fixed", no_change=True) for _ in range(3)],
+    )
+    result, _ = _call(_cfg(on_gpu=True, rounds=2))
+    assert result.verify_verdict == "not_fixed"
+    assert result.no_change
+
+
+def test_non_retryable_verdict_stops_immediately(monkeypatch):
+    seen = _install(
+        monkeypatch,
+        [_res(verdict="already_passing", no_change=True), _res(verdict="fixed")],
+    )
+    result, _ = _call(_cfg(on_gpu=True, rounds=2))
+    assert result.verify_verdict == "already_passing"
+    assert len(seen) == 1  # no retry
+
+
+def test_fixed_first_try_no_retry(monkeypatch):
+    seen = _install(monkeypatch, [_res(verdict="fixed")])
+    result, cc = _call(_cfg(on_gpu=True, rounds=2))
+    assert result.verify_verdict == "fixed"
+    assert len(seen) == 1
+    assert cc.resets == 0
+
+
+def test_format_feedback_includes_verdict_and_tracebacks():
+    res = _res(
+        verdict="not_fixed", tracebacks={"tests/x.py::T::t": "AssertionError: nope"}
+    )
+    fb = tasks._format_verify_feedback(res)
+    assert "not_fixed" in fb
+    assert "tests/x.py::T::t" in fb
+    assert "AssertionError: nope" in fb
+
+
+def test_with_verify_feedback_appends_context():
+    req = _req("base ctx")
+    out = tasks._with_verify_feedback(req, "FEEDBACK")
+    assert out.context == "base ctx\n\nFEEDBACK"
+    assert req.context == "base ctx"  # original untouched

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -396,8 +396,8 @@ class WebappTasksTests(unittest.TestCase):
             source="task",
             kind="task",
         )
-        # prepare_task/publish_task are both stubbed, so the plan value is never
-        # inspected — any sentinel works.
+        # The per-candidate prepare+publish (incl. any GPU verify retry loop) is
+        # stubbed to return the given result, so we only assert status mapping.
         with (
             patch.object(webapp, "installation_id_for_repo", return_value=1),
             patch.object(webapp, "installation_token", return_value="tok"),
@@ -409,8 +409,9 @@ class WebappTasksTests(unittest.TestCase):
             ),
             patch.object(webapp._clone_cache, "release"),
             patch.object(webapp, "_persist_terminal"),
-            patch.object(webapp, "prepare_task", return_value=object()),
-            patch.object(webapp, "publish_task", return_value=task_result),
+            patch.object(
+                webapp, "prepare_and_publish_candidate", return_value=task_result
+            ),
         ):
             webapp._run_task_worker(job, worker_cfg, req)
         return job


### PR DESCRIPTION
## Why

serge opens fix PRs **without ever running the failing tests**.  they're `@slow`/`[multi-gpu]` and don't run in normal PR CI, so a no-op patch (e.g. [transformers#47150](https://github.com/huggingface/transformers/pull/47150)) looks plausible and its PR merges clean. This closes that loop: before opening the PR, serge runs the group's targeted tests on GPU and only ships a patch that actually turns them **red → green**.

Opt-in via `VERIFY_ON_GPU` (default **off** ⇒ behavior is byte-for-byte unchanged).

## How it works

For a task, after the candidate branch/commit is created but **before** the PR is opened:

1. serge dispatches the `serge-verify-caller.yml` `workflow_dispatch` in the target repo (huggingface/transformers), correlating the run via a `correlation_id` echoed in its `run-name`.
2. That caller delegates to the reusable `serge-verify-slow.yml` in transformers-ci, which runs the node-ids on the **pre-patch baseline** (must be red) then serge's **candidate** (want green), reusing the exact run-slow image / warm `/mnt/cache` model cache / GPU runner groups.
3. serge polls the run, downloads the `verify-result.json` verdict artifact, and gates:
   - `fixed` → open the PR (new_pr) / keep the follow-up commit (existing_pr);
   - anything else → tear the branch down (new_pr) or roll the ref back (existing_pr), and don't open.

**Retry with tracebacks.** On a `not_fixed`/`broke_others` verdict, serge re-prompts the LLM with the fresh failing tracebacks appended and re-publishes, up to `VERIFY_MAX_ROUNDS` extra rounds (default 2). `already_passing` (baseline-red guard — nothing to fix) and infra errors are not retried.

The retry loop lives in one shared `prepare_and_publish_candidate()`; both the in-process worker and the per-task pod call it, so neither path duplicates the logic.