### PR TITLE
Improves Serge task failure visibility on /tasks/... pages

### DIFF
--- a/deploy/scripts/logs.sh
+++ b/deploy/scripts/logs.sh
@@ -93,12 +93,30 @@ def main():
     parser.add_argument("--since", default="2h", help="Log window, e.g. 30m, 2h")
     parser.add_argument("-f", "--follow", action="store_true", help="Follow logs")
     parser.add_argument("--grep", dest="grep_pattern", help="Filter logs with grep -Ei semantics")
+    parser.add_argument(
+        "--task-id",
+        help=(
+            "Filter to one task id. Useful for /tasks investigations; shows "
+            "queue/finalizer/watcher lines and hides high-volume HTTP access logs."
+        ),
+    )
+    parser.add_argument(
+        "--task-http",
+        action="store_true",
+        help="With --task-id, include high-volume HTTP callback/status access logs.",
+    )
     parser.add_argument("--last-error", action="store_true", help="Print the last ERROR/Traceback block")
     parser.add_argument("--context", dest="expected_context", help="Required kubectl context")
     args = parser.parse_args()
 
     if args.last_error and args.follow:
         print("--last-error cannot be combined with --follow", file=sys.stderr)
+        return 2
+    if args.task_http and not args.task_id:
+        print("--task-http requires --task-id", file=sys.stderr)
+        return 2
+    if args.task_id and args.grep_pattern:
+        print("--task-id cannot be combined with --grep", file=sys.stderr)
         return 2
 
     if shutil.which("kubectl") is None:
@@ -169,6 +187,16 @@ def main():
     log_args = ["kubectl", "logs", "-n", args.namespace, pod, f"--since={args.since}"]
     if args.follow:
         log_args.append("-f")
+
+    if args.task_id:
+        escaped = re.escape(args.task_id)
+        if args.task_http:
+            args.grep_pattern = (
+                f"{escaped}|task .*{escaped}|/internal/tasks/{escaped}|"
+                f"/tasks/[^ ]*/{escaped}"
+            )
+        else:
+            args.grep_pattern = f"^[0-9].*(task .*{escaped}|{escaped}.*task)"
 
     if args.last_error:
         return latest_error_block(log_args, pod, pod_started, args.since)

--- a/deploy/scripts/task-status.sh
+++ b/deploy/scripts/task-status.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import json
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, Optional
+
+
+TASK_URL_RE = re.compile(r"/tasks/([^/]+)/([^/]+)/([A-Za-z0-9_-]+)")
+
+
+class CommandError(Exception):
+    def __init__(self, return_code: int):
+        self.return_code = return_code
+
+
+def run_text(args: list[str]) -> str:
+    try:
+        return subprocess.check_output(args, text=True).strip()
+    except subprocess.CalledProcessError as exc:
+        raise CommandError(exc.returncode) from exc
+
+
+def parse_task_ref(ref: str) -> tuple[Optional[str], Optional[str], str]:
+    match = TASK_URL_RE.search(ref)
+    if match:
+        owner, repo, task_id = match.groups()
+        return owner, repo, task_id
+    return None, None, ref.rstrip("/").split("/")[-1]
+
+
+def fmt_time(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return "-"
+    local = dt.datetime.fromtimestamp(value).astimezone()
+    return local.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def task_query_code() -> str:
+    return r"""
+import json
+import sqlite3
+import sys
+
+db_path, task_id, history_tail_s = sys.argv[1], sys.argv[2], sys.argv[3]
+history_tail = int(history_tail_s)
+c = sqlite3.connect(db_path)
+c.row_factory = sqlite3.Row
+row = c.execute("select * from jobs where id = ?", (task_id,)).fetchone()
+if row is None:
+    print(json.dumps({"found": False, "id": task_id}))
+    raise SystemExit(0)
+
+data = dict(row)
+history_raw = data.pop("history_json", None)
+try:
+    history = json.loads(history_raw) if history_raw else []
+except json.JSONDecodeError:
+    history = []
+if history_tail < 0:
+    data["history"] = history
+elif history_tail == 0:
+    data["history"] = []
+else:
+    data["history"] = history[-history_tail:]
+for key in ("task_spec_json", "result_json", "draft_json", "review_edits_json", "published_draft_json"):
+    raw = data.get(key)
+    if raw:
+        try:
+            data[key[:-5] if key.endswith("_json") else key] = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+print(json.dumps({"found": True, "job": data}, ensure_ascii=False))
+"""
+
+
+def load_task(args: argparse.Namespace, task_id: str) -> dict[str, Any]:
+    command = [
+        "kubectl",
+        "exec",
+        "-n",
+        args.namespace,
+        f"deploy/{args.release}",
+        "--",
+        "python",
+        "-c",
+        task_query_code(),
+        args.db_path,
+        task_id,
+        str(args.history_tail),
+    ]
+    return json.loads(run_text(command))
+
+
+def print_human(
+    data: dict[str, Any],
+    *,
+    owner: Optional[str],
+    repo: Optional[str],
+    full_error: bool,
+    error_chars: int,
+) -> int:
+    if not data.get("found"):
+        print(f"task not found: {data.get('id')}", file=sys.stderr)
+        return 3
+
+    job = data["job"]
+    target = f"{job.get('target_owner')}/{job.get('target_repo')}"
+    created = job.get("created_at")
+    updated = job.get("updated_at")
+    duration = "-"
+    if isinstance(created, (int, float)) and isinstance(updated, (int, float)):
+        duration = f"{updated - created:.1f}s"
+
+    print(f"Task: {job.get('id')}")
+    if owner and repo:
+        print(f"URL: https://serge.huggingface.tech/tasks/{owner}/{repo}/{job.get('id')}")
+    print(f"Target: {target}")
+    print(f"Actor: {job.get('user')}")
+    print(f"Status: {job.get('status')}")
+    print(f"Model: {job.get('llm_provider') or '-'} {job.get('llm_model') or '-'}")
+    print(f"Created: {fmt_time(created)}")
+    print(f"Updated: {fmt_time(updated)}")
+    print(f"Duration: {duration}")
+
+    result = job.get("result")
+    if result:
+        print("\nResult:")
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    error = job.get("error")
+    if error:
+        error = str(error)
+        print("\nError:")
+        if not full_error and len(error) > error_chars:
+            error = (
+                error[:error_chars]
+                + f"\n... [truncated; use --full-error to print all {len(error)} chars]"
+            )
+        print(error)
+
+    history = job.get("history") or []
+    if history:
+        print("\nHistory tail:")
+        for event in history:
+            kind = event.get("kind", "?")
+            text = str(event.get("text", ""))
+            seq = event.get("seq", "-")
+            ts = fmt_time(event.get("ts"))
+            if len(text) > 500:
+                text = text[:497] + "..."
+            print(f"[{seq}] {ts} {kind}: {text}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="deploy/scripts/task-status.sh",
+        description="Read Serge's persisted SQLite row for a /tasks run.",
+    )
+    parser.add_argument("task", help="Task id or full https://serge.../tasks/<owner>/<repo>/<id> URL")
+    parser.add_argument("-n", "--namespace", default="serge", help="Kubernetes namespace")
+    parser.add_argument("-r", "--release", default="serge", help="Deployment name")
+    parser.add_argument("--context", dest="expected_context", help="Required kubectl context")
+    parser.add_argument("--db-path", default="/var/lib/reviewbot/jobs.db", help="Path to jobs.db inside the Serge pod")
+    parser.add_argument("--history-tail", type=int, default=25, help="Number of persisted history events to print")
+    parser.add_argument("--error-chars", type=int, default=4000, help="Maximum stored error chars to print")
+    parser.add_argument("--full-error", action="store_true", help="Print the full stored error")
+    parser.add_argument("--json", action="store_true", help="Print raw JSON from the job row")
+    args = parser.parse_args()
+
+    if shutil.which("kubectl") is None:
+        print("missing required command: kubectl", file=sys.stderr)
+        return 1
+
+    try:
+        current_context = run_text(["kubectl", "config", "current-context"])
+    except CommandError as exc:
+        return exc.return_code
+    if args.expected_context and current_context != args.expected_context:
+        print(
+            f"refusing to read task data from context '{current_context}' "
+            f"(expected '{args.expected_context}')",
+            file=sys.stderr,
+        )
+        return 1
+
+    owner, repo, task_id = parse_task_ref(args.task)
+    try:
+        data = load_task(args, task_id)
+    except CommandError as exc:
+        return exc.return_code
+
+    if args.json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return 0 if data.get("found") else 3
+    return print_human(
+        data,
+        owner=owner,
+        repo=repo,
+        full_error=args.full_error,
+        error_chars=args.error_chars,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reviewbot/k8s_sandbox.py
+++ b/reviewbot/k8s_sandbox.py
@@ -309,6 +309,8 @@ def _collect_pod_result(core, namespace: str, job_name: str) -> tuple[int, str]:
         # Logs are best-effort; the exit code is what gates the patch.
         log.warning("could not read normalize pod logs: %s", exc.reason or exc)
         logs = ""
+    if isinstance(logs, bytes):
+        logs = logs.decode("utf-8", errors="replace")
     tail = "\n".join((logs or "").splitlines()[-40:])
     return exit_code, tail
 

--- a/reviewbot/normalize.py
+++ b/reviewbot/normalize.py
@@ -63,7 +63,7 @@ def run_normalize(
 ) -> tuple[int, str]:
     """Run ``command`` against the worktree in the selected sandbox backend.
 
-    Returns ``(returncode, output_tail)``. Does not stage or commit — the
+    Returns ``(returncode, output)``. Does not stage or commit — the
     caller stages the worktree afterwards and collects the combined diff.
 
     ``backend`` is ``bwrap`` | ``docker`` | ``auto`` — all run as a local
@@ -127,5 +127,4 @@ def _run_subprocess(
         raise NormalizeError(f"could not launch normalize command: {exc}") from exc
 
     output = (proc.stdout or "") + (proc.stderr or "")
-    tail = "\n".join(output.splitlines()[-40:])
-    return proc.returncode, tail
+    return proc.returncode, output.rstrip()

--- a/reviewbot/static/styles.css
+++ b/reviewbot/static/styles.css
@@ -583,6 +583,41 @@ td .source-tag {
 }
 #error-banner.visible { display: block; }
 
+.normalize-error {
+  background: #fff7ed;
+  color: #7c2d12;
+  border: 1px solid #fed7aa;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+.normalize-error-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.normalize-error-meta {
+  margin-bottom: 10px;
+}
+.normalize-error pre {
+  white-space: pre-wrap;
+  overflow-x: auto;
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: #7c2d12;
+}
+
+@media (prefers-color-scheme: dark) {
+  .normalize-error {
+    background: rgba(124, 45, 18, 0.22);
+    color: #fed7aa;
+    border-color: rgba(251, 146, 60, 0.45);
+  }
+  .normalize-error pre {
+    color: #fed7aa;
+  }
+}
+
 table.jobs-list {
   width: 100%;
   border-collapse: collapse;

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -47,6 +47,7 @@
     const consoleEl = document.getElementById("console");
     const statusEl = document.getElementById("status");
     const targetEl = document.getElementById("target");
+    let renderedErrorText = null;
     targetEl.textContent = `${owner}/${repo}`;
 
     function append(line) {
@@ -54,18 +55,47 @@
       consoleEl.scrollTop = consoleEl.scrollHeight;
     }
 
+    function setStatus(status) {
+      const value = String(status || "running");
+      statusEl.textContent = value;
+      statusEl.className = `status-badge ${value.replace(/[^a-z0-9_-]/gi, "-").toLowerCase()}`;
+    }
+
+    function displayText(text) {
+      let s = String(text || "");
+      const marker = "\n--- runner log tail ---\n";
+      const idx = s.indexOf(marker + "b'");
+      if (idx < 0) return s;
+      const prefix = s.slice(0, idx + marker.length);
+      let tail = s.slice(idx + marker.length);
+      if (tail.startsWith("b'") && tail.endsWith("'")) {
+        tail = tail.slice(2, -1);
+      }
+      tail = tail
+        .replace(/\\n/g, "\n")
+        .replace(/\\t/g, "\t")
+        .replace(/\\'/g, "'")
+        .replace(/\\\\/g, "\\");
+      return prefix + tail;
+    }
+
     async function loadInfo() {
       try {
         const r = await fetch(`${apiBase}/info`);
         if (!r.ok) return;
         const info = await r.json();
-        statusEl.textContent = info.status;
+        setStatus(info.status);
         document.getElementById("instruction").textContent = info.instruction || "";
         if (info.error) {
+          const shown = displayText(info.error);
           const b = document.getElementById("error-banner");
-          b.textContent = info.error;
+          b.textContent = shown;
           b.className = "error";
           b.style.whiteSpace = "pre-wrap";
+          if (renderedErrorText !== shown) {
+            renderedErrorText = shown;
+            append(`[error] ${shown}`);
+          }
         }
         if (info.result) {
           const res = info.result;
@@ -140,12 +170,14 @@
         let txt;
         try { txt = JSON.parse(e.data); } catch { txt = e.data; }
         if (kind === "error") {
+          txt = displayText(txt);
           // Surface the full server-side error (incl. multi-line hints) in
           // a prominent banner as well as the console.
           const b = document.getElementById("error-banner");
           b.textContent = txt;
           b.className = "error";
           b.style.whiteSpace = "pre-wrap";
+          renderedErrorText = txt;
         }
         if (kind === "chat") { append(`💬 ${fmtMessage(txt)}`); return; }
         append(kind === "log" ? txt : `[${kind}] ${txt}`);

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -24,6 +24,11 @@
   </header>
   <main>
     <div id="error-banner"></div>
+    <section class="normalize-error" id="normalize-error" hidden>
+      <div class="normalize-error-title">Normalize failed</div>
+      <div class="normalize-error-meta" id="normalize-error-meta"></div>
+      <pre id="normalize-error-detail"></pre>
+    </section>
 
     <section class="card">
       <h2 style="margin-top:0;">Task</h2>
@@ -79,6 +84,59 @@
       return prefix + tail;
     }
 
+    function normalizeSummary(info) {
+      const trace = Array.isArray(info.trace) ? info.trace : [];
+      if (String(info.status || "") !== "error" || !trace.length) return null;
+
+      let lastStep = "";
+      let lastNormalizeAt = -1;
+      let validateLine = "";
+      let retryLine = "";
+      for (let i = 0; i < trace.length; i += 1) {
+        const ev = trace[i] || {};
+        const kind = ev.kind;
+        const text = displayText(ev.text || "");
+        if (kind === "step") {
+          lastStep = text;
+          if (text === "normalize") lastNormalizeAt = i;
+        }
+        if (lastNormalizeAt >= 0 && i >= lastNormalizeAt && kind === "log") {
+          if (text.startsWith("Validating the patch with ")) validateLine = text;
+          if (text.startsWith("Patch validation failed ")) retryLine = text;
+        }
+      }
+
+      const error = displayText(info.error || "");
+      const normalizeInTail =
+        /Validating the patch with|Patch validation failed|normalizer|normalize/i.test(error);
+      if (lastStep !== "normalize" && !validateLine && !normalizeInTail) return null;
+
+      const commandMatch = validateLine.match(/`([^`]+)`/);
+      const detail = [];
+      if (validateLine) detail.push(validateLine);
+      if (retryLine) detail.push(retryLine);
+      if (error) detail.push(error);
+
+      return {
+        meta: commandMatch
+          ? `The task errored while the normalizer command was active: ${commandMatch[1]}`
+          : "The task errored while normalize was the active step.",
+        detail: detail.join("\n\n"),
+      };
+    }
+
+    function renderNormalizeSummary(info) {
+      const panel = document.getElementById("normalize-error");
+      const summary = normalizeSummary(info);
+      if (!summary) {
+        panel.hidden = true;
+        return;
+      }
+      document.getElementById("normalize-error-meta").textContent = summary.meta;
+      document.getElementById("normalize-error-detail").textContent = summary.detail;
+      panel.hidden = false;
+    }
+
     async function loadInfo() {
       try {
         const r = await fetch(`${apiBase}/info`);
@@ -86,11 +144,12 @@
         const info = await r.json();
         setStatus(info.status);
         document.getElementById("instruction").textContent = info.instruction || "";
+        renderNormalizeSummary(info);
         if (info.error) {
           const shown = displayText(info.error);
           const b = document.getElementById("error-banner");
           b.textContent = shown;
-          b.className = "error";
+          b.className = "visible";
           b.style.whiteSpace = "pre-wrap";
           if (renderedErrorText !== shown) {
             renderedErrorText = shown;
@@ -175,7 +234,7 @@
           // a prominent banner as well as the console.
           const b = document.getElementById("error-banner");
           b.textContent = txt;
-          b.className = "error";
+          b.className = "visible";
           b.style.whiteSpace = "pre-wrap";
           renderedErrorText = txt;
         }

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -98,7 +98,11 @@
         const text = displayText(ev.text || "");
         if (kind === "step") {
           lastStep = text;
-          if (text === "normalize") lastNormalizeAt = i;
+          if (text === "normalize") {
+            lastNormalizeAt = i;
+            validateLine = "";
+            retryLine = "";
+          }
         }
         if (lastNormalizeAt >= 0 && i >= lastNormalizeAt && kind === "log") {
           if (text.startsWith("Validating the patch with ")) validateLine = text;
@@ -113,13 +117,13 @@
 
       const commandMatch = validateLine.match(/`([^`]+)`/);
       const detail = [];
+      if (error) detail.push(error);
       if (validateLine) detail.push(validateLine);
       if (retryLine) detail.push(retryLine);
-      if (error) detail.push(error);
 
       return {
         meta: commandMatch
-          ? `The task errored while the normalizer command was active: ${commandMatch[1]}`
+          ? `The task runner exited while this normalizer command was active: ${commandMatch[1]}`
           : "The task errored while normalize was the active step.",
         detail: detail.join("\n\n"),
       };

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -92,6 +92,7 @@
       let lastNormalizeAt = -1;
       let validateLine = "";
       let retryLine = "";
+      let normalizeError = "";
       for (let i = 0; i < trace.length; i += 1) {
         const ev = trace[i] || {};
         const kind = ev.kind;
@@ -102,21 +103,30 @@
             lastNormalizeAt = i;
             validateLine = "";
             retryLine = "";
+            normalizeError = "";
           }
         }
         if (lastNormalizeAt >= 0 && i >= lastNormalizeAt && kind === "log") {
           if (text.startsWith("Validating the patch with ")) validateLine = text;
           if (text.startsWith("Patch validation failed ")) retryLine = text;
         }
+        if (lastNormalizeAt >= 0 && i >= lastNormalizeAt && kind === "normalize_error") {
+          normalizeError = text;
+        }
       }
 
       const error = displayText(info.error || "");
       const normalizeInTail =
         /Validating the patch with|Patch validation failed|normalizer|normalize/i.test(error);
-      if (lastStep !== "normalize" && !validateLine && !normalizeInTail) return null;
+      if (lastStep !== "normalize" && !validateLine && !normalizeError && !normalizeInTail) return null;
 
       const commandMatch = validateLine.match(/`([^`]+)`/);
       const detail = [];
+      if (normalizeError) {
+        const highlights = normalizeHighlights(normalizeError);
+        if (highlights) detail.push(`Likely error lines:\n${highlights}`);
+        detail.push(`Full normalizer log:\n${normalizeError}`);
+      }
       if (error) detail.push(error);
       if (validateLine) detail.push(validateLine);
       if (retryLine) detail.push(retryLine);
@@ -127,6 +137,29 @@
           : "The task errored while normalize was the active step.",
         detail: detail.join("\n\n"),
       };
+    }
+
+    function normalizeHighlights(text) {
+      const lines = String(text || "").split("\n");
+      const patterns = [
+        /\bFAILED\b/,
+        /\bERROR\b/,
+        /\bTraceback\b/,
+        /\b(?:AssertionError|RuntimeError|TypeError|ValueError|ImportError|ModuleNotFoundError)\b/,
+        /\b(?:failed|error|violation|would reformat|Found \d+|No such file)\b/i,
+      ];
+      const hits = [];
+      for (let i = 0; i < lines.length; i += 1) {
+        if (!patterns.some((p) => p.test(lines[i]))) continue;
+        const start = Math.max(0, i - 2);
+        const end = Math.min(lines.length, i + 3);
+        for (let j = start; j < end; j += 1) {
+          const line = `${j + 1}: ${lines[j]}`;
+          if (!hits.includes(line)) hits.push(line);
+        }
+        if (hits.length >= 80) break;
+      }
+      return hits.join("\n");
     }
 
     function renderNormalizeSummary(info) {
@@ -225,7 +258,7 @@
       if (!body && !calls) return `assistant: (thinking…)${metaStr}`;
       return `assistant:${body ? " " + body : ""}${calls}${metaStr}`;
     }
-    ["step", "tool", "error", "log", "chat"].forEach(kind => {
+    ["step", "tool", "error", "log", "chat", "normalize_error"].forEach(kind => {
       es.addEventListener(kind, (e) => {
         // The browser also fires a native "error" event (no .data) on a
         // dropped connection; ignore those here — es.onerror handles them.

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -108,6 +108,7 @@ PERSIST_EVENT_KINDS = frozenset(
         "done",
         "metrics",
         "chat",
+        "normalize_error",
     }
 )
 

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -45,6 +45,8 @@ from .verify import VerifyOutcome, run_gpu_verify, should_retry
 
 log = logging.getLogger(__name__)
 
+_NORMALIZE_FEEDBACK_CHARS = 80_000
+
 # Serge only ever writes inside its own branch namespace. ``existing_pr``
 # mode is rejected for any head branch outside it, so the OIDC
 # ``repository`` claim cannot be leveraged to push to an arbitrary PR.
@@ -332,7 +334,7 @@ def _run_repo_normalizer(
     the current worktree with its fixers enabled, writing any regenerated files
     (e.g. transformers' ``modeling_*.py`` from ``modular_*.py``) back in place.
 
-    Returns ``(returncode, tail)``. ``returncode`` is ``None`` when the
+    Returns ``(returncode, output)``. ``returncode`` is ``None`` when the
     normalizer could not run at all (sandbox unavailable / timeout / launch
     failure) — infrastructure, not the patch's fault, which callers treat as a
     best-effort pass. Assumes ``cfg.task_normalize_command`` is set."""
@@ -412,7 +414,7 @@ def _validate_patch(
             False,
         )
 
-    returncode, tail = _run_repo_normalizer(cfg, checkout, emit)
+    returncode, output = _run_repo_normalizer(cfg, checkout, emit)
     if returncode is None:
         # Normalizer could not run (infra) — accept the applied patch
         # best-effort rather than blaming the LLM.
@@ -421,9 +423,14 @@ def _validate_patch(
     if returncode != 0:
         clone_cache.reset_worktree(checkout)
         cmd = " ".join(command)
+        feedback_output = _bounded_normalize_feedback(output)
+        emit(
+            "normalize_error",
+            f"Normalizer failed (exit {returncode}) for `{cmd}`:\n{output}",
+        )
         msg = (
             f"Your patch applied cleanly, but the repository's normalizer "
-            f"(`{cmd}`) then failed (exit {returncode}):\n\n{tail}\n\n"
+            f"(`{cmd}`) then failed (exit {returncode}):\n\n{feedback_output}\n\n"
             "Revise the patch so the normalizer passes. Fix the ROOT CAUSE — "
             "suppress a check (`# noqa`, `# type: ignore`, disabling a rule) "
             "only as a last resort, for a deliberate and justified exception, "
@@ -438,6 +445,20 @@ def _validate_patch(
 
     emit("log", "Patch validated; normalizer is clean.")
     return None, True
+
+
+def _bounded_normalize_feedback(output: str) -> str:
+    """Bound normalize feedback sent back into the LLM conversation."""
+    if len(output) <= _NORMALIZE_FEEDBACK_CHARS:
+        return output
+    head = _NORMALIZE_FEEDBACK_CHARS // 2
+    tail = _NORMALIZE_FEEDBACK_CHARS - head
+    omitted = len(output) - _NORMALIZE_FEEDBACK_CHARS
+    return (
+        output[:head].rstrip()
+        + f"\n\n--- omitted {omitted} chars of normalize output from LLM feedback ---\n\n"
+        + output[-tail:].lstrip()
+    ).rstrip()
 
 
 def _read_repo_conventions(cfg: Config, checkout: Checkout) -> str:
@@ -698,7 +719,7 @@ def _verify_failure_message(outcome: VerifyOutcome) -> str:
     if outcome.detail:
         lines.append(outcome.detail)
     for nodeid, tb in list(outcome.tracebacks.items())[:5]:
- lines.append(f"\n### {nodeid}\n```\n{(tb or '')[-1500:]}\n```")
+        lines.append(f"\n### {nodeid}\n```\n{(tb or '')[-1500:]}\n```")
     return "\n".join(lines)
 
 
@@ -960,9 +981,14 @@ def publish_task(
         # regenerated files ride along in the commit, and refuse rather than open
         # a PR the repo's own consistency CI would immediately reject.
         if cfg.task_normalize_command:
-            returncode, tail = _run_repo_normalizer(cfg, checkout, _emit)
+            returncode, output = _run_repo_normalizer(cfg, checkout, _emit)
             if returncode not in (None, 0):
                 clone_cache.reset_worktree(checkout)
+                cmd = " ".join(cfg.task_normalize_command)
+                _emit(
+                    "normalize_error",
+                    f"Normalizer failed (exit {returncode}) for `{cmd}`:\n{output}",
+                )
                 _emit("log", "Normalizer rejected the patch; not opening a PR.")
                 return TaskResult(
                     mode=req.mode,
@@ -971,7 +997,7 @@ def publish_task(
                         "The proposed patch does not pass the repository's "
                         f"normalizer (exit {returncode}), so no PR was opened — "
                         "the in-loop correction budget was exhausted before a "
-                        f"clean patch was found:\n\n{tail}"
+                        f"clean patch was found:\n\n{output}"
                     ),
                 )
 

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -3691,6 +3691,12 @@ def task_page(request: Request, owner: str, repo: str, job_id: str) -> Response:
 @app.get("/tasks/{owner}/{repo}/{job_id}/info")
 def task_info(request: Request, owner: str, repo: str, job_id: str) -> JSONResponse:
     job = _get_task_job(request, owner, repo, job_id)
+    with job.history_lock:
+        trace = [
+            {"kind": e.get("kind"), "text": e.get("text"), "ts": e.get("ts")}
+            for e in job.history
+            if e.get("kind") not in _NOISY_KINDS
+        ]
     return JSONResponse(
         {
             "id": job.id,
@@ -3704,6 +3710,7 @@ def task_info(request: Request, owner: str, repo: str, job_id: str) -> JSONRespo
             "llm_base_url": job.llm_api_base,
             "llm_model": job.llm_model or "",
             "error": job.error,
+            "trace": trace,
         }
     )
 

--- a/tests/test_k8s_sandbox.py
+++ b/tests/test_k8s_sandbox.py
@@ -238,6 +238,26 @@ class RunTaskJobTests(unittest.TestCase):
         self.assertTrue(batch.delete_namespaced_job.called)
         self.assertTrue(core.delete_namespaced_secret.called)
 
+    def test_decodes_byte_pod_logs(self):
+        done = types.SimpleNamespace(succeeded=1, failed=None, conditions=None)
+        batch, core = self._clients(
+            statuses=[done],
+            pod=_pod_with(1),
+            log_text=b"line one\nline two\n",
+        )
+        with mock.patch.object(
+            k8s_sandbox, "_load_clients", return_value=(batch, core)
+        ):
+            rc, tail = k8s_sandbox.run_task_job(
+                {"job_id": "j1", "github_token": "tok"},
+                image="serge/runner:latest",
+                settings=K8sSettings(namespace="serge"),
+                timeout=30,
+                poll_interval=0.0,
+            )
+        self.assertEqual(rc, 1)
+        self.assertEqual(tail, "line one\nline two")
+
     def test_secret_create_failure_deletes_job(self):
         done = types.SimpleNamespace(succeeded=1, failed=None, conditions=None)
         batch, core = self._clients(statuses=[done], pod=_pod_with(0))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -725,11 +725,22 @@ class ValidatePatchTests(unittest.TestCase):
             task_normalize_command=["sh", "-c", "echo boom >&2; exit 3"],
             task_normalize_timeout=30,
         )
-        feedback, prepared = self._validate(cfg, self._content(self._PATCH))
+        events = []
+        feedback, prepared = _validate_patch(
+            cfg,
+            checkout=self.co,
+            clone_cache=self.cache,
+            content=self._content(self._PATCH),
+            emit=lambda kind, text: events.append((kind, text)),
+        )
         self.assertFalse(prepared)
         self.assertIsNotNone(feedback)
         self.assertIn("normalizer", feedback.lower())
         self.assertIn("boom", feedback)
+        normalize_errors = [text for kind, text in events if kind == "normalize_error"]
+        self.assertEqual(len(normalize_errors), 1)
+        self.assertIn("Normalizer failed (exit 3)", normalize_errors[0])
+        self.assertIn("boom", normalize_errors[0])
         # Guides the model toward root-cause fixes over suppressions.
         self.assertIn("ROOT CAUSE", feedback)
         self.assertIn("noqa", feedback)

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -1057,6 +1057,29 @@ class TaskLauncherTests(unittest.TestCase):
         )
         self.assertEqual(job.status, "running")  # non-terminal
 
+    def test_task_info_includes_filtered_trace(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        job = self._make_job(webapp, status="error")
+        webapp._push_event(job, "step", "normalize")
+        webapp._push_event(job, "log", "Validating the patch with `make style`…")
+        webapp._push_event(job, "token", "noisy")
+        job.error = "task runner exited without reporting (exit code 1)"
+        client = TestClient(webapp.app)
+
+        r = client.get("/tasks/acme/widgets/job123abc456/info")
+
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(
+            [(e["kind"], e["text"]) for e in data["trace"]],
+            [
+                ("step", "normalize"),
+                ("log", "Validating the patch with `make style`…"),
+            ],
+        )
+
     def test_ingest_terminal_records_outcome(self):
         if TestClient is None:
             self.skipTest("fastapi not installed")

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -1064,6 +1064,7 @@ class TaskLauncherTests(unittest.TestCase):
         job = self._make_job(webapp, status="error")
         webapp._push_event(job, "step", "normalize")
         webapp._push_event(job, "log", "Validating the patch with `make style`…")
+        webapp._push_event(job, "normalize_error", "Normalizer failed:\nactual error")
         webapp._push_event(job, "token", "noisy")
         job.error = "task runner exited without reporting (exit code 1)"
         client = TestClient(webapp.app)
@@ -1077,6 +1078,7 @@ class TaskLauncherTests(unittest.TestCase):
             [
                 ("step", "normalize"),
                 ("log", "Validating the patch with `make style`…"),
+                ("normalize_error", "Normalizer failed:\nactual error"),
             ],
         )
 


### PR DESCRIPTION
- Show errored task state more clearly in the task UI.
- Append persisted task errors into the live stream console.
- Decode byte-style runner log tails into readable multiline output.
- Add a dedicated normalize failure panel.
- Persist failed normalizer output as a normalize_error event for future investigations.
- Show likely error lines plus the full normalizer log when available.
- Add helper scripts for task investigation:
    - deploy/scripts/task-status.sh
    - deploy/scripts/logs.sh --task-id