### PR TITLE
Fix: thread verify_reproduce_first to the runner pod (+ expose task spend)

### DIFF
--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -67,6 +67,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "tool_max_iterations",
     "tool_max_iterations_strict",
     "verify_on_gpu",
+    "verify_reproduce_first",
     "verify_workflow_file",
     "verify_ref",
     "verify_transformersci_ref",

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -3755,6 +3755,10 @@ def task_status(request: Request, owner: str, repo: str, job_id: str) -> JSONRes
     if job.target_owner != owner or job.target_repo != repo:
         raise HTTPException(status_code=404, detail="task_target_mismatch")
 
+    # Token counts live on the persisted row (written at finish), not the
+    # in-memory Job — load them so the triage reconciler can render a per-group
+    # spending recap. None while the task is still running; that is fine.
+    row = _store.load(job_id)
     return JSONResponse(
         {
             "id": job.id,
@@ -3762,6 +3766,9 @@ def task_status(request: Request, owner: str, repo: str, job_id: str) -> JSONRes
             "target": f"{job.target_owner}/{job.target_repo}",
             "result": job.task_result,
             "error": job.error,
+            "model": job.llm_model,
+            "prompt_tokens": (row or {}).get("prompt_tokens"),
+            "completion_tokens": (row or {}).get("completion_tokens"),
         }
     )
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -336,5 +336,43 @@ class BuildRunnerConfigTests(unittest.TestCase):
         self.assertEqual(cfg.helper_sandbox, "off")
 
 
+class RunnerConfigPassthroughTest(unittest.TestCase):
+    """The runner pod rebuilds Config from a near-empty env and applies only the
+    RUNNER_CONFIG_FIELDS subset from the spec. A verify_* field missing from that
+    list silently disables that behavior in the pod that actually runs tasks —
+    exactly the bug where verify_reproduce_first never reached the runner."""
+
+    def test_all_verify_fields_are_threaded_to_the_runner(self):
+        import dataclasses
+
+        from reviewbot import launcher
+        from reviewbot.config import Config
+
+        verify_fields = {
+            f.name for f in dataclasses.fields(Config) if f.name.startswith("verify_")
+        }
+        missing = verify_fields - set(launcher.RUNNER_CONFIG_FIELDS)
+        self.assertEqual(
+            missing,
+            set(),
+            f"verify_* Config fields not threaded to the runner pod: {missing}",
+        )
+
+    def test_runner_config_threads_reproduce_first(self):
+        import types
+
+        from reviewbot import launcher
+
+        fake = types.SimpleNamespace(
+            **{
+                field: (field in ("verify_on_gpu", "verify_reproduce_first"))
+                for field in launcher.RUNNER_CONFIG_FIELDS
+            }
+        )
+        out = launcher.runner_config(fake)
+        self.assertTrue(out["verify_reproduce_first"])
+        self.assertTrue(out["verify_on_gpu"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -241,6 +241,11 @@ class WebappTasksTests(unittest.TestCase):
         self.assertEqual(body["id"], "task-status-1")
         self.assertEqual(body["status"], "no_fix")
         self.assertEqual(body["target"], "acme/widgets")
+        # Model + token counts are exposed so the triage reconciler can render a
+        # per-group spending recap (tokens null until the task finishes).
+        self.assertEqual(body["model"], "m")
+        self.assertIn("prompt_tokens", body)
+        self.assertIn("completion_tokens", body)
 
     def test_status_endpoint_rejects_foreign_repo_claim(self):
         if TestClient is None:


### PR DESCRIPTION
## The bug
`verify_reproduce_first` (PR #64) was added to `Config` and wired into the task flow, but **not** added to `launcher.RUNNER_CONFIG_FIELDS`. The per-task runner pod rebuilds `Config` from a near-empty env and applies only that subset from the spec, so it never received the flag and defaulted to `False`.

**Effect:** reproduce-first was dead in prod even with `VERIFY_REPRODUCE_FIRST=1` on the web pod. A live nightly run (issue huggingface/transformers#47515) investigated all 3 groups **blind** — ~2M input tokens each, `verify_verdict` null, no GPU pre-step — exactly what reproduce-first was meant to prevent.

## Fix
- Add `verify_reproduce_first` to `RUNNER_CONFIG_FIELDS`.
- Regression guard: a test asserting **every** `verify_*` Config field is in `RUNNER_CONFIG_FIELDS`, so a future field can't be silently dropped again.

## Also (recap enablement)
Expose `model` + `prompt_tokens`/`completion_tokens` on `GET /tasks/.../status` (from the persisted row) so the triage reconciler can render a per-group spending recap in the tracking issue.

Full suite: 459 passing, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)