### PR TITLE
Fix: retry the verify/reproduce artifact fetch (no_result race)

### DIFF
--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -37,6 +37,12 @@ _MODEL_RE = re.compile(r"tests/models/([^/]+)/")
 _MULTI_GPU = "aws-g5-12xlarge-cache"
 _SINGLE_GPU = "aws-g5-4xlarge-cache"
 
+# GitHub finalizes a run's artifacts slightly AFTER the run status flips to
+# "completed", so a fetch immediately on completion can see an empty artifact
+# list and wrongly report no_result. Retry the fetch this many times (spaced by
+# the poll interval) before giving up.
+_FETCH_ATTEMPTS = 6
+
 # Verify-mode verdicts produced workflow-side (serge-verify-verdict). Only
 # `fixed` opens a PR.
 FIXED = "fixed"
@@ -335,10 +341,21 @@ def _dispatch_poll_fetch(
             TIMEOUT, run_url=run_url, detail="verify run did not complete in time"
         )
 
-    result = _fetch_verdict(gh, owner, repo, int(run["id"]))
+    # Retry the artifact fetch: it can lag the run's "completed" status by a few
+    # seconds (see _FETCH_ATTEMPTS), and dropping a real verdict as no_result
+    # forces a blind investigation.
+    result: Optional[dict] = None
+    for attempt in range(_FETCH_ATTEMPTS):
+        result = _fetch_verdict(gh, owner, repo, int(run["id"]))
+        if result is not None:
+            break
+        if attempt < _FETCH_ATTEMPTS - 1:
+            sleep(poll_interval)
     if result is None:
         return VerifyOutcome(
-            NO_RESULT, run_url=run_url, detail="no verify-result artifact"
+            NO_RESULT,
+            run_url=run_url,
+            detail=f"no verify-result artifact after {_FETCH_ATTEMPTS} attempts",
         )
     return VerifyOutcome(
         verdict=result.get("verdict", NO_RESULT),

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -197,6 +197,31 @@ def test_run_verify_no_result_artifact():
     assert out.verdict == verify.NO_RESULT
 
 
+def test_run_verify_retries_late_artifact():
+    # The artifact list is empty on the first two polls (GitHub still finalizing)
+    # and populated on the third — serge must retry rather than report no_result.
+    class LateArtifactGH(FakeGH):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self._calls = 0
+
+        def list_run_artifacts(self, owner, repo, run_id):
+            self._calls += 1
+            if self._calls < 3:
+                return []
+            return [{"id": 9, "name": "serge-verify-result-x"}]
+
+    gh = LateArtifactGH(
+        runs=[
+            {"id": 5, "name": "x [corr-123]", "status": "completed", "html_url": "u"}
+        ],
+        zip_bytes=_zip_with({"verdict": "reproduced", "tracebacks": {"t": "boom"}}),
+    )
+    out = _run_repro(gh)
+    assert out.verdict == verify.REPRODUCED
+    assert gh._calls == 3  # succeeded on the third fetch, not on the first
+
+
 def test_run_verify_correlation_id_mismatch_times_out():
     # A concurrent run for a different task must not be picked up.
     gh = FakeGH(


### PR DESCRIPTION
## The race
GitHub finalizes a run's artifacts a few seconds **after** the run status flips to `completed`. serge fetched the verdict artifact immediately on completion, saw an empty artifact list, and reported `no_result`.

**Observed live** (reproduce-first validation): a `gemma` reproduce run completed `07:48:29` with a valid `serge-verify-result` artifact; serge fetched at `07:48:48` (19s later) → `no_result` → fell back to a blind ~2M-token investigation with no reproduction seed. The fail-open safety worked, but the whole point of reproduce-first (grounding the LLM on the real traceback) was lost.

## Fix
Retry `_fetch_verdict` up to `_FETCH_ATTEMPTS` (6) times, spaced by the poll interval, before giving up — in the shared `_dispatch_poll_fetch`, so both `verify` and `reproduce` benefit.

Test: an artifact that appears only on the third poll now yields the verdict instead of `no_result`. 460 passing, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)