### PR TITLE
Fix: keep fetching the verify/reproduce verdict past the artifact-listing lag

### DIFF
--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -37,11 +37,14 @@ _MODEL_RE = re.compile(r"tests/models/([^/]+)/")
 _MULTI_GPU = "aws-g5-12xlarge-cache"
 _SINGLE_GPU = "aws-g5-4xlarge-cache"
 
-# GitHub finalizes a run's artifacts slightly AFTER the run status flips to
-# "completed", so a fetch immediately on completion can see an empty artifact
-# list and wrongly report no_result. Retry the fetch this many times (spaced by
-# the poll interval) before giving up.
-_FETCH_ATTEMPTS = 6
+# GitHub's run-scoped artifact listing lags the run's "completed" status: the
+# artifact is uploaded before completion, but `GET /runs/{id}/artifacts` can keep
+# returning an empty list for MINUTES afterwards (observed ~3 min in prod across a
+# whole nightly batch). A fetch right after completion therefore sees nothing and
+# would wrongly report no_result -> blind investigation. Keep re-fetching (spaced
+# by the poll interval) against the remaining poll budget, but for at least this
+# many seconds so a run that finishes near poll_timeout still gets a fair chance.
+_MIN_FETCH_WINDOW = 300.0
 
 # Verify-mode verdicts produced workflow-side (serge-verify-verdict). Only
 # `fixed` opens a PR.
@@ -341,21 +344,26 @@ def _dispatch_poll_fetch(
             TIMEOUT, run_url=run_url, detail="verify run did not complete in time"
         )
 
-    # Retry the artifact fetch: it can lag the run's "completed" status by a few
-    # seconds (see _FETCH_ATTEMPTS), and dropping a real verdict as no_result
-    # forces a blind investigation.
+    # Retry the artifact fetch: the run-scoped listing can lag "completed" by
+    # minutes (see _MIN_FETCH_WINDOW), and dropping a real verdict as no_result
+    # forces a blind investigation. Keep polling for the verdict until it appears
+    # or we run past the fetch deadline — the remaining poll budget, but at least
+    # _MIN_FETCH_WINDOW. Success breaks immediately, so the common case adds no
+    # latency; only a genuinely-missing artifact waits out the window.
     result: Optional[dict] = None
-    for attempt in range(_FETCH_ATTEMPTS):
+    fetch_deadline = max(deadline, monotonic() + _MIN_FETCH_WINDOW)
+    while True:
         result = _fetch_verdict(gh, owner, repo, int(run["id"]))
         if result is not None:
             break
-        if attempt < _FETCH_ATTEMPTS - 1:
-            sleep(poll_interval)
+        if monotonic() >= fetch_deadline:
+            break
+        sleep(poll_interval)
     if result is None:
         return VerifyOutcome(
             NO_RESULT,
             run_url=run_url,
-            detail=f"no verify-result artifact after {_FETCH_ATTEMPTS} attempts",
+            detail="no verify-result artifact before fetch deadline",
         )
     return VerifyOutcome(
         verdict=result.get("verdict", NO_RESULT),

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -193,8 +193,36 @@ def test_run_verify_no_result_artifact():
         ],
         artifacts=[],
     )
-    out = _run(gh)
+    # The verdict never appears: fetch loop runs until monotonic passes the fetch
+    # deadline (a big jump here), then falls open to no_result.
+    out = _run(gh, poll_timeout=1, monotonic=Clock([0, 0, 0, 10_000]))
     assert out.verdict == verify.NO_RESULT
+
+
+def test_run_verify_retries_artifact_past_old_window():
+    # Regression for the ~3-min prod listing lag: the artifact stays invisible for
+    # far longer than the old fixed 6-attempt (150s) window, then appears. serge
+    # must keep polling against the remaining budget rather than bail no_result.
+    class VeryLateArtifactGH(FakeGH):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self._calls = 0
+
+        def list_run_artifacts(self, owner, repo, run_id):
+            self._calls += 1
+            if self._calls < 20:  # empty well past the old 6-attempt window
+                return []
+            return [{"id": 9, "name": "serge-verify-result-x"}]
+
+    gh = VeryLateArtifactGH(
+        runs=[
+            {"id": 5, "name": "x [corr-123]", "status": "completed", "html_url": "u"}
+        ],
+        zip_bytes=_zip_with({"verdict": "reproduced", "tracebacks": {"t": "boom"}}),
+    )
+    out = _run_repro(gh)
+    assert out.verdict == verify.REPRODUCED
+    assert gh._calls == 20  # kept polling far beyond the old 6-attempt cap
 
 
 def test_run_verify_retries_late_artifact():


### PR DESCRIPTION
## Problem

Validation run 3 of reproduce-first (nightly triage `30112229181`, serge `sha-0de0ccc`) fired reproduce on all 3 groups — but **all three fell open to `no_result` → blind investigation**, the exact symptom #66 was supposed to fix. llava_next burned **2.08M tokens** for a `no_fix`.

Root cause (proven, not guessed): the reproduce runs produced correct verdicts (`verify-result.json` = `{"verdict": "reproduced", ...}` with a real traceback, `created_at` ~2–3s **before** the run completed). But serge's fetch returned an empty list **6×** and gave up. Replaying the fetch with both a freshly-minted token **and the task's own still-valid `ghs_` token** parses the artifact cleanly. So it's not token scope, not code — it's **GitHub's run-scoped `/runs/{id}/artifacts` listing lagging ~3 min** behind the artifact's creation, past #66's `6 × 30s = 150s` window.

| Group | artifact created | serge `no_result` | gap |
|---|---|---|---|
| llava_next | 17:21:13Z | 17:24:14Z | 3:01 |
| ovis2 | 17:23:11Z | 17:26:06Z | 2:55 |
| emu3 | 17:24:52Z | 17:27:38Z | 2:46 |

## Fix

Replace the fixed 6-attempt sub-loop with one that keeps re-fetching (spaced by the poll interval) until the verdict appears or we run past a **fetch deadline** = the remaining poll budget (`VERIFY_POLL_TIMEOUT`, ~36 min spare after a ~4 min run), floored at `_MIN_FETCH_WINDOW=300s`. Success breaks immediately → no added latency in the common case; only a genuinely-missing artifact waits out the window. Stays fail-open.

## Tests

- Updated `test_run_verify_no_result_artifact` for the time-based loop.
- Added `test_run_verify_retries_artifact_past_old_window` — artifact appears only after 20 polls (far past the old 6-attempt cap); asserts `reproduced` is still consumed.
- Full suite: 461 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)