### PR TITLE
Fix: give the reproduce-first classifier enough tokens (300 -> CLASSIFY_MAX_TOKENS=4096)

### DIFF
--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -159,6 +159,11 @@ class Config:
     task_api_enabled: bool = False
     task_oidc_issuer: str = "https://token.actions.githubusercontent.com"
     task_oidc_audience: str = "serge"
+    # Completion-token budget for the cheap product-vs-test classifier
+    # (reviewbot/classify.py). Reasoning models (Kimi) burn tokens on reasoning
+    # before emitting the JSON verdict, so the old 300 default always truncated
+    # to `unclear — unparseable`. Tunable via CLASSIFY_MAX_TOKENS.
+    classify_max_tokens: int = 4096
     # Optional task-only completion-token cap. When unset, tasks use the
     # normal llm_max_tokens value.
     task_llm_max_tokens: Optional[int] = None
@@ -416,6 +421,7 @@ class Config:
             llm_model=os.environ.get("LLM_MODEL") or None,
             llm_bill_to=os.environ.get("LLM_BILL_TO") or None,
             llm_max_tokens=_int_env("LLM_MAX_TOKENS", 4096),
+            classify_max_tokens=_int_env("CLASSIFY_MAX_TOKENS", 4096),
             # Streaming on by default — the web UI's live token counter
             # and reasoning display rely on incremental SSE chunks. Set
             # LLM_STREAM=0 to fall back to the buffered REST path.

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -76,6 +76,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "verify_poll_timeout",
     "verify_poll_interval",
     "verify_max_rounds",
+    "classify_max_tokens",
 )
 
 

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -1141,7 +1141,11 @@ def _classify_reproduced(
             stream=False,
         )
         result = classify_failure(
-            llm, node_ids=node_ids, tracebacks=tracebacks, context=context
+            llm,
+            node_ids=node_ids,
+            tracebacks=tracebacks,
+            context=context,
+            max_tokens=cfg.classify_max_tokens,
         )
     except Exception as exc:  # noqa: BLE001 — classification is best-effort
         log.debug("classify failed: %s", exc, exc_info=True)

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -373,6 +373,23 @@ class RunnerConfigPassthroughTest(unittest.TestCase):
         self.assertTrue(out["verify_reproduce_first"])
         self.assertTrue(out["verify_on_gpu"])
 
+    def test_classify_max_tokens_is_threaded_to_the_runner(self):
+        # The classifier runs in the runner pod (_classify_reproduced), so its
+        # token budget must reach it or the pod silently uses the dataclass
+        # default. Same failure class as the verify_* fields above.
+        import types
+
+        from reviewbot import launcher
+
+        self.assertIn("classify_max_tokens", launcher.RUNNER_CONFIG_FIELDS)
+        fake = types.SimpleNamespace(
+            **{
+                field: (4096 if field == "classify_max_tokens" else None)
+                for field in launcher.RUNNER_CONFIG_FIELDS
+            }
+        )
+        self.assertEqual(launcher.runner_config(fake)["classify_max_tokens"], 4096)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

On the 2026-07-25 daytime run, reproduce-first finally worked end-to-end — all 3 groups logged `reproduced ✓` and downloaded their verdicts (egress fix) — **but every classify came back `unclear — unparseable classifier output`.**

`_classify_reproduced` (tasks.py) called `classify_failure()` with the default **`max_tokens=300`**. Prod runs **Kimi-K2.6**, a reasoning model: the reasoning burns the whole 300-token budget before it emits the JSON verdict, so `parse_classify_response` always fell through to `unclear`.

Verified live from the prod pod:

| max_tokens | result |
|---|---|
| 300 (current) | `unclear` / `unparseable` (raw = truncated reasoning) |
| 3000 | clean JSON, correct label (`test_issue`) |

## Fix

- New `classify_max_tokens` Config field, env **`CLASSIFY_MAX_TOKENS`**, default **4096**.
- `_classify_reproduced` passes it to `classify_failure`.
- Threaded through `launcher.RUNNER_CONFIG_FIELDS` — the classifier runs in the **runner pod**, which rebuilds Config from a bare env + this subset; an unthreaded field would silently use the dataclass default there (the same failure class as #65). Guarded by a new test.

## Notes

- **Non-blocking:** `unclear` already proceeds to a seeded investigation, so this restores the lost product-vs-test signal; it doesn't unblock the flow.
- Tests: 462 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)