### PR TITLE
Seed the FULL reproduce/verify traceback into the fix prompt (REPRODUCE_TB_CHARS)

### DIFF
--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -164,6 +164,11 @@ class Config:
     # before emitting the JSON verdict, so the old 300 default always truncated
     # to `unclear — unparseable`. Tunable via CLASSIFY_MAX_TOKENS.
     classify_max_tokens: int = 4096
+    # Per-traceback char budget when serge seeds the reproduced/verify failures
+    # into the fix prompt. The GPU run emits full assertion diffs (pytest -vv);
+    # the old 2000-char tail chopped the very generated strings the LLM needs to
+    # rewrite stale expected values. Tunable via REPRODUCE_TB_CHARS.
+    reproduce_tb_chars: int = 12000
     # Optional task-only completion-token cap. When unset, tasks use the
     # normal llm_max_tokens value.
     task_llm_max_tokens: Optional[int] = None
@@ -422,6 +427,7 @@ class Config:
             llm_bill_to=os.environ.get("LLM_BILL_TO") or None,
             llm_max_tokens=_int_env("LLM_MAX_TOKENS", 4096),
             classify_max_tokens=_int_env("CLASSIFY_MAX_TOKENS", 4096),
+            reproduce_tb_chars=_int_env("REPRODUCE_TB_CHARS", 12000),
             # Streaming on by default — the web UI's live token counter
             # and reasoning display rely on incremental SSE chunks. Set
             # LLM_STREAM=0 to fall back to the buffered REST path.

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -77,6 +77,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "verify_poll_interval",
     "verify_max_rounds",
     "classify_max_tokens",
+    "reproduce_tb_chars",
 )
 
 

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -120,6 +120,11 @@ class ReviewEdits:
 
 
 _FENCED_BLOCK_RE = re.compile(r"```(?:json|JSON)?\s*([\s\S]*?)\s*```")
+# Opening fence of a JSON block at the very start of a reply, and the fence
+# that closes it. Used to peel the wrapper off a stub-JSON reply — see
+# `_prose_outside_json`.
+_LEADING_FENCE_RE = re.compile(r"\A```[ \t]*(?:json|JSON)?[ \t]*\r?\n?")
+_CLOSING_FENCE_RE = re.compile(r"\A\s*```[ \t]*\r?\n?")
 _TAGGED_DIFF_LINE_RE = re.compile(r"^\[(R|L)\s*(\d+)\] ")
 _PARSE_PREVIEW_CHARS = 500
 
@@ -180,6 +185,38 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
         f"LLM response did not contain a JSON object "
         f"(length={len(content)} chars, preview={_content_preview(text)!r})"
     )
+
+
+def _prose_outside_json(content: Optional[str]) -> str:
+    """The markdown left over once the JSON object `_extract_json` picked up
+    (and any fence wrapping it) is removed.
+
+    Models occasionally answer with a *stub* JSON object — empty summary, no
+    comments — and then write the actual review as prose underneath, often
+    forgetting the closing ``` of the fence they opened. Handing that whole
+    reply to the reader publishes the fence and the stub verbatim, and an
+    unterminated fence swallows the entire review into one code block.
+
+    Returns "" when there is no prose to salvage, so callers can keep their
+    own fallback.
+    """
+    text = (content or "").strip()
+    if not text:
+        return ""
+    text = _LEADING_FENCE_RE.sub("", text, count=1)
+
+    decoder = json.JSONDecoder()
+    for idx in (i for i, ch in enumerate(text) if ch == "{"):
+        try:
+            _, end = decoder.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        head = text[:idx]
+        # Drop only the fence that closes the JSON block — a global strip
+        # would eat legitimate code fences inside the prose review.
+        tail = _CLOSING_FENCE_RE.sub("", text[idx + end :], count=1)
+        return "\n\n".join(part for part in (head.strip(), tail.strip()) if part)
+    return ""
 
 
 @dataclass
@@ -1465,15 +1502,18 @@ def prepare_review(
         # object alongside the actual review written as prose. Since
         # `_extract_json` accepts the first decodable `{...}`, we can
         # end up with an empty `summary` while the model's real
-        # write-up sits in `chat.content`. Use the raw content rather
-        # than publishing an empty "(no overall summary provided)".
+        # write-up sits in `chat.content`. Salvage the prose rather
+        # than publishing an empty "(no overall summary provided)" —
+        # but peel off the JSON stub and its ``` fence first, or the
+        # published summary opens with a fence the model never closed
+        # and renders as one giant code block.
         if (
             not summary
             and not (result.get("comments") or [])
             and chat.content
             and chat.content.strip()
         ):
-            summary = chat.content.strip()
+            summary = _prose_outside_json(chat.content) or chat.content.strip()
             log.warning(
                 "Parsed JSON yielded empty summary/comments; using "
                 "raw content (%d chars) as summary",

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -1032,7 +1032,19 @@ def publish_task(
     )
 
 
-def _format_verify_feedback(result: TaskResult) -> str:
+def _tail_tb(tb: Optional[str], max_chars: int) -> str:
+    """Keep the tail of a traceback (the assertion diff + captured output sit at
+    the end) up to ``max_chars``, marking the cut so the LLM knows it's partial."""
+    text = tb or ""
+    if len(text) <= max_chars:
+        return text
+    return "…(traceback truncated to last %d chars)…\n%s" % (
+        max_chars,
+        text[-max_chars:],
+    )
+
+
+def _format_verify_feedback(result: TaskResult, max_chars: int = 12000) -> str:
     """Markdown feedback for the next LLM round: the failures the previous
     candidate's GPU verify still produced."""
     lines = [
@@ -1047,7 +1059,7 @@ def _format_verify_feedback(result: TaskResult) -> str:
     for nodeid, tb in list(result.verify_tracebacks.items())[:5]:
         lines.append(f"### {nodeid}")
         lines.append("```")
-        lines.append((tb or "")[-2000:])
+        lines.append(_tail_tb(tb, max_chars))
         lines.append("```")
         lines.append("")
     return "\n".join(lines).rstrip()
@@ -1087,7 +1099,9 @@ def _reproduce_bail_message(outcome: VerifyOutcome) -> str:
 
 
 def _format_reproduce_feedback(
-    outcome: VerifyOutcome, classification: ClassifyResult
+    outcome: VerifyOutcome,
+    classification: ClassifyResult,
+    max_chars: int = 12000,
 ) -> str:
     """Authoritative reproduction context seeded into the LLM prompt. Supersedes
     any inbound 'do not run the test suite' note: serge already ran the tests on
@@ -1119,7 +1133,7 @@ def _format_reproduce_feedback(
             "",
         ]
     for nodeid, tb in list(outcome.tracebacks.items())[:5]:
-        lines += [f"### {nodeid}", "```", (tb or "")[-2000:], "```", ""]
+        lines += [f"### {nodeid}", "```", _tail_tb(tb, max_chars), "```", ""]
     return "\n".join(lines).rstrip()
 
 
@@ -1225,7 +1239,10 @@ def _maybe_reproduce_first(
         cfg, node_ids, outcome.tracebacks, req.context, emit
     )
     seeded = _with_verify_feedback(
-        req, _format_reproduce_feedback(outcome, classification)
+        req,
+        _format_reproduce_feedback(
+            outcome, classification, max_chars=cfg.reproduce_tb_chars
+        ),
     )
     return None, seeded
 
@@ -1292,7 +1309,8 @@ def prepare_and_publish_candidate(
                 f"(round {attempt + 2}/{rounds + 1})",
             )
             req_i = _with_verify_feedback(
-                candidate_req, _format_verify_feedback(result)
+                candidate_req,
+                _format_verify_feedback(result, max_chars=cfg.reproduce_tb_chars),
             )
             continue
         return result

--- a/tests/test_reproduce_first.py
+++ b/tests/test_reproduce_first.py
@@ -26,6 +26,8 @@ def _cfg(reproduce_first=True):
         verify_transformersci_ref="main",
         verify_poll_timeout=100,
         verify_poll_interval=0,
+        classify_max_tokens=4096,
+        reproduce_tb_chars=12000,
     )
 
 

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -17,6 +17,7 @@ from reviewbot.reviewer import (
     _extract_json,
     _merge_chunk_event,
     _merge_chunk_summaries,
+    _prose_outside_json,
     _run_agentic_loop,
     _summarize_rejected_comments,
 )
@@ -224,6 +225,63 @@ class ExtractJsonTests(unittest.TestCase):
             _extract_json(content),
             {"summary": "use { and } carefully", "comments": []},
         )
+
+
+class ProseOutsideJsonTests(unittest.TestCase):
+    """The stub-JSON-plus-prose reply: `_extract_json` takes the stub, this
+    takes the review the model actually wrote."""
+
+    STUB = '{"summary": "", "event": "COMMENT", "comments": []}'
+    PROSE = (
+        "### Correctness\n- `src/foo.py` drops the return value.\n\n### Style\n- nit"
+    )
+
+    def test_unclosed_json_fence_yields_prose_only(self) -> None:
+        # The peft#3354 case: the model opened ```json and never closed it,
+        # so the whole review rendered inside one code block.
+        content = f"```json\n{self.STUB}\n\n{self.PROSE}\n"
+        out = _prose_outside_json(content)
+        self.assertEqual(out, self.PROSE)
+        self.assertNotIn("```json", out)
+        self.assertNotIn('"summary"', out)
+
+    def test_closed_json_fence_yields_prose_only(self) -> None:
+        content = f"```json\n{self.STUB}\n```\n\n{self.PROSE}\n"
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
+
+    def test_unfenced_stub_yields_prose_only(self) -> None:
+        content = f"{self.STUB}\n\n{self.PROSE}"
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
+
+    def test_prose_before_the_json_is_kept(self) -> None:
+        content = f"Here is my review:\n\n{self.STUB}\n\n{self.PROSE}"
+        self.assertEqual(
+            _prose_outside_json(content),
+            f"Here is my review:\n\n{self.PROSE}",
+        )
+
+    def test_code_fences_inside_the_prose_survive(self) -> None:
+        prose = "### Correctness\n\n```python\nx = 1\n```\n\nLooks wrong."
+        content = f"```json\n{self.STUB}\n```\n\n{prose}"
+        self.assertEqual(_prose_outside_json(content), prose)
+
+    def test_json_only_reply_has_no_prose(self) -> None:
+        self.assertEqual(_prose_outside_json(f"```json\n{self.STUB}\n```"), "")
+        self.assertEqual(_prose_outside_json(self.STUB), "")
+
+    def test_no_json_object_returns_empty(self) -> None:
+        self.assertEqual(_prose_outside_json("just prose, no object"), "")
+
+    def test_empty_and_none_content(self) -> None:
+        self.assertEqual(_prose_outside_json(""), "")
+        self.assertEqual(_prose_outside_json("   \n\t "), "")
+        self.assertEqual(_prose_outside_json(None), "")
+
+    def test_matches_what_extract_json_consumed(self) -> None:
+        # The two halves of the same reply: the dict and the leftover prose.
+        content = f"```json\n{self.STUB}\n\n{self.PROSE}\n"
+        self.assertEqual(_extract_json(content), json.loads(self.STUB))
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
 
 
 class ContentPreviewTests(unittest.TestCase):

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -390,6 +390,22 @@ class RunnerConfigPassthroughTest(unittest.TestCase):
         )
         self.assertEqual(launcher.runner_config(fake)["classify_max_tokens"], 4096)
 
+    def test_reproduce_tb_chars_is_threaded_to_the_runner(self):
+        # The reproduce/verify traceback seed is built in the runner pod, so its
+        # char budget must reach it (same failure class as classify_max_tokens).
+        import types
+
+        from reviewbot import launcher
+
+        self.assertIn("reproduce_tb_chars", launcher.RUNNER_CONFIG_FIELDS)
+        fake = types.SimpleNamespace(
+            **{
+                field: (12000 if field == "reproduce_tb_chars" else None)
+                for field in launcher.RUNNER_CONFIG_FIELDS
+            }
+        )
+        self.assertEqual(launcher.runner_config(fake)["reproduce_tb_chars"], 12000)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -8,6 +8,8 @@ def _cfg(on_gpu: bool, rounds: int = 2, reproduce_first: bool = False):
         verify_on_gpu=on_gpu,
         verify_max_rounds=rounds,
         verify_reproduce_first=reproduce_first,
+        classify_max_tokens=4096,
+        reproduce_tb_chars=12000,
     )
 
 


### PR DESCRIPTION
## Problem

On the 2026-07-25 run, reproduce-first worked and classified groups correctly (`test_issue`) — but they still ended `no_fix`. The task messages said it plainly:

> *the actual generated outputs are heavily truncated in the tracebacks (e.g. "Diff is 2399 characters long"). Without the full generated strings, the expected values cannot be reconstructed.*

Two truncation points on the path from the GPU run to the LLM:
1. **pytest `-v`** in transformers-ci `serge-verify-slow.yml` truncates assertion diffs at the source (that's the "Diff is N characters long" message). → fixed there by `-v`→`-vv` (companion PR).
2. **serge** then re-truncated each traceback to the **last 2000 chars** in `_format_reproduce_feedback` / `_format_verify_feedback`, chopping the generated strings the LLM needs.

## This PR (serge side)

- New `reproduce_tb_chars` Config field, env **`REPRODUCE_TB_CHARS`**, default **12000**.
- Shared `_tail_tb` helper applied in both the reproduce-first seed and the retry-round seed; marks the cut when it truncates.
- Threaded through `launcher.RUNNER_CONFIG_FIELDS` — the seed is built in the **runner pod** (same failure class as #65), with a guard test.

## Notes

- **Needs the companion transformers-ci PR** (`-v`→`-vv`); either alone is insufficient.
- Fixes **string/list** expectation failures (e.g. `EXPECTED_OUTPUT`, chat-template token lists). **Logits** `assert_close` still doesn't print the full actual tensor — a separate, transformers-side item.
- Tests: 472 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)