### PR TITLE
Fix: don't publish the JSON stub + its ``` fence as the review summary

### DIFF
--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -120,6 +120,11 @@ class ReviewEdits:
 
 
 _FENCED_BLOCK_RE = re.compile(r"```(?:json|JSON)?\s*([\s\S]*?)\s*```")
+# Opening fence of a JSON block at the very start of a reply, and the fence
+# that closes it. Used to peel the wrapper off a stub-JSON reply — see
+# `_prose_outside_json`.
+_LEADING_FENCE_RE = re.compile(r"\A```[ \t]*(?:json|JSON)?[ \t]*\r?\n?")
+_CLOSING_FENCE_RE = re.compile(r"\A\s*```[ \t]*\r?\n?")
 _TAGGED_DIFF_LINE_RE = re.compile(r"^\[(R|L)\s*(\d+)\] ")
 _PARSE_PREVIEW_CHARS = 500
 
@@ -180,6 +185,38 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
         f"LLM response did not contain a JSON object "
         f"(length={len(content)} chars, preview={_content_preview(text)!r})"
     )
+
+
+def _prose_outside_json(content: Optional[str]) -> str:
+    """The markdown left over once the JSON object `_extract_json` picked up
+    (and any fence wrapping it) is removed.
+
+    Models occasionally answer with a *stub* JSON object — empty summary, no
+    comments — and then write the actual review as prose underneath, often
+    forgetting the closing ``` of the fence they opened. Handing that whole
+    reply to the reader publishes the fence and the stub verbatim, and an
+    unterminated fence swallows the entire review into one code block.
+
+    Returns "" when there is no prose to salvage, so callers can keep their
+    own fallback.
+    """
+    text = (content or "").strip()
+    if not text:
+        return ""
+    text = _LEADING_FENCE_RE.sub("", text, count=1)
+
+    decoder = json.JSONDecoder()
+    for idx in (i for i, ch in enumerate(text) if ch == "{"):
+        try:
+            _, end = decoder.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        head = text[:idx]
+        # Drop only the fence that closes the JSON block — a global strip
+        # would eat legitimate code fences inside the prose review.
+        tail = _CLOSING_FENCE_RE.sub("", text[idx + end :], count=1)
+        return "\n\n".join(part for part in (head.strip(), tail.strip()) if part)
+    return ""
 
 
 @dataclass
@@ -1465,15 +1502,18 @@ def prepare_review(
         # object alongside the actual review written as prose. Since
         # `_extract_json` accepts the first decodable `{...}`, we can
         # end up with an empty `summary` while the model's real
-        # write-up sits in `chat.content`. Use the raw content rather
-        # than publishing an empty "(no overall summary provided)".
+        # write-up sits in `chat.content`. Salvage the prose rather
+        # than publishing an empty "(no overall summary provided)" —
+        # but peel off the JSON stub and its ``` fence first, or the
+        # published summary opens with a fence the model never closed
+        # and renders as one giant code block.
         if (
             not summary
             and not (result.get("comments") or [])
             and chat.content
             and chat.content.strip()
         ):
-            summary = chat.content.strip()
+            summary = _prose_outside_json(chat.content) or chat.content.strip()
             log.warning(
                 "Parsed JSON yielded empty summary/comments; using "
                 "raw content (%d chars) as summary",

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -17,6 +17,7 @@ from reviewbot.reviewer import (
     _extract_json,
     _merge_chunk_event,
     _merge_chunk_summaries,
+    _prose_outside_json,
     _run_agentic_loop,
     _summarize_rejected_comments,
 )
@@ -224,6 +225,63 @@ class ExtractJsonTests(unittest.TestCase):
             _extract_json(content),
             {"summary": "use { and } carefully", "comments": []},
         )
+
+
+class ProseOutsideJsonTests(unittest.TestCase):
+    """The stub-JSON-plus-prose reply: `_extract_json` takes the stub, this
+    takes the review the model actually wrote."""
+
+    STUB = '{"summary": "", "event": "COMMENT", "comments": []}'
+    PROSE = (
+        "### Correctness\n- `src/foo.py` drops the return value.\n\n### Style\n- nit"
+    )
+
+    def test_unclosed_json_fence_yields_prose_only(self) -> None:
+        # The peft#3354 case: the model opened ```json and never closed it,
+        # so the whole review rendered inside one code block.
+        content = f"```json\n{self.STUB}\n\n{self.PROSE}\n"
+        out = _prose_outside_json(content)
+        self.assertEqual(out, self.PROSE)
+        self.assertNotIn("```json", out)
+        self.assertNotIn('"summary"', out)
+
+    def test_closed_json_fence_yields_prose_only(self) -> None:
+        content = f"```json\n{self.STUB}\n```\n\n{self.PROSE}\n"
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
+
+    def test_unfenced_stub_yields_prose_only(self) -> None:
+        content = f"{self.STUB}\n\n{self.PROSE}"
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
+
+    def test_prose_before_the_json_is_kept(self) -> None:
+        content = f"Here is my review:\n\n{self.STUB}\n\n{self.PROSE}"
+        self.assertEqual(
+            _prose_outside_json(content),
+            f"Here is my review:\n\n{self.PROSE}",
+        )
+
+    def test_code_fences_inside_the_prose_survive(self) -> None:
+        prose = "### Correctness\n\n```python\nx = 1\n```\n\nLooks wrong."
+        content = f"```json\n{self.STUB}\n```\n\n{prose}"
+        self.assertEqual(_prose_outside_json(content), prose)
+
+    def test_json_only_reply_has_no_prose(self) -> None:
+        self.assertEqual(_prose_outside_json(f"```json\n{self.STUB}\n```"), "")
+        self.assertEqual(_prose_outside_json(self.STUB), "")
+
+    def test_no_json_object_returns_empty(self) -> None:
+        self.assertEqual(_prose_outside_json("just prose, no object"), "")
+
+    def test_empty_and_none_content(self) -> None:
+        self.assertEqual(_prose_outside_json(""), "")
+        self.assertEqual(_prose_outside_json("   \n\t "), "")
+        self.assertEqual(_prose_outside_json(None), "")
+
+    def test_matches_what_extract_json_consumed(self) -> None:
+        # The two halves of the same reply: the dict and the leftover prose.
+        content = f"```json\n{self.STUB}\n\n{self.PROSE}\n"
+        self.assertEqual(_extract_json(content), json.loads(self.STUB))
+        self.assertEqual(_prose_outside_json(content), self.PROSE)
 
 
 class ContentPreviewTests(unittest.TestCase):


### PR DESCRIPTION
When a forced-final turn answers with a stub JSON object (empty summary, no comments) and writes the real review as prose underneath, `prepare_review` fell back to publishing `chat.content` verbatim. That carries the model's opening ```json fence — and models routinely forget the closing one, so the whole review rendered as a single unterminated code block (seen on huggingface/peft#3354).

`_prose_outside_json` peels off the leading fence, the JSON object `_extract_json` already consumed, and the fence that closes it, leaving just the prose. Only the fence closing the JSON block is stripped, so code fences inside the review survive. Falls back to the old behavior when there is no prose to salvage.