### PR TITLE
Add GPU-verification provenance to the serge PR body

### DIFF
--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -107,6 +107,10 @@ class TaskRequest:
     slack_notify_task_finished: bool = False
     # Resolved during processing (existing_pr): the PR's head branch.
     head_branch: Optional[str] = None
+    # Set by reproduce-first when the group reproduced on GPU: the run that
+    # confirmed the failure at the base commit. Surfaced in the PR body as the
+    # "failed before" evidence.
+    reproduce_run_url: Optional[str] = None
 
     @property
     def repo_full_name(self) -> str:
@@ -781,6 +785,29 @@ def _make_verify_gate(
     return _gate
 
 
+def _verification_footer(
+    verify_run_url: Optional[str], reproduce_run_url: Optional[str]
+) -> str:
+    """Provenance appended to the PR body: serge ran the targeted ``@slow`` tests
+    on GPU and opened this PR only after they passed with the patch. Links the
+    verify run (green with the patch) and, when reproduce-first ran, the run that
+    confirmed the failure at the base commit (red before)."""
+    if not verify_run_url and not reproduce_run_url:
+        return ""
+    lines = [
+        "",
+        "---",
+        "### ✅ Verified on GPU",
+        "serge ran the targeted `@slow` test(s) on a GPU runner and opened this PR "
+        "only after they passed with this patch.",
+    ]
+    if verify_run_url:
+        lines.append(f"- **Passes with this patch:** {verify_run_url}")
+    if reproduce_run_url:
+        lines.append(f"- **Failed before the fix (base commit):** {reproduce_run_url}")
+    return "\n".join(lines)
+
+
 def _commit_changes(
     cfg: Config,
     gh: GitHubClient,
@@ -879,6 +906,7 @@ def _commit_changes(
     # GPU verify gate (opt-in): run the targeted tests on the candidate before
     # opening the PR. `parent_sha` is the baseline-red reference. On a non-`fixed`
     # verdict, tear the branch down and return without a PR.
+    verify_run_url: Optional[str] = None
     if verify is not None:
         outcome = verify(parent_sha, commit_sha)
         if not outcome.is_fixed:
@@ -895,6 +923,7 @@ def _commit_changes(
                 verify_verdict=outcome.verdict,
                 verify_tracebacks=outcome.tracebacks,
             )
+        verify_run_url = outcome.run_url
 
     # Open as a draft, then immediately mark ready-for-review. The
     # draft->ready transition is what fires the `ready_for_review` webhook that
@@ -907,7 +936,7 @@ def _commit_changes(
         title=title,
         head=branch,
         base=req.base_ref,
-        body=body,
+        body=body + _verification_footer(verify_run_url, req.reproduce_run_url),
         draft=True,
     )
     gh.mark_pull_request_ready(pr["node_id"])
@@ -1244,6 +1273,7 @@ def _maybe_reproduce_first(
             outcome, classification, max_chars=cfg.reproduce_tb_chars
         ),
     )
+    seeded = dataclasses.replace(seeded, reproduce_run_url=outcome.run_url)
     return None, seeded
 
 

--- a/tests/test_reproduce_first.py
+++ b/tests/test_reproduce_first.py
@@ -61,6 +61,7 @@ def _install(monkeypatch, *, repro_outcome, classify_result=None):
 
     def fake_prepare(cfg, req, **kwargs):
         rec["prepare_contexts"].append(req.context)
+        rec["reproduce_run_url"] = req.reproduce_run_url
         return tasks.TaskPlan(title="t", body="b", patch="p")
 
     def fake_publish(cfg, gh, req, plan, **kwargs):
@@ -121,7 +122,9 @@ def test_reproduced_seeds_prompt_and_investigates(monkeypatch):
     rec = _install(
         monkeypatch,
         repro_outcome=VerifyOutcome(
-            REPRODUCED, tracebacks={"n": "RuntimeError: boom"}, run_url="u"
+            REPRODUCED,
+            tracebacks={"n": "RuntimeError: boom"},
+            run_url="https://github.com/o/r/actions/runs/111-repro",
         ),
         classify_result=ClassifyResult(PRODUCT_ISSUE, reason="hard crash"),
     )
@@ -131,6 +134,8 @@ def test_reproduced_seeds_prompt_and_investigates(monkeypatch):
     assert "REPRODUCED on GPU" in seeded
     assert "RuntimeError: boom" in seeded
     assert "genuine library/model bug" in seeded  # product_issue routing note
+    # the reproduce run is threaded to the request for the PR "failed before" link
+    assert rec["reproduce_run_url"] == "https://github.com/o/r/actions/runs/111-repro"
     assert result.pr_number == 1
     # reproduce dispatched with a distinct correlation id + resolved base sha.
     assert rec["reproduce_kwargs"]["correlation_id"] == "job1234-repro"
@@ -185,3 +190,24 @@ def test_no_nodeids_skips_reproduce(monkeypatch):
     )
     assert rec["reproduce_called"] is False
     assert rec["prepare_contexts"] == ["- no node ids in this context"]
+
+
+def test_verification_footer_links_both_runs():
+    footer = tasks._verification_footer(
+        verify_run_url="https://gh/run/verify",
+        reproduce_run_url="https://gh/run/repro",
+    )
+    assert "Verified on GPU" in footer
+    assert "Passes with this patch:** https://gh/run/verify" in footer
+    assert "Failed before the fix (base commit):** https://gh/run/repro" in footer
+
+
+def test_verification_footer_empty_when_no_runs():
+    assert tasks._verification_footer(None, None) == ""
+
+
+def test_verification_footer_verify_only():
+    # reproduce-first disabled / failed-open: still surface the verify run.
+    footer = tasks._verification_footer("https://gh/run/verify", None)
+    assert "Passes with this patch:** https://gh/run/verify" in footer
+    assert "Failed before" not in footer


### PR DESCRIPTION
## What

Every serge fix PR is opened **only** after the targeted `@slow` tests pass on GPU (red at base → green with the patch), but the PR body didn't say so. This adds a footer that makes each PR self-evidencing:

```
---
### ✅ Verified on GPU
serge ran the targeted `@slow` test(s) on a GPU runner and opened this PR only after they passed with this patch.
- **Passes with this patch:** <verify run URL>
- **Failed before the fix (base commit):** <reproduce run URL>
```

## How

- **Verify run** — from the gate's `VerifyOutcome.run_url` (the run that turned red→green and gated the PR), captured in `_commit_changes`.
- **Reproduce run** — threaded on a new `TaskRequest.reproduce_run_url`, set by `_maybe_reproduce_first` when the group reproduced at base.
- **Graceful degradation:** verify-only link when reproduce-first was disabled or failed open; no footer when neither ran.
- Scope: `new_pr` path (an `existing_pr` appends a follow-up commit, not a fresh body).

## Tests

475 passed, ruff clean — footer rendering (both links / verify-only / empty) + `reproduce_run_url` threading through `_maybe_reproduce_first`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)