### PR TITLE
Support private repositories in the web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Private repositories are supported in the web app. Submitting a review for a
+  private repo, and opening an existing review or task on one, now require the
+  signed-in user to be a collaborator on that repo — checked App-side via
+  `Metadata: read`, cached for five minutes, and fail-closed. Public repos are
+  unchanged.
 - GitHub App mode is documented as the zero-config default: installed repos need
   no workflow file or secret, with instructions for overriding gating via an
   explicit workflow and a note on the forked-PR limitation.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -43,6 +43,9 @@ Use these permissions:
 | Issues | Read |
 | Metadata | Read |
 
+`Metadata: read` also powers the web app's private-repository access check —
+see [Private Repositories](web-app.md#private-repositories).
+
 Subscribe to:
 
 - Issue comment

--- a/docs/security.md
+++ b/docs/security.md
@@ -89,6 +89,25 @@ repo build code (e.g. `make style`). Its egress is therefore locked down:
   secrets present while untrusted code runs), which this design deliberately
   trades away for simplicity and speed.
 
+## Private Repositories
+
+The login allowlist (`WEB_ALLOWED_USERS` / `WEB_ALLOWED_ORG`) governs who may
+use the web app at all. For a private repository that is not enough — an org
+member is not necessarily allowed to read every private repo in the org — so
+serge additionally requires the user to be a collaborator on the target
+repository before it will submit a review for it or serve an existing
+review/task's content. This is the UI counterpart of the webhook's
+`author_association` gate (`MEMBER`, `OWNER`, `COLLABORATOR`).
+
+The collaborator lookup uses the GitHub App installation token
+(`Metadata: read`), not a user token, so it works under SAML SSO and needs no
+extra OAuth scope. It is fail-closed: an unreachable GitHub, a missing
+installation, or an inconclusive answer denies access. Verdicts are cached for
+five minutes per (user, repository).
+
+Public repositories keep the previous posture: any signed-in user may review
+them and follow anyone's review of them.
+
 ## Web App Sessions
 
 Production web app deployments should use OAuth, a strong

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,12 +91,19 @@ repo build code (e.g. `make style`). Its egress is therefore locked down:
 
 ## Private Repositories
 
-The login allowlist (`WEB_ALLOWED_USERS` / `WEB_ALLOWED_ORG`) governs who may
-use the web app at all. For a private repository that is not enough — an org
-member is not necessarily allowed to read every private repo in the org — so
-serge additionally requires the user to be a collaborator on the target
-repository before it will submit a review for it or serve an existing
-review/task's content. This is the UI counterpart of the webhook's
+Neither of the pre-existing web-app gates authorizes access to a *repository*:
+
+- `WEB_ALLOWED_USERS` / `WEB_ALLOWED_ORG` bootstrap the deployment at setup
+  time. They decide who gets an account, not what those accounts may read, and
+  org membership does not imply access to every private repo in the org.
+- Provider configs (in the database, edited from the web UI) decide which LLM
+  key a given repository runs on. Any signed-in user may create one for any
+  repository pattern, so they route keys rather than fence users off from each
+  other.
+
+For a private repository serge therefore requires the user to be a collaborator
+on the target repository before it will submit a review for it or serve an
+existing review/task's content. This is the UI counterpart of the webhook's
 `author_association` gate (`MEMBER`, `OWNER`, `COLLABORATOR`).
 
 The collaborator lookup uses the GitHub App installation token

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -42,6 +42,12 @@ reviewbot-web
 Use `WEB_ALLOWED_ORG=org-a,org-b` instead of, or in addition to,
 `WEB_ALLOWED_USERS`.
 
+These two variables bootstrap the deployment: they decide who may sign in at
+all and are normally set once at initial setup, not edited afterwards. Which
+users or orgs may then run reviews on which repositories — and with which key —
+is configured from the web UI and lives in the database, as
+[provider configs](#provider-configs).
+
 Set `DEV_NO_AUTH=1` only for local development.
 
 ## Private Repositories
@@ -51,8 +57,16 @@ matching [provider config](#provider-configs). serge reads and clones them with
 the App's installation token, so no personal access token is involved and the
 OAuth scope stays `read:org`.
 
+Access to a repository through serge comes in layers:
+
+1. **Sign-in** — the bootstrap allowlist above decides who gets an account.
+2. **Provider config** — decides which key a review runs on. Any signed-in user
+   can create one for any repository pattern, so this routes keys; it is not a
+   boundary between signed-in users.
+3. **GitHub itself** — for private repositories only, and new here.
+
 Because a private repository's diff must not reach someone GitHub would not
-show it to, serge checks repository access on top of the login allowlist:
+show it to, layer 3 asks GitHub directly:
 
 - Submitting a review requires the signed-in user to be a **collaborator** on
   the target repository (org membership alone is not enough).

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -44,6 +44,33 @@ Use `WEB_ALLOWED_ORG=org-a,org-b` instead of, or in addition to,
 
 Set `DEV_NO_AUTH=1` only for local development.
 
+## Private Repositories
+
+Private repositories are supported: install the GitHub App on them and add a
+matching [provider config](#provider-configs). serge reads and clones them with
+the App's installation token, so no personal access token is involved and the
+OAuth scope stays `read:org`.
+
+Because a private repository's diff must not reach someone GitHub would not
+show it to, serge checks repository access on top of the login allowlist:
+
+- Submitting a review requires the signed-in user to be a **collaborator** on
+  the target repository (org membership alone is not enough).
+- Following a review or task — including webhook-triggered ones, which any
+  signed-in user may otherwise open — requires the same.
+
+Public repositories are unaffected: any signed-in user may review and follow
+them, as before.
+
+The check runs against the App's `Metadata: read` permission and is
+**fail-closed** — if GitHub cannot be reached, or the App is not installed on
+the repository, access is denied. Verdicts are cached for five minutes, so
+revoking someone's repository access takes up to that long to take effect in
+serge.
+
+Repository names and PR numbers stay visible to all signed-in users on the
+cross-user `/journal` page; only review and task *content* is gated.
+
 ## Provider Configs
 
 The web app stores per-repository provider configs in SQLite. A provider config

--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -25,6 +25,32 @@ class GitHubClient:
             }
         )
 
+    def get_repo(self, owner: str, repo: str) -> dict:
+        r = self.session.get(
+            f"https://api.github.com/repos/{owner}/{repo}",
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def is_collaborator(self, owner: str, repo: str, username: str) -> Optional[bool]:
+        """True/False when GitHub answers 204/404; None when the answer is
+        inconclusive (App lacks ``Metadata: read`` on the repo, GitHub 5xx,
+        …). Callers gating private-repo content treat None as a denial.
+
+        ``allow_redirects=False`` so GitHub's 302 fallback (permission
+        missing) doesn't get followed into a misleading answer."""
+        r = self.session.get(
+            f"https://api.github.com/repos/{owner}/{repo}/collaborators/{username}",
+            timeout=30,
+            allow_redirects=False,
+        )
+        if r.status_code == 204:
+            return True
+        if r.status_code == 404:
+            return False
+        return None
+
     def get_pr(self, owner: str, repo: str, number: int) -> dict:
         r = self.session.get(
             f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}",

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -286,6 +286,119 @@ def _user_is_allowed(login: str, orgs: list[str]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Private-repo gate.
+#
+# The login allowlist says who may use serge at all; on a public repo that
+# is enough, since the diff serge shows is public anyway. A private repo is
+# different: its diff, draft and task patch must not reach a user GitHub
+# itself wouldn't show them to. So for private repos serge additionally
+# requires the submitter/viewer to be a collaborator — the UI equivalent of
+# the webhook's ``author_association`` check.
+#
+# The check is App-side (installation token + ``Metadata: read``), so it
+# needs no extra OAuth scope from the user and is not defeated by SAML SSO.
+# Verdicts are cached per (user, repo) for a few minutes to keep the extra
+# round-trips off the streaming/publish path; the TTL bounds how long a
+# revoked access stays usable.
+# ---------------------------------------------------------------------------
+_REPO_ACCESS_TTL_SECONDS = 300.0
+_REPO_ACCESS_CACHE_MAX = 512
+_repo_access_lock = threading.Lock()
+_repo_access_cache: dict[tuple[str, str, str], tuple[float, bool]] = {}
+
+
+def _installation_client(owner: str, repo: str) -> GitHubClient:
+    """A GitHubClient carrying the App's installation token for the repo.
+    Raises AppNotInstalledError when the App can't see it at all."""
+    installation_id = installation_id_for_repo(
+        cfg.github_app_id or "", cfg.github_private_key or "", owner, repo
+    )
+    token = installation_token(
+        cfg.github_app_id or "", cfg.github_private_key or "", installation_id
+    )
+    return GitHubClient(token)
+
+
+def _user_may_access_repo(user: str, owner: str, repo: str) -> bool:
+    """True when ``user`` may see ``owner/repo`` through serge: always for a
+    public repo, only for collaborators on a private one.
+
+    Fail-closed — a GitHub error or an inconclusive collaborator answer
+    denies. Raises AppNotInstalledError if the App isn't installed on the
+    repo (the caller decides whether that is a setup hint or a denial)."""
+    if cfg.web_dev_no_auth or not (cfg.github_app_id and cfg.github_private_key):
+        return True
+    key = (user.lower(), owner.lower(), repo.lower())
+    now = time.monotonic()
+    with _repo_access_lock:
+        cached = _repo_access_cache.get(key)
+        if cached and cached[0] > now:
+            return cached[1]
+
+    gh = _installation_client(owner, repo)
+    try:
+        if not bool(gh.get_repo(owner, repo).get("private")):
+            allowed: Optional[bool] = True
+        else:
+            allowed = gh.is_collaborator(owner, repo, user)
+    except requests.RequestException:
+        # Don't cache a transient failure — the next request retries.
+        log.warning(
+            "could not check %s's access to %s/%s", user, owner, repo, exc_info=True
+        )
+        return False
+    if allowed is None:
+        log.warning(
+            "inconclusive collaborator check for %s on private %s/%s; denying. "
+            "The GitHub App needs 'Metadata: read' on the repository.",
+            user,
+            owner,
+            repo,
+        )
+        allowed = False
+
+    with _repo_access_lock:
+        if len(_repo_access_cache) >= _REPO_ACCESS_CACHE_MAX:
+            _repo_access_cache.clear()
+        _repo_access_cache[key] = (now + _REPO_ACCESS_TTL_SECONDS, allowed)
+    return allowed
+
+
+def _require_repo_access(user: str, owner: str, repo: str) -> None:
+    """Submit path. A missing installation is an actionable setup error
+    (400) rather than a permission failure — it is the same condition the
+    review worker would hit seconds later, surfaced up front."""
+    try:
+        allowed = _user_may_access_repo(user, owner, repo)
+    except AppNotInstalledError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not allowed:
+        log.warning("denied %s access to private repo %s/%s", user, owner, repo)
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"no_repo_access: your GitHub account does not have access to "
+                f"the private repository '{owner}/{repo}'."
+            ),
+        )
+
+
+def _require_job_repo_access(user: str, owner: str, repo: str) -> None:
+    """View path. Same gate, but an App that can no longer see the repo is a
+    denial: the job may predate an uninstall, and we can't tell whether its
+    content was private."""
+    try:
+        allowed = _user_may_access_repo(user, owner, repo)
+    except AppNotInstalledError:
+        log.warning(
+            "cannot verify %s's access to %s/%s: App not installed", user, owner, repo
+        )
+        allowed = False
+    if not allowed:
+        raise HTTPException(status_code=403, detail="no_repo_access")
+
+
+# ---------------------------------------------------------------------------
 # In-memory job registry. Each Job owns an asyncio.Queue the SSE endpoint
 # consumes; the worker thread pushes events via call_soon_threadsafe.
 # ---------------------------------------------------------------------------
@@ -3156,6 +3269,9 @@ async def submit_review(request: Request) -> JSONResponse:
     if len(trigger_comment) > _MAX_TRIGGER_COMMENT_CHARS:
         raise HTTPException(status_code=413, detail="comment_too_long")
     owner, repo, number = _parse_pr_ref(pr_ref)
+    # Private repos: the submitter must be able to see the repo on GitHub
+    # before serge streams its diff into the browser.
+    _require_repo_access(user, owner, repo)
     llm_provider = _parse_provider(payload)
     llm_max_input_tokens = _parse_max_input_tokens(payload)
     # Stash any newly-discovered orgs on the eventual response so a
@@ -3330,6 +3446,10 @@ def _get_owned_job(
         or job.target_number != number
     ):
         raise HTTPException(status_code=404, detail="job_target_mismatch")
+    # Webhook jobs (and shared links followed by an admin) skip the owner
+    # check above, so a private repo's review would otherwise be readable by
+    # any signed-in user. Gate every viewer on repo access instead.
+    _require_job_repo_access(user, job.target_owner, job.target_repo)
     return job
 
 
@@ -3671,12 +3791,13 @@ def discard(
 
 
 # ---------------------------------------------------------------------------
-# Tasks views: any authenticated user may follow a task (they are kicked
-# off by a machine via OIDC, not by a UI user, so there is no per-user
-# ownership to enforce — same posture as webhook reviews).
+# Tasks views: any authenticated user with access to the repo may follow a
+# task (they are kicked off by a machine via OIDC, not by a UI user, so
+# there is no per-user ownership to enforce — same posture as webhook
+# reviews).
 # ---------------------------------------------------------------------------
 def _get_task_job(request: Request, owner: str, repo: str, job_id: str) -> Job:
-    _require_user(request)
+    user = _require_user(request)
     with _jobs_lock:
         job = _jobs.get(job_id)
     if job is None:
@@ -3685,6 +3806,9 @@ def _get_task_job(request: Request, owner: str, repo: str, job_id: str) -> Job:
         raise HTTPException(status_code=404, detail="task_not_found")
     if job.target_owner != owner or job.target_repo != repo:
         raise HTTPException(status_code=404, detail="task_target_mismatch")
+    # No per-user ownership on tasks, so repo access is the only thing
+    # standing between a private repo's patch and any signed-in user.
+    _require_job_repo_access(user, job.target_owner, job.target_repo)
     return job
 
 

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -288,12 +288,15 @@ def _user_is_allowed(login: str, orgs: list[str]) -> bool:
 # ---------------------------------------------------------------------------
 # Private-repo gate.
 #
-# The login allowlist says who may use serge at all; on a public repo that
-# is enough, since the diff serge shows is public anyway. A private repo is
-# different: its diff, draft and task patch must not reach a user GitHub
-# itself wouldn't show them to. So for private repos serge additionally
-# requires the submitter/viewer to be a collaborator — the UI equivalent of
-# the webhook's ``author_association`` check.
+# Nothing upstream of this authorizes access to a *repository*: the
+# WEB_ALLOWED_USERS / WEB_ALLOWED_ORG allowlist bootstraps the deployment
+# (who gets an account), and a provider_config picks which LLM key a repo
+# runs on — any signed-in user can create one for any repo pattern. On a
+# public repo that is fine, since the diff serge shows is public anyway. A
+# private repo is different: its diff, draft and task patch must not reach
+# a user GitHub itself wouldn't show them to. So for private repos serge
+# asks GitHub whether the submitter/viewer is a collaborator — the UI
+# equivalent of the webhook's ``author_association`` check.
 #
 # The check is App-side (installation token + ``Metadata: read``), so it
 # needs no extra OAuth scope from the user and is not defeated by SAML SSO.

--- a/tests/test_webapp_private_repos.py
+++ b/tests/test_webapp_private_repos.py
@@ -1,0 +1,240 @@
+"""Tests for the private-repo gate: public repos stay open to every
+signed-in user, while a private repo's review/task is only submittable and
+readable by a collaborator (checked App-side, fail-closed)."""
+
+import importlib
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+
+from reviewbot.github_auth import AppNotInstalledError
+
+try:
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:  # pragma: no cover
+    TestClient = None
+
+
+class _FakeGH:
+    """Stands in for the installation-scoped GitHubClient, recording which
+    endpoints the gate actually touched."""
+
+    def __init__(self, private: bool, collaborator=None, error: bool = False):
+        self.private = private
+        self.collaborator = collaborator
+        self.error = error
+        self.calls: list[str] = []
+
+    def get_repo(self, owner, repo):
+        self.calls.append("get_repo")
+        if self.error:
+            raise requests.ConnectionError("github unreachable")
+        return {"private": self.private, "full_name": f"{owner}/{repo}"}
+
+    def is_collaborator(self, owner, repo, username):
+        self.calls.append("is_collaborator")
+        return self.collaborator
+
+
+class PrivateRepoGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.webapp = self._import_webapp()
+        self._seed_config(self.webapp)
+
+    def _import_webapp(self, dev_no_auth: str = "0"):
+        sys.modules.pop("reviewbot.webapp", None)
+        env = {
+            "DEV_NO_AUTH": dev_no_auth,
+            "GITHUB_APP_ID": "123",
+            "GITHUB_PRIVATE_KEY": "dummy-private-key",
+            "GITHUB_WEBHOOK_SECRET": "webhook-secret",
+            "GITHUB_OAUTH_CLIENT_ID": "oauth-client",
+            "GITHUB_OAUTH_CLIENT_SECRET": "oauth-secret",
+            "LLM_API_KEY": "llm-token",
+            "WEB_SESSION_SECRET": "session-secret",
+            "WEB_ALLOWED_USERS": "dev",
+            "WEB_STORE_PATH": os.path.join(self.tmpdir, "jobs.db"),
+            "WEB_CLONE_CACHE_DIR": os.path.join(self.tmpdir, "clones"),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            return importlib.import_module("reviewbot.webapp")
+
+    def _seed_config(self, webapp) -> None:
+        webapp._store.insert_provider_config(
+            id="c1",
+            provider="hf",
+            api_key="key",
+            api_base=None,
+            default_model="some-model",
+            repo_pattern="acme/widgets",
+            allowed_users=["dev"],
+            allowed_orgs=[],
+            created_by="admin",
+        )
+
+    def _client(self, user: str = "dev"):
+        client = TestClient(self.webapp.app)
+        client.cookies.set(
+            self.webapp._SESSION_COOKIE,
+            self.webapp._serializer.dumps({"user": user, "orgs": []}),
+        )
+        return client
+
+    def _submit(self, client):
+        return client.post(
+            "/reviews",
+            json={"pr": "acme/widgets#7", "llm_provider": "hf"},
+            headers={"Origin": "http://testserver"},
+        )
+
+    def _insert_job(self, *, job_id="job-1", user="someone-else", source, kind):
+        self.webapp._store.insert_job(
+            id=job_id,
+            user=user,
+            target_owner="acme",
+            target_repo="widgets",
+            target_number=7,
+            trigger_comment="x",
+            llm_provider="hf",
+            llm_api_base=None,
+            llm_model="m",
+            created_at=1.0,
+            status="done",
+            source=source,
+            kind=kind,
+            task_spec_json=None,
+        )
+
+    # --- the check itself ---------------------------------------------
+    def test_public_repo_skips_the_collaborator_check(self):
+        gh = _FakeGH(private=False)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            self.assertTrue(self.webapp._user_may_access_repo("dev", "acme", "widgets"))
+        self.assertEqual(gh.calls, ["get_repo"])
+
+    def test_private_repo_allows_a_collaborator(self):
+        gh = _FakeGH(private=True, collaborator=True)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            self.assertTrue(self.webapp._user_may_access_repo("dev", "acme", "widgets"))
+        self.assertEqual(gh.calls, ["get_repo", "is_collaborator"])
+
+    def test_private_repo_denies_a_non_collaborator(self):
+        gh = _FakeGH(private=True, collaborator=False)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            self.assertFalse(
+                self.webapp._user_may_access_repo("dev", "acme", "widgets")
+            )
+
+    def test_inconclusive_collaborator_answer_denies(self):
+        # is_collaborator returns None when the App lacks the permission.
+        gh = _FakeGH(private=True, collaborator=None)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            self.assertFalse(
+                self.webapp._user_may_access_repo("dev", "acme", "widgets")
+            )
+
+    def test_github_error_denies_and_is_not_cached(self):
+        gh = _FakeGH(private=True, error=True)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            self.assertFalse(
+                self.webapp._user_may_access_repo("dev", "acme", "widgets")
+            )
+        ok = _FakeGH(private=True, collaborator=True)
+        with patch.object(self.webapp, "_installation_client", return_value=ok):
+            self.assertTrue(self.webapp._user_may_access_repo("dev", "acme", "widgets"))
+
+    def test_verdict_is_cached_per_user(self):
+        gh = _FakeGH(private=True, collaborator=True)
+        with patch.object(self.webapp, "_installation_client", return_value=gh) as mk:
+            self.webapp._user_may_access_repo("dev", "acme", "widgets")
+            self.webapp._user_may_access_repo("dev", "acme", "widgets")
+            self.assertEqual(mk.call_count, 1)
+            # A different user is a different verdict, so it re-checks.
+            self.webapp._user_may_access_repo("other", "acme", "widgets")
+            self.assertEqual(mk.call_count, 2)
+
+    def test_dev_no_auth_skips_the_gate(self):
+        webapp = self._import_webapp(dev_no_auth="1")
+        with patch.object(webapp, "_installation_client") as mk:
+            self.assertTrue(webapp._user_may_access_repo("dev", "acme", "widgets"))
+        mk.assert_not_called()
+
+    # --- submit path ---------------------------------------------------
+    def test_submit_rejects_private_repo_without_access(self):
+        gh = _FakeGH(private=True, collaborator=False)
+        with (
+            patch.object(self.webapp, "_installation_client", return_value=gh),
+            patch.object(self.webapp, "_run_review_worker") as worker,
+        ):
+            r = self._submit(self._client())
+        self.assertEqual(r.status_code, 403)
+        self.assertIn("no_repo_access", r.json()["detail"])
+        worker.assert_not_called()
+
+    def test_submit_accepts_private_repo_for_a_collaborator(self):
+        gh = _FakeGH(private=True, collaborator=True)
+        with (
+            patch.object(self.webapp, "_installation_client", return_value=gh),
+            patch.object(self.webapp, "_run_review_worker") as worker,
+        ):
+            r = self._submit(self._client())
+        self.assertEqual(r.status_code, 200, r.text)
+        worker.assert_called_once()
+
+    def test_submit_surfaces_missing_installation(self):
+        with (
+            patch.object(
+                self.webapp,
+                "_installation_client",
+                side_effect=AppNotInstalledError("acme", "widgets"),
+            ),
+            patch.object(self.webapp, "_run_review_worker") as worker,
+        ):
+            r = self._submit(self._client())
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("not installed", r.json()["detail"])
+        worker.assert_not_called()
+
+    # --- view path -----------------------------------------------------
+    def test_webhook_review_on_private_repo_is_not_world_readable(self):
+        self._insert_job(job_id="job-hook", source="webhook", kind="review")
+        gh = _FakeGH(private=True, collaborator=False)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            r = self._client().get("/reviews/acme/widgets/7/job-hook/info")
+        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.json()["detail"], "no_repo_access")
+
+    def test_webhook_review_on_public_repo_stays_world_readable(self):
+        self._insert_job(job_id="job-hook", source="webhook", kind="review")
+        gh = _FakeGH(private=False)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            r = self._client().get("/reviews/acme/widgets/7/job-hook/info")
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_task_on_private_repo_is_not_world_readable(self):
+        self._insert_job(job_id="job-task", source="task", kind="task")
+        gh = _FakeGH(private=True, collaborator=False)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            r = self._client().get("/tasks/acme/widgets/job-task/info")
+        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.json()["detail"], "no_repo_access")
+
+    def test_task_on_private_repo_is_readable_by_a_collaborator(self):
+        self._insert_job(job_id="job-task", source="task", kind="task")
+        gh = _FakeGH(private=True, collaborator=True)
+        with patch.object(self.webapp, "_installation_client", return_value=gh):
+            r = self._client().get("/tasks/acme/widgets/job-task/info")
+        self.assertEqual(r.status_code, 200, r.text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## What

Makes private repositories usable in [serge](https://serge.huggingface.tech/).

The plumbing already works: clones and API calls both go through the GitHub App installation token, so a private repo the App is installed on reviews fine. What was missing is **authorization** — the web UI only gated on the login allowlist (`WEB_ALLOWED_USERS` / `WEB_ALLOWED_ORG`) plus a provider config's repo pattern. With an `org/*` config, any signed-in org member could submit a review for any private repo the App can see, and webhook- or task-triggered jobs were readable by *every* signed-in user regardless of target repo. That is fine while everything reviewed is public; it is not fine once private code is in scope.

## Changes

- `GitHubClient.get_repo()` and `GitHubClient.is_collaborator()` — the latter tri-state (`True`/`False`/`None`), where `None` means GitHub gave an inconclusive answer (permission missing, 5xx).
- A private-repo gate in `webapp.py`:
  - **Public repos**: unchanged — any signed-in user may review them and follow anyone's review.
  - **Private repos**: submitting a review (`POST /reviews`), and opening an existing review or task, require the user to be a collaborator on the target repo. This is the UI counterpart of the webhook's existing `author_association` check.
  - The lookup runs against the App installation token (`Metadata: read`), so it needs no extra OAuth scope from the user and isn't defeated by SAML SSO — same reasoning as the existing `user_is_org_member` fallback.
  - **Fail-closed**: an unreachable GitHub, a missing installation, or an inconclusive collaborator answer all deny. Transient failures aren't cached.
  - Verdicts are cached 5 minutes per `(user, owner, repo)` so the check stays off the streaming/publish hot path. That TTL also bounds how long revoked access keeps working.
  - A missing installation on the submit path now surfaces as an actionable 400 up front, instead of the job failing seconds later.

## Notes / limitations

- Repo names and PR numbers of private repos remain visible to all signed-in users on the cross-user `/journal` page; only review and task *content* is gated. Called out in the docs; can be tightened separately if wanted.
- Org membership alone is deliberately not sufficient — being in `huggingface` does not imply access to every private repo in it.

## Docs

`docs/web-app.md` (new "Private Repositories" section), `docs/security.md`, a pointer from `docs/github-app.md`, and a CHANGELOG entry.

## Tests

New `tests/test_webapp_private_repos.py` (14 tests): public repos skip the collaborator call; collaborator allowed / non-collaborator denied / inconclusive denied; GitHub errors deny without poisoning the cache; caching is per user; `DEV_NO_AUTH` bypasses; submit returns 403 / 400 as appropriate and never queues a worker; webhook reviews and tasks on a private repo 403 for non-collaborators while public ones stay readable.

Full suite: 506 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)