### PR TITLE
web: make the per-provider model dropdown visible without a PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The new-review form's per-provider model dropdown is visible again: it now
+  lists a provider's models on page load (via `GET /llm-options/models`) instead
+  of only after a PR reference resolved to a matching config, and Anthropic's
+  `/v1/models` is called with the `anthropic-version` header it requires.
 - The trigger gate now ignores comments authored by a bot, so the App never
   reacts to its own output (no self-trigger loops in App mode).
 

--- a/docs/web-app-tour.md
+++ b/docs/web-app-tour.md
@@ -34,9 +34,12 @@ run it:
 - **Trigger comment** — plays the role of the comment you'd post on GitHub;
   start it with `@askserge` (the trigger must be the first word), plus any extra
   instructions for this run.
-- **Provider / Model** — pick the provider and model. For Hugging Face the model
-  field becomes a dropdown of tool-capable models from the
-  [HF Inference Providers](https://router.huggingface.co) router.
+- **Provider / Model** — pick the provider and model. The model field is a
+  dropdown of that provider's models: for Hugging Face, the tool-capable models
+  from the [HF Inference Providers](https://router.huggingface.co) router; for
+  the keyed providers, the models their `/models` route advertises, listed
+  server-side with a stored key you're authorized to use. Typing a PR re-lists
+  against the config that actually matches that repo.
 - **Max input tokens** — the cumulative input-token budget for the whole review.
   Blank uses the deployment default; presets (First-pass, New model addition, Bug
   fix, Documentation) fill in a sensible starting point.
@@ -45,7 +48,8 @@ run it:
 ![New review page]({{ "/assets/webapp/new-review.png" | relative_url }})
 
 For a Hugging Face provider, the **Model** field is a searchable dropdown of the
-tool-capable models served by the router:
+tool-capable models served by the router (the other providers get the same
+control, populated from their own catalogue):
 
 ![Model dropdown on the new review page]({{ "/assets/webapp/new-review-models.png" | relative_url }})
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -63,10 +63,12 @@ The most-specific matching config wins when a review is submitted.
 1. Open the New Review page.
 2. Enter a PR URL or `owner/repo#123`.
 3. Enter a trigger comment, for example `@askserge please review`.
-4. Pick the provider and model. When the provider is Hugging Face, the model
-   field becomes a dropdown of tool-capable models served by the
-   [HF Inference Providers](https://router.huggingface.co) router; other
-   providers keep a free-text model field.
+4. Pick the provider and model. The model field is a dropdown of the models that
+   provider serves: for Hugging Face, the tool-capable models on the
+   [HF Inference Providers](https://router.huggingface.co) router; for the keyed
+   providers, whatever their `/models` route advertises, listed server-side with
+   a stored key you're authorized to use (the key never reaches the browser). It
+   falls back to a free-text field when no list can be fetched.
 5. Start the review and watch the stream.
 6. Edit the summary and comments.
 7. Publish or discard the draft.

--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -54,6 +54,15 @@ def _is_parameter_rejection(param: str, body_preview: str) -> bool:
     )
 
 
+# Anthropic requires this header on its native routes (notably /v1/models,
+# which backs the model dropdown); the OpenAI-compat chat route ignores it.
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _is_anthropic_base(api_base: str) -> bool:
+    return "api.anthropic.com" in api_base.lower()
+
+
 class LLMResponseError(requests.HTTPError):
     """Non-OK HTTP response from the chat-completions endpoint that
     exhausted retries (or wasn't retryable to begin with). Carries the
@@ -151,6 +160,11 @@ class ChatCompletionClient:
         if self.bill_to:
             # HF Router: route inference billing to an org the token has access to.
             headers["X-HF-Bill-To"] = self.bill_to
+        if _is_anthropic_base(self.api_base):
+            # /v1/chat/completions is Anthropic's OpenAI shim, but /v1/models is
+            # the native route and rejects requests without anthropic-version.
+            # The shim ignores the extra header, so send it unconditionally.
+            headers["anthropic-version"] = _ANTHROPIC_VERSION
         return headers
 
     def _discover_model(self) -> str:

--- a/reviewbot/static/index.js
+++ b/reviewbot/static/index.js
@@ -185,9 +185,33 @@
     modelEl.required = true;
   }
 
+  // Models for the selected provider, listed server-side against any config
+  // the user is authorized to use with it (the key never reaches the browser).
+  // This is what makes the Model field a dropdown before a PR is typed;
+  // cached per provider. [] means "no config, or the listing failed" — the
+  // form then keeps the free-text box.
+  const providerModels = {};
+
+  async function ensureProviderModels(provider) {
+    if (providerModels[provider]) return providerModels[provider];
+    providerModels[provider] = (async () => {
+      try {
+        const qs = new URLSearchParams({ provider });
+        const r = await fetch(`/llm-options/models?${qs}`);
+        const data = r.ok ? await r.json() : {};
+        return Array.isArray(data.models) ? data.models : [];
+      } catch {
+        return [];
+      }
+    })();
+    return providerModels[provider];
+  }
+
   // Models for the provider config that matches the entered repo, fetched
   // server-side (the key never reaches the browser). Keyed by repo+provider so
-  // a stale list is never shown after either changes.
+  // a stale list is never shown after either changes. Takes precedence over
+  // the provider-wide list above: once the repo resolves, its config is the
+  // one that will actually serve the review.
   let repoModels = [];
   let repoModelsSig = "";
 
@@ -212,12 +236,14 @@
     return repoModels;
   }
 
-  // HF has a public, tool-filtered catalogue and needs no repo/key, so it
-  // populates directly. Every other provider lists the matched config's models
-  // (fetched by ensureRepoModels once the repo resolves); until then — or when
-  // nothing matches / the fetch fails — it stays a free-text box.
+  // HF has a public, tool-filtered catalogue and needs no repo/key. Every
+  // other provider lists the matched config's models once the repo resolves,
+  // and otherwise the provider-wide list — so the dropdown is there on page
+  // load, not only after a PR is typed. Falls back to the free-text box when
+  // no list can be had (no config for the provider, or the fetch failed).
   async function updateModelControl() {
-    if (providerEl.value === "hf") {
+    const provider = providerEl.value;
+    if (provider === "hf") {
       const models = await ensureHfModels();
       // Guard against the provider changing while the fetch was in flight.
       if (providerEl.value === "hf" && models.length) {
@@ -230,9 +256,14 @@
     const parsed = parseOwnerRepo(prEl.value);
     if (parsed && repoModelSig(parsed) === repoModelsSig && repoModels.length) {
       showModelDropdown(repoModels);
-    } else {
-      showModelInput();
+      return;
     }
+    const models = await ensureProviderModels(provider);
+    if (providerEl.value === provider && models.length) {
+      showModelDropdown(models);
+      return;
+    }
+    showModelInput();
   }
 
   function ingestProviderDefaults(providers) {

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -611,6 +611,37 @@ class JobStore:
                 return best_exact
         return best_exact or best_wild
 
+    def find_provider_config_for_provider(
+        self,
+        *,
+        user: str,
+        user_orgs: list[str],
+        provider: str,
+    ) -> Optional[dict[str, Any]]:
+        """Pick a config the user is authorized for on ``provider``,
+        ignoring ``repo_pattern`` entirely. Used by the submit form to
+        list a provider's models before a PR has been typed — any key
+        the user may already use with that provider serves the same
+        catalogue. Most-recently-updated wins; None when none match."""
+        user_lc = user.lower()
+        orgs_lc = {o.lower() for o in user_orgs}
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM provider_configs
+                 WHERE provider = ?
+                 ORDER BY updated_at DESC
+                """,
+                (provider,),
+            ).fetchall()
+        for row in rows:
+            cfg = _decode_provider_config(row)
+            allowed_users = {u.lower() for u in cfg["allowed_users"]}
+            allowed_orgs = {o.lower() for o in cfg["allowed_orgs"]}
+            if user_lc in allowed_users or (allowed_orgs & orgs_lc):
+                return cfg
+        return None
+
     def find_provider_config_for_repo(
         self,
         *,

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -2496,6 +2496,49 @@ async def hf_models(request: Request) -> JSONResponse:
     return JSONResponse({"models": await _fetch_hf_router_models()})
 
 
+def _models_for_provider_config(matched: dict[str, Any]) -> dict[str, Any]:
+    """List the models a stored provider config's endpoint advertises,
+    using its key server-side. Never raises: ``{models: [...]}`` on
+    success, ``{models: [], error}`` when the provider's ``/models``
+    route can't be reached — the form then keeps the free-text box."""
+    body: dict[str, Any] = {"models": []}
+    provider = matched["provider"]
+    try:
+        api_base = _api_base_for_provider(provider, custom_base=matched.get("api_base"))
+        bill_to = _llm_bill_to_for_provider(provider)
+        client = ChatCompletionClient(
+            api_base, matched["api_key"], bill_to=bill_to, stream=False
+        )
+        body["models"] = client.list_models()
+    except HTTPException:
+        body["error"] = "provider base URL is not configured"
+    except Exception as exc:  # noqa: BLE001 — a bad token / no-/models route is a hint
+        body["error"] = f"{type(exc).__name__}: {exc}"
+    return body
+
+
+@app.get("/llm-options/models")
+def llm_option_models(request: Request, provider: str) -> JSONResponse:
+    """Model ids for the selected provider, listed with a stored key the
+    user is already authorized to use — no repo required. This is what
+    makes the submit form's Model field a dropdown on page load; once a
+    PR is typed, ``/reviews/models`` re-lists against the config that
+    actually matches that repo. HF keeps its own public catalogue
+    (``/llm-options/hf-models``), which needs no key at all.
+
+    Always HTTP 200: ``{models: [], error?}`` when the user has no config
+    for the provider or its ``/models`` route fails."""
+    user = _require_user(request)
+    if provider not in _VALID_PROVIDERS:
+        raise HTTPException(status_code=400, detail="bad_provider")
+    matched = _store.find_provider_config_for_provider(
+        user=user, user_orgs=_current_user_orgs(request), provider=provider
+    )
+    if matched is None:
+        return JSONResponse({"models": []})
+    return JSONResponse(_models_for_provider_config(matched))
+
+
 @app.get("/reviews/lookup-provider")
 def lookup_provider(request: Request, owner: str, repo: str) -> JSONResponse:
     """Pre-flight match for the submit form: given a (owner, repo)
@@ -2568,20 +2611,7 @@ def review_models(request: Request, owner: str, repo: str) -> JSONResponse:
     )
     if matched is None:
         return placeholder
-    provider = matched["provider"]
-    body: dict[str, Any] = {"models": []}
-    try:
-        api_base = _api_base_for_provider(provider, custom_base=matched.get("api_base"))
-        bill_to = _llm_bill_to_for_provider(provider)
-        client = ChatCompletionClient(
-            api_base, matched["api_key"], bill_to=bill_to, stream=False
-        )
-        body["models"] = client.list_models()
-    except HTTPException:
-        body["error"] = "provider base URL is not configured"
-    except Exception as exc:  # noqa: BLE001 — a bad token / no-/models route is a hint
-        body["error"] = f"{type(exc).__name__}: {exc}"
-    resp = JSONResponse(body)
+    resp = JSONResponse(_models_for_provider_config(matched))
     cookie = placeholder.headers.get("set-cookie")
     if cookie:
         resp.raw_headers.append((b"set-cookie", cookie.encode("latin-1")))

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -2499,8 +2499,10 @@ async def hf_models(request: Request) -> JSONResponse:
 def _models_for_provider_config(matched: dict[str, Any]) -> dict[str, Any]:
     """List the models a stored provider config's endpoint advertises,
     using its key server-side. Never raises: ``{models: [...]}`` on
-    success, ``{models: [], error}`` when the provider's ``/models``
-    route can't be reached — the form then keeps the free-text box."""
+    success, ``{models: [], error, error_code}`` when the provider's
+    ``/models`` route can't be reached — the form then keeps the
+    free-text box. The cause only ever reaches the server log: the
+    endpoint's own error text can carry sensitive detail."""
     body: dict[str, Any] = {"models": []}
     provider = matched["provider"]
     try:
@@ -2510,10 +2512,10 @@ def _models_for_provider_config(matched: dict[str, Any]) -> dict[str, Any]:
             api_base, matched["api_key"], bill_to=bill_to, stream=False
         )
         body["models"] = client.list_models()
-    except HTTPException:
-        body["error"] = "provider base URL is not configured"
-    except Exception as exc:  # noqa: BLE001 — a bad token / no-/models route is a hint
-        body["error"] = f"{type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001 — a failed listing is a hint, not a 500
+        log.error("could not list models for provider %s", provider, exc_info=True)
+        body["error"] = "Could not retrieve list of models"
+        body["error_code"] = exc.status_code if isinstance(exc, HTTPException) else 500
     return body
 
 
@@ -2526,8 +2528,8 @@ def llm_option_models(request: Request, provider: str) -> JSONResponse:
     actually matches that repo. HF keeps its own public catalogue
     (``/llm-options/hf-models``), which needs no key at all.
 
-    Always HTTP 200: ``{models: [], error?}`` when the user has no config
-    for the provider or its ``/models`` route fails."""
+    Always HTTP 200: ``{models: [], error?, error_code?}`` when the user
+    has no config for the provider or its ``/models`` route fails."""
     user = _require_user(request)
     if provider not in _VALID_PROVIDERS:
         raise HTTPException(status_code=400, detail="bad_provider")
@@ -2596,9 +2598,9 @@ def review_models(request: Request, owner: str, repo: str) -> JSONResponse:
     catalogue (``/llm-options/hf-models``); this covers the keyed providers,
     whose key is only knowable once the repo (hence its config) is resolved.
 
-    Always HTTP 200: ``{models: [...]}`` on success, ``{models: [], error?}``
-    when nothing matches or the provider's ``/models`` route fails — the form
-    then keeps the free-text box."""
+    Always HTTP 200: ``{models: [...]}`` on success, ``{models: [], error?,
+    error_code?}`` when nothing matches or the provider's ``/models`` route
+    fails — the form then keeps the free-text box."""
     user = _require_user(request)
     if not _GH_NAME_RE.match(owner) or not _GH_NAME_RE.match(repo):
         raise HTTPException(status_code=400, detail="bad_repo")

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -783,6 +783,29 @@ class ChatCompletionClientTests(unittest.TestCase):
 
         mock_post.assert_not_called()
 
+    def test_list_models_sends_anthropic_version_header(self) -> None:
+        with patch("reviewbot.llm_client.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                ok=True,
+                status_code=200,
+                json=Mock(return_value={"data": [{"id": "claude-opus-5"}]}),
+            )
+            client = ChatCompletionClient("https://api.anthropic.com", "sk-ant")
+            models = client.list_models()
+
+        self.assertEqual(models, ["claude-opus-5"])
+        headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual(headers["anthropic-version"], "2023-06-01")
+
+    def test_list_models_omits_anthropic_version_for_other_bases(self) -> None:
+        with patch("reviewbot.llm_client.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                ok=True, status_code=200, json=Mock(return_value={"data": []})
+            )
+            ChatCompletionClient("https://api.openai.com/v1", "sk").list_models()
+
+        self.assertNotIn("anthropic-version", mock_get.call_args.kwargs["headers"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_provider_configs.py
+++ b/tests/test_provider_configs.py
@@ -288,6 +288,47 @@ class ProviderConfigsTests(unittest.TestCase):
             )
         )
 
+    def test_provider_lookup_ignores_repo_but_not_authorization(self) -> None:
+        store = self._store()
+        self._insert(
+            store,
+            "anthropic-cfg",
+            provider="anthropic",
+            allowed_users=["alice"],
+            repo_pattern="hf/transformers",
+        )
+        self._insert(
+            store,
+            "openai-cfg",
+            provider="openai",
+            allowed_orgs=["hf"],
+            repo_pattern="other/repo",
+        )
+
+        # No repo involved: any authorized config for the provider serves.
+        a = store.find_provider_config_for_provider(
+            user="alice", user_orgs=[], provider="anthropic"
+        )
+        assert a is not None
+        self.assertEqual(a["id"], "anthropic-cfg")
+        o = store.find_provider_config_for_provider(
+            user="bob", user_orgs=["HF"], provider="openai"
+        )
+        assert o is not None
+        self.assertEqual(o["id"], "openai-cfg")
+
+        # Unauthorized users and unconfigured providers get nothing.
+        self.assertIsNone(
+            store.find_provider_config_for_provider(
+                user="mallory", user_orgs=[], provider="anthropic"
+            )
+        )
+        self.assertIsNone(
+            store.find_provider_config_for_provider(
+                user="alice", user_orgs=[], provider="hf"
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webapp_reviews.py
+++ b/tests/test_webapp_reviews.py
@@ -191,7 +191,10 @@ class WebappReviewsTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         data = r.json()
         self.assertEqual(data["models"], [])
-        self.assertIn("401", data["error"])
+        # One generic message, never the upstream text (it can leak).
+        self.assertEqual(data["error"], "Could not retrieve list of models")
+        self.assertEqual(data["error_code"], 500)
+        self.assertNotIn("401", r.text)
 
     def test_provider_models_listed_without_a_repo(self):
         """The dropdown must be populated on page load, before any PR has
@@ -252,7 +255,25 @@ class WebappReviewsTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         data = r.json()
         self.assertEqual(data["models"], [])
-        self.assertIn("401", data["error"])
+        self.assertEqual(data["error"], "Could not retrieve list of models")
+        self.assertEqual(data["error_code"], 500)
+        self.assertNotIn("401", r.text)
+
+    def test_provider_models_error_code_carries_http_status(self):
+        """An unconfigured base URL raises HTTPException — its status is
+        what ``error_code`` is for."""
+        client = TestClient(self.webapp.app)
+        with patch.object(
+            self.webapp,
+            "_api_base_for_provider",
+            side_effect=self.webapp.HTTPException(status_code=400, detail="no_base"),
+        ):
+            r = client.get("/llm-options/models", params={"provider": "hf"})
+        self.assertEqual(r.status_code, 200, r.text)
+        data = r.json()
+        self.assertEqual(data["models"], [])
+        self.assertEqual(data["error"], "Could not retrieve list of models")
+        self.assertEqual(data["error_code"], 400)
 
     # --- effective_draft (single source of truth for what gets posted) ---
     def _sample_draft(self, **overrides):

--- a/tests/test_webapp_reviews.py
+++ b/tests/test_webapp_reviews.py
@@ -193,6 +193,67 @@ class WebappReviewsTests(unittest.TestCase):
         self.assertEqual(data["models"], [])
         self.assertIn("401", data["error"])
 
+    def test_provider_models_listed_without_a_repo(self):
+        """The dropdown must be populated on page load, before any PR has
+        been typed — that's the whole point of the provider-wide list."""
+        client = TestClient(self.webapp.app)
+        self.webapp._store.insert_provider_config(
+            id="c-anthropic",
+            provider="anthropic",
+            api_key="sk-ant-stored",
+            api_base=None,
+            default_model=None,
+            repo_pattern="acme/*",
+            allowed_users=["dev"],
+            allowed_orgs=[],
+            created_by="admin",
+        )
+        seen = {}
+
+        class _FakeClient:
+            def __init__(self, api_base, api_key, *, bill_to=None, **kw):
+                seen["api_base"] = api_base
+                seen["api_key"] = api_key
+
+            def list_models(self):
+                return ["claude-opus-5", "claude-sonnet-5"]
+
+        with patch.object(self.webapp, "ChatCompletionClient", _FakeClient):
+            r = client.get("/llm-options/models", params={"provider": "anthropic"})
+        self.assertEqual(r.status_code, 200, r.text)
+        data = r.json()
+        self.assertEqual(data["models"], ["claude-opus-5", "claude-sonnet-5"])
+        self.assertEqual(seen["api_key"], "sk-ant-stored")
+        self.assertNotIn("api_key", data)
+
+    def test_provider_models_empty_without_an_authorized_config(self):
+        client = TestClient(self.webapp.app)
+        r = client.get("/llm-options/models", params={"provider": "openai"})
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json()["models"], [])
+
+    def test_provider_models_rejects_unknown_provider(self):
+        client = TestClient(self.webapp.app)
+        r = client.get("/llm-options/models", params={"provider": "bogus"})
+        self.assertEqual(r.status_code, 400)
+
+    def test_provider_models_fetch_error_is_a_verdict(self):
+        client = TestClient(self.webapp.app)
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            def list_models(self):
+                raise RuntimeError("Failed to list models (status 401).")
+
+        with patch.object(self.webapp, "ChatCompletionClient", _FakeClient):
+            r = client.get("/llm-options/models", params={"provider": "hf"})
+        self.assertEqual(r.status_code, 200, r.text)
+        data = r.json()
+        self.assertEqual(data["models"], [])
+        self.assertIn("401", data["error"])
+
     # --- effective_draft (single source of truth for what gets posted) ---
     def _sample_draft(self, **overrides):
         kwargs = dict(


### PR DESCRIPTION
#59 shipped a per-provider model dropdown, but it isn't visible in the deployment: the Model field is still a free-text box on a freshly loaded New review page.

## Why

Two independent reasons:

1. **The dropdown was gated on the PR field.** For every provider except HF, `updateModelControl()` only swapped in the dropdown once the PR input parsed into an `owner/repo` *and* `/reviews/models` had returned a non-empty list for the matching config. With an empty PR field — the state in the screenshot — it always fell through to `showModelInput()`.
2. **Anthropic model listing failed anyway.** `ChatCompletionClient.list_models()` hits `{base}/v1/models`. Only `/v1/chat/completions` is Anthropic's OpenAI shim; `/v1/models` is the native route and rejects requests without an `anthropic-version` header. So even after typing a PR, the Anthropic list came back as an error and the form kept the text box.

## What changed

- **New `GET /llm-options/models?provider=X`.** Picks any provider config the caller is authorized for on that provider (`repo_pattern` ignored — the catalogue is the same whichever key lists it) and lists models server-side, so the key still never reaches the browser. Always 200: `{models: [], error?}` when there's no config or the `/models` route fails.
- **`store.find_provider_config_for_provider()`** backs it — same `allowed_users` / `allowed_orgs` authorization as `find_provider_config`, without the repo match.
- **`index.js`** populates the dropdown from that endpoint on load and on provider change, cached per provider. When a PR later resolves, the repo-matched list from `/reviews/models` takes precedence — that config is the one that will actually serve the review. Free-text box remains the fallback whenever no list can be had.
- **`anthropic-version: 2023-06-01`** is sent on requests to `api.anthropic.com`. The shim ignores it, the native route requires it.
- `/reviews/models` and the new endpoint now share one `_models_for_provider_config()` helper instead of duplicating the list-and-swallow-errors block.

## Verification

Ran the app locally against a fake OpenAI-compatible `/models` endpoint and drove `index.html` + `index.js` in jsdom:

```
on load (empty PR):          provider=custom dropdown=true options=[fake-a,fake-b] model=fake-a
after typing a matching PR:  provider=custom dropdown=true options=[fake-a,fake-b] hint="Using custom (via acme/*)."
after switching to a provider with no config: dropdown=false (free-text fallback)
```

New tests cover the endpoint (lists without a repo, empty without an authorized config, 400 on an unknown provider, error surfaced as a verdict), the store lookup's authorization, and the Anthropic header. Full suite passes (`tests/test_app.py` has a pre-existing import failure on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)