### PR TITLE
Task robustness: survive token expiry, stuck tool loops, and stale-base normalizer churn

### DIFF
--- a/reviewbot/commit_scope.py
+++ b/reviewbot/commit_scope.py
@@ -1,0 +1,128 @@
+"""Keep pre-existing repo drift out of serge's commit.
+
+serge applies the model's patch and then runs the repo normalizer with its fixers
+on, so files the patch *requires* to be regenerated ride along in the commit —
+most consequentially transformers' modular coupling, where editing a
+``modular_X.py`` must regenerate ``modeling_X.py``.
+
+The trouble is that the normalizer fixes the whole worktree, not just the patch.
+When ``main`` is not itself normalizer-clean, every unrelated stale file gets
+regenerated too and lands in the PR. Prod task 433e8274 patched exactly one file,
+``tests/models/glm_ocr/test_modeling_glm_ocr.py``, and committed **32**: the other
+31 were regenerated ``modeling_*``/``processing_*`` files for bamba, colpali,
+zamba2, modernbert and 27 more models that the fix never touched. No maintainer
+can review that, and it cost 12 minutes of normalizer time per attempt.
+
+So: validate against the whole tree (unchanged — the normalizer must still pass
+repo-wide), but commit only what the patch is responsible for.
+
+"Responsible for" is deliberately generous, because dropping a genuinely needed
+generated file is the worse failure (serge #58 shipped a PR with a
+``modular_*.py`` and no regenerated ``modeling_*.py``, which is unmergeable). A
+normalizer-changed file is kept when it is
+:func:`related to <_is_related>` a patched path — same directory, or the same
+model-directory name, which is how transformers couples
+``{src/transformers,tests}/models/<model>/``. Anything else is drift and is
+dropped, loudly.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import posixpath
+import re
+
+_GIT_HEADER = re.compile(r"^diff --git a/(?P<a>\S+) b/(?P<b>\S+)", re.MULTILINE)
+_PLUS_HEADER = re.compile(r"^\+\+\+ (?:b/)?(?P<path>\S+)", re.MULTILINE)
+
+
+def patch_paths(patch: str) -> set[str]:
+    """Every path the unified diff ``patch`` claims to touch.
+
+    Reads ``diff --git`` headers, falling back to ``+++`` headers for diffs
+    written without the git prefix. Both sides of a rename are returned — a
+    rename makes the old path the patch's business too."""
+    paths: set[str] = set()
+    for match in _GIT_HEADER.finditer(patch or ""):
+        paths.add(match.group("a"))
+        paths.add(match.group("b"))
+    if not paths:
+        for match in _PLUS_HEADER.finditer(patch or ""):
+            path = match.group("path")
+            if path != "/dev/null":
+                paths.add(path)
+    return {p for p in paths if p and p != "/dev/null"}
+
+
+def _scope_keys(paths: set[str]) -> tuple[set[str], set[str]]:
+    """``(directories, directory names)`` the patch reaches into.
+
+    The directory *name* is what carries the coupling in transformers: a patch to
+    ``tests/models/glm_ocr/`` legitimately regenerates
+    ``src/transformers/models/glm_ocr/`` — a different directory, same leaf.
+
+    A patch to a **root-level** file scopes to the repo root, so root-level
+    normalizer output rides along with it. That is intentional and slightly
+    generous: it is how a generated file next to its source is kept (serge #58),
+    and real generated files in the repos serge targets live in a model
+    directory, never at the root — so it costs nothing against the drift this
+    module exists to drop."""
+    dirs = {posixpath.dirname(p) for p in paths}
+    return dirs, {posixpath.basename(d) for d in dirs if d}
+
+
+def _is_related(path: str, dirs: set[str], dir_names: set[str]) -> bool:
+    directory = posixpath.dirname(path)
+    if directory in dirs:
+        return True
+    if posixpath.basename(directory) in dir_names:
+        return True
+    # A patched file's subtree (e.g. a patch to a package's __init__ that makes
+    # the normalizer rewrite files beneath it).
+    return any(d and directory.startswith(f"{d}/") for d in dirs)
+
+
+def scope_paths(
+    changed: list[str],
+    patch: str,
+    *,
+    always_include: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Split ``changed`` into ``(keep, dropped)`` relative to ``patch``.
+
+    Paths the patch names itself are always kept, as is anything matching an
+    ``always_include`` glob (the operator's escape hatch for a normalizer that
+    legitimately rewrites cross-cutting generated files, e.g.
+    ``src/transformers/utils/dummy_*.py``).
+
+    An empty or unparseable patch scopes to nothing, so everything is kept —
+    with no patch we cannot tell drift from the change, and committing too much
+    beats committing nothing."""
+    touched = patch_paths(patch)
+    if not touched:
+        return list(changed), []
+    dirs, dir_names = _scope_keys(touched)
+    globs = always_include or []
+    keep: list[str] = []
+    dropped: list[str] = []
+    for path in changed:
+        if (
+            path in touched
+            or _is_related(path, dirs, dir_names)
+            or any(fnmatch.fnmatch(path, pattern) for pattern in globs)
+        ):
+            keep.append(path)
+        else:
+            dropped.append(path)
+    # Never scope the commit down to nothing: if the rule somehow rejected every
+    # change, the rule is wrong about this repo and dropping the fix is worse.
+    if not keep:
+        return list(changed), []
+    return keep, dropped
+
+
+def describe_dropped(dropped: list[str], *, limit: int = 8) -> str:
+    """Operator-facing one-liner naming what was left out, and how much."""
+    shown = ", ".join(sorted(dropped)[:limit])
+    more = len(dropped) - limit
+    return shown + (f", +{more} more" if more > 0 else "")

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import stat
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from . import sandbox
@@ -94,6 +94,14 @@ class Config:
     # it is repeating; past this many the loop stops rather than spending the
     # rest of the input-token budget re-running the same search. 0 disables.
     tool_repeat_limit: int = 6
+    # Commit only the files the patch is responsible for, dropping files the
+    # normalizer regenerated because the *base* was stale (see commit_scope).
+    # Validation still runs repo-wide; this only bounds the commit.
+    task_scope_commit_to_patch: bool = True
+    # Globs always committed even when unrelated to the patch — the escape hatch
+    # for a normalizer that rewrites cross-cutting generated files (e.g.
+    # "src/transformers/utils/dummy_*.py").
+    task_commit_always_include: list[str] = field(default_factory=list)
 
     # When true, published reviews carry a note that they came from a
     # non-production (staging) deployment. Set via the STAGING env var.
@@ -485,6 +493,12 @@ class Config:
             tool_max_iterations=_int_env("TOOL_MAX_ITERATIONS", 30),
             llm_max_input_tokens=_int_env("LLM_MAX_INPUT_TOKENS", 2_000_000),
             tool_repeat_limit=_int_env("TOOL_REPEAT_LIMIT", 6),
+            task_scope_commit_to_patch=_bool_env("TASK_SCOPE_COMMIT_TO_PATCH", True),
+            task_commit_always_include=[
+                p.strip()
+                for p in (os.environ.get("TASK_COMMIT_ALWAYS_INCLUDE") or "").split(",")
+                if p.strip()
+            ],
             is_staging=_bool_env("STAGING", False),
             github_oauth_client_id=oauth_client_id,
             github_oauth_client_secret=oauth_client_secret,

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -89,6 +89,11 @@ class Config:
     # stop the agentic loop, ask the model for a final review with tools
     # off, and skip any remaining diff chunks. Set to 0 to disable.
     llm_max_input_tokens: int = 2_000_000
+    # How many *repeated* (byte-identical) tool calls to tolerate before
+    # declaring the agent stuck and forcing a final answer. Each repeat is told
+    # it is repeating; past this many the loop stops rather than spending the
+    # rest of the input-token budget re-running the same search. 0 disables.
+    tool_repeat_limit: int = 6
 
     # When true, published reviews carry a note that they came from a
     # non-production (staging) deployment. Set via the STAGING env var.
@@ -479,6 +484,7 @@ class Config:
             # PRs complete without being forced to truncate.
             tool_max_iterations=_int_env("TOOL_MAX_ITERATIONS", 30),
             llm_max_input_tokens=_int_env("LLM_MAX_INPUT_TOKENS", 2_000_000),
+            tool_repeat_limit=_int_env("TOOL_REPEAT_LIMIT", 6),
             is_staging=_bool_env("STAGING", False),
             github_oauth_client_id=oauth_client_id,
             github_oauth_client_secret=oauth_client_secret,

--- a/reviewbot/github_auth.py
+++ b/reviewbot/github_auth.py
@@ -71,6 +71,18 @@ def installation_id_for_repo(
     return iid
 
 
+def installation_token_for_repo(
+    app_id: str, private_key: str, owner: str, repo: str
+) -> str:
+    """Mint a fresh installation token for ``owner/repo``.
+
+    The two-step (look up the installation, then mint) that every caller wanting
+    "a token for this repo" needs. Used by the token-refresh endpoint when a long
+    task's one-hour token expires mid-flight."""
+    iid = installation_id_for_repo(app_id, private_key, owner, repo)
+    return installation_token(app_id, private_key, iid)
+
+
 def user_is_org_member(app_id: str, private_key: str, org: str, username: str) -> bool:
     """Return True if ``username`` belongs to ``org``.
 

--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -1,7 +1,11 @@
 import base64
-from typing import Any, Optional
+import logging
+from typing import Any, Callable, Optional
 
 import requests
+
+
+log = logging.getLogger(__name__)
 
 
 # Identity stamped on serge-authored commits created through the Git Data
@@ -11,11 +15,59 @@ SERGE_GIT_NAME = "serge[bot]"
 SERGE_GIT_EMAIL = "serge[bot]@users.noreply.github.com"
 
 
-class GitHubClient:
-    """Thin REST wrapper scoped to a single installation token."""
+class _AuthRetrySession(requests.Session):
+    """A session that re-mints its token on a ``401`` and replays the request.
 
-    def __init__(self, token: str):
-        self.session = requests.Session()
+    GitHub App installation tokens are valid for **one hour**. A ``/tasks`` run
+    that spends longer than that in the agentic loop plus the repo normalizer
+    reaches the publish step holding a dead token, and every write fails with
+    ``401 Bad credentials`` — the fix is finished but unpublishable, and the
+    whole run is wasted. Observed repeatedly in prod on runs of 65-67 minutes.
+
+    Rather than refresh on a timer (which needs a clock nobody owns and still
+    races a request in flight), let the request that *discovers* the expiry fix
+    it: ask ``token_provider`` for a fresh token, restamp the header, replay
+    once. Overriding :meth:`requests.Session.request` — the single funnel every
+    ``get``/``post``/``patch`` helper goes through — covers every call site in
+    :class:`GitHubClient`, present and future, with no per-method plumbing.
+
+    Only ever replays once, and only when the fresh token actually differs: a
+    401 from a genuinely bad token (wrong App, revoked install) must surface as
+    a 401 rather than double every request."""
+
+    def __init__(self, token_provider: Optional[Callable[[], str]] = None):
+        super().__init__()
+        self._token_provider = token_provider
+
+    def request(  # type: ignore[override]
+        self, method: str, url: str, **kwargs: Any
+    ) -> requests.Response:
+        response = super().request(method, url, **kwargs)
+        if response.status_code != 401 or self._token_provider is None:
+            return response
+        try:
+            token = self._token_provider()
+        except Exception:  # noqa: BLE001
+            # Refresh is best-effort: on failure return the original 401 so the
+            # caller reports the real GitHub error, not a refresh stacktrace.
+            log.warning("token refresh after 401 failed", exc_info=True)
+            return response
+        if not token or self.headers.get("Authorization") == f"Bearer {token}":
+            return response
+        log.info("got 401 from %s; re-minted the token and retrying once", url)
+        self.headers["Authorization"] = f"Bearer {token}"
+        return super().request(method, url, **kwargs)
+
+
+class GitHubClient:
+    """Thin REST wrapper scoped to a single installation token.
+
+    ``token_provider``, when given, is called to mint a replacement token after
+    a ``401`` so long-running tasks survive the one-hour installation-token
+    lifetime (see :class:`_AuthRetrySession`)."""
+
+    def __init__(self, token: str, token_provider: Optional[Callable[[], str]] = None):
+        self.session = _AuthRetrySession(token_provider)
         self.session.headers.update(
             {
                 "Authorization": f"Bearer {token}",

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -66,6 +66,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "llm_max_input_tokens",
     "tool_max_iterations",
     "tool_max_iterations_strict",
+    "tool_repeat_limit",
     "verify_on_gpu",
     "verify_reproduce_first",
     "verify_workflow_file",

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -97,6 +97,7 @@ def build_spec(
     llm: dict[str, Any],
     callback_url: str,
     callback_token: str,
+    token_url: Optional[str] = None,
     config: Optional[dict[str, Any]] = None,
     repo_remote_url: Optional[str] = None,
     request_type: str = "task",
@@ -107,7 +108,11 @@ def build_spec(
     ``stream``); ``config`` is the resolved-worker-Config subset (see
     :func:`runner_config`) the runner applies over its env-built base;
     ``github_token`` is the short-lived installation token serge minted for this
-    task."""
+    task, and ``token_url`` is where the runner asks for a replacement once that
+    token expires (installation tokens last an hour; long tasks outlive them)."""
+    callback: dict[str, Any] = {"url": callback_url, "token": callback_token}
+    if token_url:
+        callback["token_url"] = token_url
     spec: dict[str, Any] = {
         "job_id": job_id,
         "request": request,
@@ -115,7 +120,7 @@ def build_spec(
         "request_type": request_type,
         "llm": llm,
         "config": config or {},
-        "callback": {"url": callback_url, "token": callback_token},
+        "callback": callback,
     }
     if repo_remote_url:
         spec["repo_remote_url"] = repo_remote_url

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -67,6 +67,8 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "tool_max_iterations",
     "tool_max_iterations_strict",
     "tool_repeat_limit",
+    "task_scope_commit_to_patch",
+    "task_commit_always_include",
     "verify_on_gpu",
     "verify_reproduce_first",
     "verify_workflow_file",

--- a/reviewbot/review_runner.py
+++ b/reviewbot/review_runner.py
@@ -29,7 +29,12 @@ from .github_client import GitHubClient
 from .llm_client import LLMResponseError
 from .reviewer import ReviewRequest, _UnparseableLLMOutput, prepare_review
 from .store import encode_draft
-from .task_runner import CallbackEmitter, RunnerSpec, build_runner_config
+from .task_runner import (
+    CallbackEmitter,
+    RunnerSpec,
+    TokenRefresher,
+    build_runner_config,
+)
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +59,14 @@ def run(spec: RunnerSpec) -> int:
         spec.callback.get("url"), spec.callback.get("token"), spec.job_id
     )
     clone_cache = CloneCache(cfg.web_clone_cache_dir)
-    gh = GitHubClient(spec.github_token)
+    gh = GitHubClient(
+        spec.github_token,
+        token_provider=TokenRefresher(
+            spec.callback.get("token_url"),
+            spec.callback.get("token"),
+            spec.github_token,
+        ),
+    )
     checkout: Optional[Checkout] = None
 
     def emit(kind: str, text: str) -> None:

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -17,6 +17,7 @@ from .prompts import (
     build_system_prompt,
     build_user_prompt,
 )
+from .tool_repeat import ToolRepeatGuard
 from .tools import (
     RepoHelperTool,
     ToolEnv,
@@ -800,6 +801,10 @@ def _run_agentic_loop(
     # calls indefinitely while still leaving real investigations room
     # to grow when the operator raises tool_max_iterations.
     ABSOLUTE_ITER_CEILING = max(60, (iter_cap or 0) * 2)
+    # Stops a model that has started re-issuing the *same* tool call from eating
+    # the whole input-token budget on it. Each repeat is told it is repeating;
+    # past the limit we break out and spend what's left on an answer.
+    repeat_guard = ToolRepeatGuard(getattr(cfg, "tool_repeat_limit", 0) or 0)
     iteration = 0
     blind_tool_turns = 0
     validation_retries = 0
@@ -970,6 +975,18 @@ def _run_agentic_loop(
                 emit("tool", f"{tc.name}({_summarize_args_str(tc.arguments)})")
                 _emit_metrics(emit, metrics)
             result = _execute_tool_call(tool_env, tc)
+            # An identical re-run still executes (a re-read after an edit must
+            # see the new content) — but the model is told it is repeating, so
+            # it can break out before the repeat budget runs down.
+            repeat_note = repeat_guard.observe(tc.name, tc.arguments)
+            if repeat_note is not None:
+                result = f"{result}{repeat_note}"
+                log.info(
+                    "Repeated tool call %s (%s); %s",
+                    tc.name,
+                    _summarize_args_str(tc.arguments),
+                    repeat_guard.summary(),
+                )
             # Kimi-K2 (and some other engines) require ``name`` on tool
             # replies; OpenAI's spec ignores it. Always sending it is
             # the safer cross-provider choice.
@@ -983,6 +1000,21 @@ def _run_agentic_loop(
             )
             _emit_chat_message(emit, "tool", content=result, tool_name=tc.name)
 
+        if repeat_guard.tripped:
+            log.warning(
+                "Tool-repeat guard tripped (%s, limit=%d); asking for a final "
+                "answer instead of spending the rest of the budget looping",
+                repeat_guard.summary(),
+                repeat_guard.trip_after,
+            )
+            if emit is not None:
+                emit(
+                    "log",
+                    f"Stuck in a tool-call loop ({repeat_guard.summary()}); "
+                    "asking for a final answer without tools",
+                )
+            break
+
     # Iteration budget hit — force a final answer with tools disabled.
     # Only reachable when ``tool_max_iterations > 0`` and the model
     # used up its content-turn allowance, or when the absolute ceiling
@@ -995,7 +1027,8 @@ def _run_agentic_loop(
         iteration,
         cfg.tool_max_iterations,
     )
-    if emit is not None:
+    if emit is not None and not repeat_guard.tripped:
+        # The repeat guard already emitted its own, more specific reason.
         emit("log", "Agent budget exhausted; asking for a final review without tools")
     messages.append(
         {

--- a/reviewbot/task_runner.py
+++ b/reviewbot/task_runner.py
@@ -71,7 +71,8 @@ class RunnerSpec:
     ``request`` is the serialized :class:`TaskRequest`; ``github_token`` is a
     short-lived installation token minted by serge; ``llm`` carries the
     per-repo-resolved provider settings; ``callback`` is where to stream events
-    and the terminal result."""
+    and the terminal result, and optionally (``token_url``) where to ask for a
+    replacement GitHub token once the minted one expires."""
 
     job_id: str
     request: dict[str, Any]
@@ -179,6 +180,57 @@ class CallbackEmitter:
         )
 
 
+class TokenRefresher:
+    """Fetches a replacement GitHub installation token from serge.
+
+    Installation tokens expire after an hour, and the runner pod deliberately
+    holds no App private key (see the module docstring) — so it cannot mint one
+    itself. serge exposes ``POST /internal/tasks/{id}/github-token``, guarded by
+    the same per-job bearer token as the event callback; this asks for a fresh
+    token there.
+
+    Wired into :class:`GitHubClient` as its ``token_provider``, so any 401 from
+    an expired token is repaired and the request replayed. Without it a task that
+    outlives its token loses all of its work at the publish step: the patch is
+    written, validated and GPU-verified, and then every Git Data API write fails
+    ``401 Bad credentials``.
+
+    ``current`` keeps the freshest token so callers that need the raw credential
+    (a re-clone, say) don't have to re-request it."""
+
+    def __init__(self, url: Optional[str], callback_token: Optional[str], initial: str):
+        self._url = (url or "").strip() or None
+        self._callback_token = callback_token
+        self.current = initial
+        self._session = requests.Session()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._url)
+
+    def __call__(self) -> str:
+        """Return a freshly minted token, or the current one if serge can't be
+        reached / isn't configured for refresh. Raises nothing: the caller
+        (``_AuthRetrySession``) treats an unchanged token as "no refresh
+        available" and surfaces the original 401."""
+        if not self._url:
+            return self.current
+        headers = {"Content-Type": "application/json"}
+        if self._callback_token:
+            headers["Authorization"] = f"Bearer {self._callback_token}"
+        try:
+            r = self._session.post(self._url, headers=headers, timeout=30)
+            r.raise_for_status()
+            token = str((r.json() or {}).get("token") or "")
+        except (requests.RequestException, ValueError):
+            log.warning("could not refresh the GitHub token", exc_info=True)
+            return self.current
+        if token:
+            log.info("refreshed the GitHub installation token")
+            self.current = token
+        return self.current
+
+
 # ---------------------------------------------------------------------------
 # Config / request assembly
 # ---------------------------------------------------------------------------
@@ -254,7 +306,18 @@ def run(spec: RunnerSpec) -> int:
         cfg = build_runner_config(spec)
         req = build_task_request(spec)
         clone_cache = CloneCache(cfg.web_clone_cache_dir)
-        gh = GitHubClient(spec.github_token)
+        refresher = TokenRefresher(
+            spec.callback.get("token_url"),
+            spec.callback.get("token"),
+            spec.github_token,
+        )
+        if not refresher.enabled:
+            log.warning(
+                "the spec carries no callback token_url; this task cannot refresh "
+                "its GitHub token, so a run past the one-hour token lifetime will "
+                "fail to publish"
+            )
+        gh = GitHubClient(spec.github_token, token_provider=refresher)
 
         existing_diff: Optional[str] = None
         if req.mode == "existing_pr":

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Optional
 
 from . import __version__
 from .clone_cache import Checkout, CloneCache, FileChange
+from .commit_scope import describe_dropped, scope_paths
 from .compression import MessageCompressor
 from .config import Config
 from .github_client import SERGE_GIT_EMAIL, GitHubClient
@@ -1072,6 +1073,26 @@ def publish_task(
             no_change=True,
             message="Patch applied but produced no file changes.",
         )
+
+    # The normalizer fixes the whole worktree, so a base that is not itself
+    # normalizer-clean contributes regenerated files the fix never touched (one
+    # prod task patched 1 file and committed 32). Drop those — validation above
+    # still ran repo-wide; only the commit is scoped.
+    if getattr(cfg, "task_scope_commit_to_patch", False):
+        keep, dropped = scope_paths(
+            [c.path for c in changes],
+            plan.patch,
+            always_include=getattr(cfg, "task_commit_always_include", None),
+        )
+        if dropped:
+            kept = set(keep)
+            changes = [c for c in changes if c.path in kept]
+            _emit(
+                "log",
+                f"Left {len(dropped)} unrelated file(s) out of the commit — "
+                f"regenerated from a stale base, not by this fix: "
+                f"{describe_dropped(dropped)}",
+            )
 
     return _commit_changes(
         cfg,

--- a/reviewbot/tool_repeat.py
+++ b/reviewbot/tool_repeat.py
@@ -1,0 +1,120 @@
+"""Guard against an agent re-issuing the same tool call forever.
+
+The failure mode this exists for, measured on prod task 433e8274 (glm_ocr
+integration-failure triage): the model asked for
+
+    grep(pattern="GlmOcrProcessor|Glm46VProcessor", path="src/transformers/models/glm_ocr")
+
+**21 times**, and another grep **44 times**, each returning the identical "no
+matches" — and hit the 2M cumulative-input-token cap after ~55 turns and only
+60s of LLM wall time. It never reasoned about the fix at all: the budget was
+gone, so the loop forced a tool-less final answer and the patch that came out
+failed GPU verification. All three verify rounds died the same way.
+
+The tool calls themselves are cheap. What is expensive is the *turn* around each
+one: every repeat resends the whole conversation, ~40k input tokens a time. So
+the cure is not to memoize the tool — it is to tell the model it is looping and,
+if it keeps going, to stop the loop early and spend the remaining budget on an
+answer instead of on the 50th identical grep.
+
+Deliberately **not** a cache. A repeated ``read_file`` after an ``apply_patch``
+must return the *new* content, so every call still executes for real; the guard
+only appends a correction to the result and counts how often it has had to.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+# Appended to a repeated call's result. Addressed at the model: it names what
+# happened, why continuing is pointless, and the two ways out (change the
+# arguments, or answer). Kept short — it rides along on every repeat.
+_NUDGE = (
+    "\n\n[serge] You have already made this exact {name} call {count} times in "
+    "this session and it returned the same thing every time. Repeating it cannot "
+    "tell you anything new, and each attempt consumes a large share of your "
+    "remaining token budget. Either search for something different (a different "
+    "pattern, a different path) or stop searching and give your final answer now."
+)
+
+_TRIPPED_NOTE = (
+    "\n\n[serge] This is repeat #{repeats}. You are in a loop. Give your final "
+    "answer from what you already know — no further tool calls will be answered."
+)
+
+
+def normalize_arguments(arguments: str) -> str:
+    """Canonical form of a tool call's arguments, for identity comparison.
+
+    Parsed and re-dumped with sorted keys so that key order and whitespace don't
+    disguise the same call as a new one; falls back to the stripped raw string
+    when the arguments aren't JSON (some providers emit partial or non-JSON
+    arguments, and two identical malformed strings are still a repeat)."""
+    try:
+        parsed = json.loads(arguments or "{}")
+    except (TypeError, ValueError):
+        return (arguments or "").strip()
+    try:
+        return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return (arguments or "").strip()
+
+
+class ToolRepeatGuard:
+    """Count identical tool calls and produce a correction for the repeats.
+
+    ``trip_after`` is the total number of *repeat* calls (across all signatures)
+    tolerated before :attr:`tripped` goes true and the caller should break out of
+    the agent loop and force a final answer. ``0`` disables the guard entirely.
+
+    Counting repeats globally rather than per-signature is what catches the real
+    prod shape: the stuck model alternated between two identical greps, so a
+    per-signature limit of 6 would have allowed 12 wasted turns and a limit low
+    enough to stop that would misfire on legitimate re-reads.
+    """
+
+    def __init__(self, trip_after: int = 6):
+        self.trip_after = trip_after
+        self.counts: dict[str, int] = {}
+        self.repeats = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.trip_after > 0
+
+    @property
+    def tripped(self) -> bool:
+        return self.enabled and self.repeats >= self.trip_after
+
+    def observe(self, name: str, arguments: str) -> str | None:
+        """Record one tool call. Returns text to append to its result when the
+        call is a repeat, else ``None``.
+
+        The first occurrence of a call is always free — legitimate investigation
+        re-lists directories and re-reads files. Only an *exact* re-run of a call
+        already made in this session is treated as a repeat."""
+        if not self.enabled:
+            return None
+        signature = f"{name}\x00{normalize_arguments(arguments)}"
+        count = self.counts.get(signature, 0) + 1
+        self.counts[signature] = count
+        if count == 1:
+            return None
+        self.repeats += 1
+        note = _NUDGE.format(name=name, count=count)
+        if self.tripped:
+            note += _TRIPPED_NOTE.format(repeats=self.repeats)
+        return note
+
+    def summary(self) -> str:
+        """One-line description of the worst offenders, for the run log."""
+        worst = sorted(self.counts.items(), key=lambda kv: kv[1], reverse=True)
+        parts = [
+            f"{sig.split(chr(0), 1)[0]}×{count}"
+            for sig, count in worst[:3]
+            if count > 1
+        ]
+        return f"{self.repeats} repeated tool call(s)" + (
+            f" (most repeated: {', '.join(parts)})" if parts else ""
+        )

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -44,6 +44,7 @@ from .github_auth import (
     AppNotInstalledError,
     installation_id_for_repo,
     installation_token,
+    installation_token_for_repo,
     user_is_org_member,
 )
 from .github_client import GitHubClient
@@ -1496,6 +1497,9 @@ def _launch_task_pod(job: Job, worker_cfg: Config, req: TaskRequest) -> None:
                 f"{cfg.task_callback_base_url}/internal/tasks/{job.id}/events"
             ),
             callback_token=callback_token,
+            token_url=(
+                f"{cfg.task_callback_base_url}/internal/tasks/{job.id}/github-token"
+            ),
         )
         emit("step", "launch")
         emit(
@@ -1633,6 +1637,9 @@ def _launch_review_pod(
                 f"{cfg.task_callback_base_url}/internal/tasks/{job.id}/events"
             ),
             callback_token=callback_token,
+            token_url=(
+                f"{cfg.task_callback_base_url}/internal/tasks/{job.id}/github-token"
+            ),
         )
         emit("step", "launch")
         emit("log", f"Launching review runner ({cfg.review_execution}: {image})…")
@@ -3095,6 +3102,62 @@ async def submit_task(request: Request) -> JSONResponse:
     )
 
 
+def _authorize_runner_callback(job_id: str, request: Request) -> Job:
+    """Shared auth for the runner's internal endpoints.
+
+    The sole authorization is the unguessable per-job bearer token serge minted
+    at launch plus a live task/review job — a finished job (token cleared) or a
+    wrong token is rejected."""
+    token = _bearer_token(request)
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if (
+        job is None
+        or job.kind not in ("task", "review")
+        or not job.callback_token
+        or not hmac.compare_digest(token, job.callback_token)
+    ):
+        raise HTTPException(status_code=401, detail="invalid_callback_token")
+    return job
+
+
+@app.post("/internal/tasks/{job_id}/github-token")
+async def refresh_task_github_token(job_id: str, request: Request) -> JSONResponse:
+    """Mint a replacement GitHub installation token for a running runner.
+
+    Installation tokens expire after an hour. The runner pod deliberately holds
+    no App private key (serge mints the token and hands it over in the spec), so
+    when a long run's token dies mid-flight the pod cannot re-mint on its own —
+    it asks here, over the same authenticated channel it already streams events
+    on. Scoped to the job's own target repo, so the token this returns is never
+    broader than the one the pod started with.
+
+    Internal only — same authorization as the events callback."""
+    job = _authorize_runner_callback(job_id, request)
+    if not (cfg.github_app_id and cfg.github_private_key):
+        raise HTTPException(status_code=500, detail="github_app_not_configured")
+    try:
+        token = await asyncio.to_thread(
+            installation_token_for_repo,
+            cfg.github_app_id,
+            cfg.github_private_key,
+            job.target_owner,
+            job.target_repo,
+        )
+    except AppNotInstalledError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except Exception:  # noqa: BLE001
+        log.exception("could not re-mint an installation token for job %s", job_id)
+        raise HTTPException(status_code=502, detail="token_mint_failed")
+    log.info(
+        "re-minted the installation token for job %s (%s/%s)",
+        job_id,
+        job.target_owner,
+        job.target_repo,
+    )
+    return JSONResponse({"token": token})
+
+
 @app.post("/internal/tasks/{job_id}/events")
 async def ingest_task_event(job_id: str, request: Request) -> JSONResponse:
     """Callback sink for the per-task runner (docker/kubernetes backends).
@@ -3107,16 +3170,7 @@ async def ingest_task_event(job_id: str, request: Request) -> JSONResponse:
     pushed onto the job's SSE stream; a *terminal* payload records the final
     ``status``/``result``/``error`` (the launcher thread then persists +
     notifies, exactly as for the in-process worker)."""
-    token = _bearer_token(request)
-    with _jobs_lock:
-        job = _jobs.get(job_id)
-    if (
-        job is None
-        or job.kind not in ("task", "review")
-        or not job.callback_token
-        or not hmac.compare_digest(token, job.callback_token)
-    ):
-        raise HTTPException(status_code=401, detail="invalid_callback_token")
+    job = _authorize_runner_callback(job_id, request)
 
     try:
         payload = await request.json()

--- a/tests/test_commit_scope.py
+++ b/tests/test_commit_scope.py
@@ -1,0 +1,180 @@
+"""Tests for scoping the commit to the files the patch is responsible for.
+
+Reference failure: prod task 433e8274 patched one file,
+``tests/models/glm_ocr/test_modeling_glm_ocr.py``, and committed 32 — the other
+31 were ``modeling_*``/``processing_*`` files the normalizer regenerated across
+30 unrelated models because ``main`` was already stale.
+"""
+
+import unittest
+
+from reviewbot.commit_scope import describe_dropped, patch_paths, scope_paths
+
+PATCH = """diff --git a/tests/models/glm_ocr/test_modeling_glm_ocr.py b/tests/models/glm_ocr/test_modeling_glm_ocr.py
+index 1111111..2222222 100644
+--- a/tests/models/glm_ocr/test_modeling_glm_ocr.py
++++ b/tests/models/glm_ocr/test_modeling_glm_ocr.py
+@@ -400,7 +400,7 @@ class GlmOcrIntegrationTest(unittest.TestCase):
+-        expected = [1, 2, 3]
++        expected = [4, 5, 6]
+"""
+
+# The real 32, in the order serge logged them.
+PROD_CHANGED = [
+    "src/transformers/models/bamba/modeling_bamba.py",
+    "src/transformers/models/colmodernvbert/processing_colmodernvbert.py",
+    "src/transformers/models/colpali/processing_colpali.py",
+    "src/transformers/models/colqwen2/processing_colqwen2.py",
+    "src/transformers/models/deepseek_vl_hybrid/processing_deepseek_vl_hybrid.py",
+    "src/transformers/models/exaone4_5/processing_exaone4_5.py",
+    "src/transformers/models/gemma3n/modeling_gemma3n.py",
+    "src/transformers/models/gemma4_unified/processing_gemma4_unified.py",
+    "src/transformers/models/glm46v/image_processing_glm46v.py",
+    "src/transformers/models/glm46v/processing_glm46v.py",
+    "src/transformers/models/glm4v/processing_glm4v.py",
+    "src/transformers/models/glm_image/image_processing_glm_image.py",
+    "src/transformers/models/glmasr/processing_glmasr.py",
+    "src/transformers/models/granite4_vision/processing_granite4_vision.py",
+    "src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py",
+    "src/transformers/models/kimi_k25/processing_kimi_k25.py",
+    "src/transformers/models/laguna/modeling_laguna.py",
+    "src/transformers/models/mellum/modeling_mellum.py",
+    "src/transformers/models/mimo_v2_flash/modeling_mimo_v2_flash.py",
+    "src/transformers/models/modernbert/modeling_modernbert.py",
+    "src/transformers/models/modernbert_decoder/modeling_modernbert_decoder.py",
+    "src/transformers/models/nemotron_h/modeling_nemotron_h.py",
+    "src/transformers/models/olmo3/modeling_olmo3.py",
+    "src/transformers/models/pp_formulanet/processing_pp_formulanet.py",
+    "src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py",
+    "src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py",
+    "src/transformers/models/qwen3_vl/processing_qwen3_vl.py",
+    "src/transformers/models/t5gemma2/modeling_t5gemma2.py",
+    "src/transformers/models/video_llama_3/processing_video_llama_3.py",
+    "src/transformers/models/zamba2/modeling_zamba2.py",
+    "src/transformers/models/zaya/modeling_zaya.py",
+    "tests/models/glm_ocr/test_modeling_glm_ocr.py",
+]
+
+
+class PatchPathsTests(unittest.TestCase):
+    def test_reads_git_headers(self):
+        self.assertEqual(
+            patch_paths(PATCH), {"tests/models/glm_ocr/test_modeling_glm_ocr.py"}
+        )
+
+    def test_reads_both_sides_of_a_rename(self):
+        patch = "diff --git a/old/x.py b/new/x.py\n--- a/old/x.py\n+++ b/new/x.py\n"
+        self.assertEqual(patch_paths(patch), {"old/x.py", "new/x.py"})
+
+    def test_falls_back_to_plus_headers(self):
+        patch = "--- a/x/y.py\n+++ b/x/y.py\n@@ -1 +1 @@\n-a\n+b\n"
+        self.assertEqual(patch_paths(patch), {"x/y.py"})
+
+    def test_ignores_dev_null_for_deletions(self):
+        patch = "--- a/x/y.py\n+++ /dev/null\n"
+        self.assertEqual(patch_paths(patch), set())
+
+    def test_empty_patch_has_no_paths(self):
+        self.assertEqual(patch_paths(""), set())
+
+
+class ScopePathsTests(unittest.TestCase):
+    def test_prod_case_drops_all_31_unrelated_files(self):
+        keep, dropped = scope_paths(PROD_CHANGED, PATCH)
+        self.assertEqual(keep, ["tests/models/glm_ocr/test_modeling_glm_ocr.py"])
+        self.assertEqual(len(dropped), 31)
+
+    def test_keeps_regenerated_files_for_the_same_model(self):
+        """The coupling that matters: a glm_ocr test patch legitimately
+        regenerates src/transformers/models/glm_ocr/. Dropping that would
+        reintroduce serge #58 (a PR with a modular file and no modeling file)."""
+        changed = [
+            "tests/models/glm_ocr/test_modeling_glm_ocr.py",
+            "src/transformers/models/glm_ocr/modeling_glm_ocr.py",
+            "src/transformers/models/glm_ocr/processing_glm_ocr.py",
+            "src/transformers/models/bamba/modeling_bamba.py",
+        ]
+        keep, dropped = scope_paths(changed, PATCH)
+        self.assertIn("src/transformers/models/glm_ocr/modeling_glm_ocr.py", keep)
+        self.assertIn("src/transformers/models/glm_ocr/processing_glm_ocr.py", keep)
+        self.assertEqual(dropped, ["src/transformers/models/bamba/modeling_bamba.py"])
+
+    def test_keeps_files_in_the_same_directory(self):
+        patch = (
+            "diff --git a/src/pkg/a.py b/src/pkg/a.py\n--- a/src/pkg/a.py\n"
+            "+++ b/src/pkg/a.py\n"
+        )
+        keep, dropped = scope_paths(
+            ["src/pkg/a.py", "src/pkg/b.py", "src/other/c.py"], patch
+        )
+        self.assertEqual(keep, ["src/pkg/a.py", "src/pkg/b.py"])
+        self.assertEqual(dropped, ["src/other/c.py"])
+
+    def test_keeps_a_patched_directorys_subtree(self):
+        patch = (
+            "diff --git a/src/pkg/__init__.py b/src/pkg/__init__.py\n"
+            "--- a/src/pkg/__init__.py\n+++ b/src/pkg/__init__.py\n"
+        )
+        keep, _ = scope_paths(["src/pkg/__init__.py", "src/pkg/sub/deep.py"], patch)
+        self.assertIn("src/pkg/sub/deep.py", keep)
+
+    def test_always_include_globs_survive(self):
+        changed = [
+            "tests/models/glm_ocr/test_modeling_glm_ocr.py",
+            "src/transformers/utils/dummy_pt_objects.py",
+            "src/transformers/models/bamba/modeling_bamba.py",
+        ]
+        keep, dropped = scope_paths(
+            changed, PATCH, always_include=["src/transformers/utils/dummy_*.py"]
+        )
+        self.assertIn("src/transformers/utils/dummy_pt_objects.py", keep)
+        self.assertEqual(dropped, ["src/transformers/models/bamba/modeling_bamba.py"])
+
+    def test_a_patched_path_is_always_kept(self):
+        """Even a patched file whose directory looks unrelated to the rest."""
+        patch = "diff --git a/setup.py b/setup.py\n--- a/setup.py\n+++ b/setup.py\n"
+        keep, dropped = scope_paths(["setup.py"], patch)
+        self.assertEqual(keep, ["setup.py"])
+        self.assertEqual(dropped, [])
+
+    def test_empty_patch_keeps_everything(self):
+        """With no patch we cannot tell drift from the fix; committing too much
+        beats committing nothing."""
+        keep, dropped = scope_paths(PROD_CHANGED, "")
+        self.assertEqual(keep, PROD_CHANGED)
+        self.assertEqual(dropped, [])
+
+    def test_never_scopes_down_to_nothing(self):
+        """If the rule rejected every change it is wrong about this repo —
+        keep the change rather than silently publish an empty commit."""
+        patch = "diff --git a/a/only.py b/a/only.py\n--- a/a/only.py\n+++ b/a/only.py\n"
+        keep, dropped = scope_paths(["z/unrelated.py"], patch)
+        self.assertEqual(keep, ["z/unrelated.py"])
+        self.assertEqual(dropped, [])
+
+    def test_a_root_patch_scopes_to_the_root(self):
+        """Documenting a deliberate generosity: a patch to a root-level file
+        adopts root-level normalizer output, because that is how a generated file
+        sitting next to its source rides along (serge #58, whose test fixture is
+        exactly hello.txt -> extra.txt). Nested files are still dropped, which is
+        what the real drift looks like — generated files in the repos serge
+        targets live in a model directory, never at the root."""
+        patch = "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n"
+        keep, dropped = scope_paths(["README.md", "setup.py", "src/pkg/a.py"], patch)
+        self.assertEqual(keep, ["README.md", "setup.py"])
+        self.assertEqual(dropped, ["src/pkg/a.py"])
+
+
+class DescribeDroppedTests(unittest.TestCase):
+    def test_lists_and_counts_the_remainder(self):
+        out = describe_dropped([f"d/f{i}.py" for i in range(12)], limit=3)
+        self.assertIn("d/f0.py", out)
+        self.assertIn("+9 more", out)
+
+    def test_short_list_has_no_suffix(self):
+        out = describe_dropped(["a/b.py", "c/d.py"], limit=8)
+        self.assertEqual(out, "a/b.py, c/d.py")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_github_token_refresh.py
+++ b/tests/test_github_token_refresh.py
@@ -1,0 +1,222 @@
+"""Tests for surviving GitHub installation-token expiry mid-task.
+
+Installation tokens last one hour. A ``/tasks`` run longer than that reached the
+publish step with a dead token and lost all its work to ``401 Bad credentials``
+(observed on three prod runs of 65-67 minutes). Two pieces cover it: the client
+session replays a 401 once with a re-minted token, and the runner asks serge for
+that token over the existing authenticated callback channel.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from reviewbot.github_client import GitHubClient, _AuthRetrySession
+from reviewbot.task_runner import TokenRefresher
+
+
+def _resp(status: int, payload=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.ok = 200 <= status < 300
+    r.json.return_value = payload if payload is not None else {}
+    r.text = text
+    return r
+
+
+class AuthRetrySessionTests(unittest.TestCase):
+    """The 401-replay contract, asserted at the session level so it holds for
+    every GitHubClient method rather than the ones we remembered to plumb."""
+
+    def test_replays_once_with_the_refreshed_token(self):
+        session = _AuthRetrySession(lambda: "fresh")
+        session.headers["Authorization"] = "Bearer stale"
+        with patch.object(
+            requests.Session, "request", side_effect=[_resp(401), _resp(201)]
+        ) as inner:
+            out = session.post("https://api.github.com/repos/o/r/git/blobs", json={})
+        self.assertEqual(out.status_code, 201)
+        self.assertEqual(inner.call_count, 2)
+        self.assertEqual(session.headers["Authorization"], "Bearer fresh")
+
+    def test_replay_carries_the_original_body(self):
+        session = _AuthRetrySession(lambda: "fresh")
+        session.headers["Authorization"] = "Bearer stale"
+        with patch.object(
+            requests.Session, "request", side_effect=[_resp(401), _resp(201)]
+        ) as inner:
+            session.post("https://api.github.com/x", json={"content": "abc"})
+        first, second = inner.call_args_list
+        self.assertEqual(first.kwargs["json"], {"content": "abc"})
+        self.assertEqual(second.kwargs["json"], {"content": "abc"})
+
+    def test_success_is_not_retried(self):
+        provider = MagicMock(return_value="fresh")
+        session = _AuthRetrySession(provider)
+        with patch.object(requests.Session, "request", return_value=_resp(200)):
+            session.get("https://api.github.com/x")
+        provider.assert_not_called()
+
+    def test_non_401_failure_is_not_retried(self):
+        """A 403 (rate limit / missing permission) is not an expiry — surface it
+        rather than burning a mint and doubling the request."""
+        provider = MagicMock(return_value="fresh")
+        session = _AuthRetrySession(provider)
+        with patch.object(
+            requests.Session, "request", return_value=_resp(403)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 403)
+        self.assertEqual(inner.call_count, 1)
+        provider.assert_not_called()
+
+    def test_without_a_provider_the_401_is_returned(self):
+        session = _AuthRetrySession(None)
+        with patch.object(
+            requests.Session, "request", return_value=_resp(401)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 401)
+        self.assertEqual(inner.call_count, 1)
+
+    def test_unchanged_token_is_not_replayed(self):
+        """A 401 from a genuinely bad token (revoked install, wrong App) must
+        stay a 401 instead of doubling every request forever."""
+        session = _AuthRetrySession(lambda: "same")
+        session.headers["Authorization"] = "Bearer same"
+        with patch.object(
+            requests.Session, "request", return_value=_resp(401)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 401)
+        self.assertEqual(inner.call_count, 1)
+
+    def test_empty_token_is_not_replayed(self):
+        session = _AuthRetrySession(lambda: "")
+        session.headers["Authorization"] = "Bearer stale"
+        with patch.object(
+            requests.Session, "request", return_value=_resp(401)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 401)
+        self.assertEqual(inner.call_count, 1)
+
+    def test_a_failing_provider_surfaces_the_original_401(self):
+        def boom() -> str:
+            raise RuntimeError("serge unreachable")
+
+        session = _AuthRetrySession(boom)
+        with patch.object(
+            requests.Session, "request", return_value=_resp(401)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 401)
+        self.assertEqual(inner.call_count, 1)
+
+    def test_retries_only_once(self):
+        """Two consecutive 401s end after one replay — no unbounded loop."""
+        session = _AuthRetrySession(lambda: "fresh")
+        session.headers["Authorization"] = "Bearer stale"
+        with patch.object(
+            requests.Session, "request", side_effect=[_resp(401), _resp(401)]
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 401)
+        self.assertEqual(inner.call_count, 2)
+
+
+class GitHubClientRefreshTests(unittest.TestCase):
+    """The regression this whole change exists for: the exact call that failed
+    in prod (``create_blob`` on the first write of the publish step) now
+    survives an expired token."""
+
+    def test_create_blob_survives_an_expired_token(self):
+        gh = GitHubClient("stale", token_provider=lambda: "fresh")
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(401, text="Bad credentials"), _resp(201, {"sha": "b1"})],
+        ):
+            sha = gh.create_blob("huggingface", "transformers", b"print()")
+        self.assertEqual(sha, "b1")
+        self.assertEqual(gh.session.headers["Authorization"], "Bearer fresh")
+
+    def test_create_blob_still_raises_when_refresh_cannot_help(self):
+        gh = GitHubClient("stale", token_provider=lambda: "stale")
+        with (
+            patch.object(
+                requests.Session,
+                "request",
+                return_value=_resp(401, text="Bad credentials"),
+            ),
+            self.assertRaises(requests.HTTPError) as ctx,
+        ):
+            gh.create_blob("huggingface", "transformers", b"print()")
+        self.assertIn("401 creating blob", str(ctx.exception))
+
+    def test_no_provider_keeps_the_previous_behaviour(self):
+        gh = GitHubClient("tok")
+        self.assertIsInstance(gh.session, _AuthRetrySession)
+        with patch.object(
+            requests.Session, "request", return_value=_resp(200)
+        ) as inner:
+            gh.get_pr("o", "r", 1)
+        self.assertEqual(inner.call_count, 1)
+
+
+class TokenRefresherTests(unittest.TestCase):
+    def test_posts_to_serge_with_the_callback_token(self):
+        refresher = TokenRefresher(
+            "https://serge/internal/tasks/j1/github-token", "cb", "old"
+        )
+        refresher._session = MagicMock()
+        refresher._session.post.return_value = _resp(200, {"token": "new"})
+        self.assertEqual(refresher(), "new")
+        self.assertEqual(refresher.current, "new")
+        args, kwargs = refresher._session.post.call_args
+        self.assertEqual(args[0], "https://serge/internal/tasks/j1/github-token")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer cb")
+
+    def test_no_url_means_disabled_and_returns_the_initial_token(self):
+        refresher = TokenRefresher(None, "cb", "old")
+        self.assertFalse(refresher.enabled)
+        self.assertEqual(refresher(), "old")
+
+    def test_network_failure_returns_the_current_token(self):
+        """Returning the *unchanged* token is what makes the session skip its
+        replay and surface the real 401 — the failure mode must stay quiet."""
+        refresher = TokenRefresher("https://serge/t", "cb", "old")
+        refresher._session = MagicMock()
+        refresher._session.post.side_effect = requests.ConnectionError("boom")
+        self.assertEqual(refresher(), "old")
+        self.assertEqual(refresher.current, "old")
+
+    def test_http_error_returns_the_current_token(self):
+        refresher = TokenRefresher("https://serge/t", "cb", "old")
+        refresher._session = MagicMock()
+        bad = _resp(502)
+        bad.raise_for_status.side_effect = requests.HTTPError("502")
+        refresher._session.post.return_value = bad
+        self.assertEqual(refresher(), "old")
+
+    def test_empty_token_in_the_response_keeps_the_current_one(self):
+        refresher = TokenRefresher("https://serge/t", "cb", "old")
+        refresher._session = MagicMock()
+        refresher._session.post.return_value = _resp(200, {})
+        self.assertEqual(refresher(), "old")
+
+    def test_second_refresh_replaces_the_first(self):
+        refresher = TokenRefresher("https://serge/t", "cb", "t0")
+        refresher._session = MagicMock()
+        refresher._session.post.side_effect = [
+            _resp(200, {"token": "t1"}),
+            _resp(200, {"token": "t2"}),
+        ]
+        self.assertEqual(refresher(), "t1")
+        self.assertEqual(refresher(), "t2")
+        self.assertEqual(refresher.current, "t2")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -426,11 +426,13 @@ class _CfgStub:
         tool_max_iterations: int = 30,
         llm_max_input_tokens: int = 0,
         llm_reasoning_effort: str | None = None,
+        tool_repeat_limit: int = 0,
     ) -> None:
         self.llm_max_tokens = llm_max_tokens
         self.tool_max_iterations = tool_max_iterations
         self.llm_max_input_tokens = llm_max_input_tokens
         self.llm_reasoning_effort = llm_reasoning_effort
+        self.tool_repeat_limit = tool_repeat_limit
 
 
 class _FakeLLM:
@@ -508,6 +510,123 @@ class InputTokenBudgetTests(unittest.TestCase):
         )
         self.assertEqual(metrics.turns, 1)
         self.assertEqual(len(llm.calls), 1)
+
+
+class ToolRepeatGuardLoopTests(unittest.TestCase):
+    """The repeat guard has to cut the loop off, not just annotate results.
+
+    Prod task 433e8274 spent ~55 turns and its whole 2M input-token budget on two
+    greps it kept re-issuing verbatim, then was forced into a tool-less answer
+    with nothing learned. Here the same shape stops after a handful of turns.
+    """
+
+    def _repeating_llm(self, tool_turns: int = 4) -> _FakeLLM:
+        # Each of the first ``tool_turns`` turns re-issues the identical grep;
+        # the trailing entry answers the forced final turn and is reused for any
+        # turn beyond it (see _FakeLLM).
+        repeat = ChatResult(
+            content="",
+            usage={"prompt_tokens": 40_000, "completion_tokens": 40},
+            tool_calls=[
+                ToolCall(
+                    id="t", name="grep", arguments='{"pattern": "Foo", "path": "."}'
+                )
+            ],
+        )
+        final = ChatResult(
+            content='{"summary": "stuck", "comments": []}',
+            usage={"prompt_tokens": 40_000, "completion_tokens": 20},
+        )
+        return _FakeLLM([repeat] * tool_turns + [final])
+
+    def test_repeated_calls_break_the_loop_early(self) -> None:
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=3)
+        llm = self._repeating_llm()
+        chat, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        # 1 original + 3 repeats = 4 tool turns, then the forced final answer.
+        self.assertEqual(len(llm.calls), 5)
+        self.assertNotIn("tools", llm.calls[-1])
+        self.assertEqual(chat.content, '{"summary": "stuck", "comments": []}')
+        self.assertEqual(metrics.tool_calls, 4)
+
+    def test_the_model_is_told_it_is_repeating(self) -> None:
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=3)
+        llm = self._repeating_llm()
+        _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        tool_messages = [
+            m for m in llm.calls[-1]["messages"] if m.get("role") == "tool"
+        ]
+        # First result is clean; every repeat carries the correction.
+        self.assertNotIn("[serge]", tool_messages[0]["content"])
+        self.assertIn("already made this exact grep call", tool_messages[1]["content"])
+        self.assertIn("You are in a loop", tool_messages[-1]["content"])
+
+    def test_emits_the_loop_reason_not_budget_exhausted(self) -> None:
+        """Operators read these events to tell a real budget exhaustion from a
+        stuck loop — the generic message must not mask the specific one."""
+        events: list[tuple[str, str]] = []
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=3)
+        _run_agentic_loop(
+            self._repeating_llm(),  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+            emit=lambda kind, text: events.append((kind, text)),
+        )
+        logs = [text for kind, text in events if kind == "log"]
+        self.assertTrue(any("Stuck in a tool-call loop" in line for line in logs))
+        self.assertFalse(any("Agent budget exhausted" in line for line in logs))
+
+    def test_disabled_guard_lets_the_loop_run_to_its_other_caps(self) -> None:
+        cfg = _CfgStub(tool_max_iterations=4, tool_repeat_limit=0)
+        llm = self._repeating_llm()
+        _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        # Blind-turn cap (4) governs instead of the repeat guard.
+        self.assertEqual(len(llm.calls), 5)
+
+    def test_distinct_calls_are_not_cut_off(self) -> None:
+        """A genuine investigation making different calls must be untouched."""
+        turns = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+                tool_calls=[
+                    ToolCall(
+                        id=f"t{i}", name="grep", arguments='{"pattern": "P%d"}' % i
+                    )
+                ],
+            )
+            for i in range(8)
+        ]
+        final = ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+        )
+        llm = _FakeLLM(turns + [final])
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=3)
+        chat, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.tool_calls, 8)
+        self.assertEqual(chat.content, '{"summary": "ok", "comments": []}')
 
 
 class ValidationGateTests(unittest.TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -600,6 +600,72 @@ class PublishFallbackNormalizeTests(unittest.TestCase):
         self.assertEqual(sorted(result.changed_files), ["extra.txt", "hello.txt"])
         self.assertIsNotNone(gh.created_pr)
 
+    def test_unrelated_normalizer_output_is_left_out_of_the_commit(self):
+        # The prod shape (task 433e8274): the base is stale, so the normalizer
+        # rewrites files in directories the patch never touched. Those must not
+        # land in the PR — one prod task patched 1 file and committed 32.
+        co = self._checkout()
+        cfg = self._cfg(
+            task_normalize_command=[
+                "sh",
+                "-c",
+                "mkdir -p models/other && echo drift > models/other/regen.py "
+                "&& echo generated > extra.txt",
+            ],
+            task_normalize_timeout=30,
+        )
+        plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        events: list[tuple[str, str]] = []
+        with patch("reviewbot.tasks.post_task_pr_created_notification"):
+            result = publish_task(
+                cfg,
+                gh,
+                self._req(),
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+                emit=lambda kind, text: events.append((kind, text)),
+            )
+        self.assertFalse(result.no_change)
+        # hello.txt (patched) and extra.txt (root, alongside it) ship;
+        # models/other/regen.py is drift from a stale base and does not.
+        self.assertEqual(sorted(result.changed_files), ["extra.txt", "hello.txt"])
+        logs = [text for kind, text in events if kind == "log"]
+        self.assertTrue(
+            any("Left 1 unrelated file(s) out of the commit" in line for line in logs),
+            logs,
+        )
+        self.assertTrue(any("models/other/regen.py" in line for line in logs))
+
+    def test_scoping_can_be_turned_off(self):
+        co = self._checkout()
+        cfg = self._cfg(
+            task_normalize_command=[
+                "sh",
+                "-c",
+                "mkdir -p models/other && echo drift > models/other/regen.py",
+            ],
+            task_normalize_timeout=30,
+            task_scope_commit_to_patch=False,
+        )
+        plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        with patch("reviewbot.tasks.post_task_pr_created_notification"):
+            result = publish_task(
+                cfg,
+                gh,
+                self._req(),
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+            )
+        self.assertEqual(
+            sorted(result.changed_files), ["hello.txt", "models/other/regen.py"]
+        )
+
     def test_fallback_refuses_when_normalizer_rejects(self):
         # Normalizer exits non-zero on the raw patch -> no PR, worktree reset.
         co = self._checkout()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -639,6 +639,38 @@ class PublishFallbackNormalizeTests(unittest.TestCase):
         )
         self.assertTrue(any("models/other/regen.py" in line for line in logs))
 
+    def test_scoping_applies_to_the_prepared_worktree_path(self):
+        """The path prod task 433e8274 actually took: validation accepted the
+        patch in-loop (worktree_prepared=True), so publish_task commits the
+        worktree as-is. The scope comes from plan.patch, which is set on both
+        paths — without that this fix would no-op exactly where it is needed."""
+        co = self._checkout()
+        # Stand in for what the in-loop validation left behind: the patch applied
+        # plus normalizer drift in an unrelated directory.
+        self.cache.apply_patch(co, self._PATCH)
+        os.makedirs(os.path.join(co.path, "models", "other"), exist_ok=True)
+        with open(os.path.join(co.path, "models", "other", "regen.py"), "w") as f:
+            f.write("drift\n")
+        cfg = self._cfg(task_normalize_command=["true"], task_normalize_timeout=30)
+        plan = TaskPlan(
+            title="Fix hello",
+            body="desc",
+            patch=self._PATCH,
+            worktree_prepared=True,
+        )
+        gh = _FakeGH()
+        with patch("reviewbot.tasks.post_task_pr_created_notification"):
+            result = publish_task(
+                cfg,
+                gh,
+                self._req(),
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+            )
+        self.assertEqual(result.changed_files, ["hello.txt"])
+
     def test_scoping_can_be_turned_off(self):
         co = self._checkout()
         cfg = self._cfg(

--- a/tests/test_tool_repeat.py
+++ b/tests/test_tool_repeat.py
@@ -1,0 +1,148 @@
+"""Tests for the repeated-tool-call guard.
+
+Reference failure: prod task 433e8274 issued the same two greps 21 and 44 times,
+exhausted the 2M input-token cap in ~55 turns without ever reasoning about the
+fix, and produced a patch that failed GPU verification — three rounds running.
+"""
+
+import unittest
+
+from reviewbot.tool_repeat import ToolRepeatGuard, normalize_arguments
+
+
+GREP_A = '{"pattern": "GlmOcrProcessor|Glm46VProcessor", "path": "src/transformers/models/glm_ocr", "max_results": 50}'
+GREP_B = '{"pattern": "image_token_id|video_token_id", "path": "src/transformers"}'
+
+
+class NormalizeArgumentsTests(unittest.TestCase):
+    def test_key_order_does_not_disguise_a_repeat(self):
+        self.assertEqual(
+            normalize_arguments('{"a": 1, "b": 2}'),
+            normalize_arguments('{"b": 2, "a": 1}'),
+        )
+
+    def test_whitespace_does_not_disguise_a_repeat(self):
+        self.assertEqual(
+            normalize_arguments('{"path":"x"}'),
+            normalize_arguments('{  "path"  :  "x"  }'),
+        )
+
+    def test_different_arguments_stay_different(self):
+        self.assertNotEqual(
+            normalize_arguments('{"path": "a"}'),
+            normalize_arguments('{"path": "b"}'),
+        )
+
+    def test_non_json_falls_back_to_the_raw_string(self):
+        """Some providers emit partial/non-JSON arguments; two identical broken
+        strings are still a repeat."""
+        self.assertEqual(
+            normalize_arguments("not json  "), normalize_arguments("not json")
+        )
+        self.assertNotEqual(
+            normalize_arguments("not json"), normalize_arguments("other")
+        )
+
+    def test_empty_and_missing_arguments_are_equal(self):
+        self.assertEqual(normalize_arguments(""), normalize_arguments("{}"))
+
+
+class ToolRepeatGuardTests(unittest.TestCase):
+    def test_first_call_is_free(self):
+        guard = ToolRepeatGuard(6)
+        self.assertIsNone(guard.observe("grep", GREP_A))
+        self.assertEqual(guard.repeats, 0)
+        self.assertFalse(guard.tripped)
+
+    def test_distinct_calls_never_count_as_repeats(self):
+        """Legitimate investigation makes many different calls."""
+        guard = ToolRepeatGuard(6)
+        for i in range(50):
+            self.assertIsNone(guard.observe("read_file", '{"path": "f%d.py"}' % i))
+        self.assertEqual(guard.repeats, 0)
+        self.assertFalse(guard.tripped)
+
+    def test_repeat_is_told_it_is_repeating(self):
+        guard = ToolRepeatGuard(6)
+        guard.observe("grep", GREP_A)
+        note = guard.observe("grep", GREP_A)
+        self.assertIsNotNone(note)
+        self.assertIn("already made this exact grep call 2 times", note)
+        # Both escape hatches are spelled out.
+        self.assertIn("different pattern", note)
+        self.assertIn("final answer", note)
+
+    def test_repeat_count_climbs(self):
+        guard = ToolRepeatGuard(0)  # disabled; count via a live one below
+        self.assertIsNone(guard.observe("grep", GREP_A))
+        guard = ToolRepeatGuard(99)
+        for _ in range(4):
+            guard.observe("grep", GREP_A)
+        note = guard.observe("grep", GREP_A)
+        self.assertIn("5 times", note)
+        self.assertEqual(guard.repeats, 4)
+
+    def test_trips_after_the_limit(self):
+        guard = ToolRepeatGuard(3)
+        guard.observe("grep", GREP_A)  # first — free
+        guard.observe("grep", GREP_A)  # repeat 1
+        guard.observe("grep", GREP_A)  # repeat 2
+        self.assertFalse(guard.tripped)
+        note = guard.observe("grep", GREP_A)  # repeat 3 → trip
+        self.assertTrue(guard.tripped)
+        self.assertIn("You are in a loop", note)
+
+    def test_repeats_are_counted_across_signatures(self):
+        """The prod shape: the model alternated between two identical greps. A
+        per-signature limit would have allowed twice the waste."""
+        guard = ToolRepeatGuard(4)
+        guard.observe("grep", GREP_A)
+        guard.observe("grep", GREP_B)
+        for _ in range(2):
+            guard.observe("grep", GREP_A)
+            guard.observe("grep", GREP_B)
+        self.assertTrue(guard.tripped)
+        self.assertEqual(guard.repeats, 4)
+
+    def test_same_arguments_different_tool_is_not_a_repeat(self):
+        guard = ToolRepeatGuard(6)
+        self.assertIsNone(guard.observe("grep", '{"path": "x"}'))
+        self.assertIsNone(guard.observe("list_dir", '{"path": "x"}'))
+
+    def test_disabled_guard_never_fires(self):
+        guard = ToolRepeatGuard(0)
+        self.assertFalse(guard.enabled)
+        for _ in range(100):
+            self.assertIsNone(guard.observe("grep", GREP_A))
+        self.assertFalse(guard.tripped)
+        self.assertEqual(guard.repeats, 0)
+
+    def test_summary_names_the_worst_offenders(self):
+        guard = ToolRepeatGuard(999)
+        for _ in range(21):
+            guard.observe("grep", GREP_A)
+        for _ in range(3):
+            guard.observe("list_dir", '{"path": "src"}')
+        summary = guard.summary()
+        self.assertIn("22 repeated tool call(s)", summary)
+        self.assertIn("grep×21", summary)
+        self.assertIn("list_dir×3", summary)
+
+    def test_prod_shape_stops_early(self):
+        """The real regression: 21 + 44 identical greps must not all get through.
+
+        With the default limit the loop is cut off after a handful of repeats
+        instead of ~55 turns and 2M input tokens."""
+        guard = ToolRepeatGuard(6)
+        served = 0
+        for _ in range(21):
+            guard.observe("grep", GREP_A)
+            served += 1
+            if guard.tripped:
+                break
+        self.assertTrue(guard.tripped)
+        self.assertLessEqual(served, 8)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -1062,6 +1062,121 @@ class TaskLauncherTests(unittest.TestCase):
         )
         self.assertEqual(job.status, "running")  # non-terminal
 
+    # --- POST /internal/tasks/{id}/github-token --------------------------
+    # Installation tokens die after an hour; a >60min task asks here for a
+    # replacement rather than losing its finished work to 401 Bad credentials.
+    def test_launch_advertises_the_token_refresh_url(self):
+        webapp = self._import_webapp()
+        job = self._make_job(webapp)
+        worker_cfg, req = self._worker_cfg_and_req(webapp)
+        captured = {}
+
+        with (
+            patch.object(webapp, "installation_id_for_repo", return_value=1),
+            patch.object(webapp, "installation_token", return_value="gh-token"),
+            patch.object(
+                webapp,
+                "launch_docker",
+                side_effect=lambda spec, opts, *, wait, timeout: (
+                    captured.setdefault("spec", spec),
+                    (0, "cid"),
+                )[1],
+            ),
+            patch.object(webapp, "_notify_task_finished"),
+            patch.object(webapp, "_persist_terminal"),
+        ):
+            webapp._launch_task_pod(job, worker_cfg, req)
+
+        self.assertEqual(
+            captured["spec"]["callback"]["token_url"],
+            f"http://serge:8000/internal/tasks/{job.id}/github-token",
+        )
+
+    def test_token_refresh_mints_for_the_jobs_own_repo(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._make_job(webapp, callback_token="tok")
+        client = TestClient(webapp.app)
+        with patch.object(
+            webapp, "installation_token_for_repo", return_value="fresh-token"
+        ) as mint:
+            r = client.post(
+                "/internal/tasks/job123abc456/github-token",
+                headers={"Authorization": "Bearer tok"},
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["token"], "fresh-token")
+        # Scoped to the job's target repo — never broader than the token the
+        # pod launched with.
+        self.assertEqual(mint.call_args[0][2], "acme")
+        self.assertEqual(mint.call_args[0][3], "widgets")
+
+    def test_token_refresh_rejects_bad_token(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._make_job(webapp, callback_token="right")
+        client = TestClient(webapp.app)
+        with patch.object(webapp, "installation_token_for_repo") as mint:
+            r = client.post(
+                "/internal/tasks/job123abc456/github-token",
+                headers={"Authorization": "Bearer wrong"},
+            )
+        self.assertEqual(r.status_code, 401)
+        mint.assert_not_called()
+
+    def test_token_refresh_rejects_missing_token(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._make_job(webapp, callback_token="right")
+        client = TestClient(webapp.app)
+        r = client.post("/internal/tasks/job123abc456/github-token")
+        self.assertEqual(r.status_code, 401)
+
+    def test_token_refresh_rejects_unknown_job(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        client = TestClient(webapp.app)
+        r = client.post(
+            "/internal/tasks/does-not-exist/github-token",
+            headers={"Authorization": "Bearer whatever"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_token_refresh_rejects_a_finished_job(self):
+        """The callback token is cleared when the launcher returns, so a reaped
+        job cannot mint tokens even with the right token replayed."""
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._make_job(webapp, status="published", callback_token=None)
+        client = TestClient(webapp.app)
+        r = client.post(
+            "/internal/tasks/job123abc456/github-token",
+            headers={"Authorization": "Bearer tok"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_token_refresh_reports_a_mint_failure(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._make_job(webapp, callback_token="tok")
+        client = TestClient(webapp.app)
+        with patch.object(
+            webapp,
+            "installation_token_for_repo",
+            side_effect=RuntimeError("github down"),
+        ):
+            r = client.post(
+                "/internal/tasks/job123abc456/github-token",
+                headers={"Authorization": "Bearer tok"},
+            )
+        self.assertEqual(r.status_code, 502)
+
     def test_task_info_includes_filtered_trace(self):
         if TestClient is None:
             self.skipTest("fastapi not installed")


### PR DESCRIPTION
Three independent failures found while working out why task
[`433e8274`](https://serge.huggingface.tech/tasks/huggingface/transformers/433e827476ad4a06b9cb0b2a57461773)
(glm_ocr integration-failure triage, `github-merge-queue`, 66.3 min) ended in

```
401 creating blob on huggingface/transformers: {"message": "Bad credentials", "status": "401"}
```

All three are live in prod today. Each fix is separately switchable off.

## 1. GitHub installation tokens expire after an hour; nothing re-minted them

serge mints an installation token at launch and hands it to the runner pod in the
spec. Those tokens live for exactly one hour, and there was no refresh or
401-retry anywhere — so a task that spends longer than that in the agentic loop
plus the normalizer reaches the publish step holding a dead token and every Git
Data API write fails. The patch is written, validated and GPU-verified, then
thrown away.

Not a one-off. Every task in the last 7 days that crossed the hour and then tried
to write died identically:

| task | duration | outcome |
|---|---|---|
| `433e827476` | 66.3m | 401 Bad credentials |
| `2f27d9616b` | 67.1m | 401 Bad credentials |
| `21ef239e3c` | 65.6m | 401 Bad credentials |
| `7c93bb610d` | 95.2m | `no_fix` — survived only because it never wrote |

Task `433e8274`'s first two verify rounds committed fine and only the third
failed, which pins this to expiry rather than a bad token.

The pod deliberately holds no App private key, so it cannot re-mint on its own.
It now asks serge over the channel it already streams events on:

- **`POST /internal/tasks/{id}/github-token`** mints a replacement scoped to the
  job's own target repo, behind the existing per-job bearer token. A finished job
  (token cleared) or a wrong token still gets a 401. Auth is now shared with the
  events callback via `_authorize_runner_callback`.
- **`TokenRefresher`** (runner) fetches from it and caches the newest token.
- **`_AuthRetrySession`** wires it into `GitHubClient`: on a 401 it re-mints,
  restamps the header and replays once. Overriding `Session.request` — the single
  funnel every `get`/`post`/`patch` goes through — covers all ~20 client methods
  instead of the ones we remember to plumb.

Replay is deliberately conservative: once only, only on 401, and only when the
fresh token actually differs, so a revoked install or wrong App still surfaces as
a 401 rather than doubling every request. A refresh that fails returns the
current token unchanged, which makes the session skip its replay and report the
real GitHub error. Review pods get the same wiring through the shared spec.

## 2. The agent burned its whole 2M input budget re-issuing two identical greps

Same task asked for

```
grep(pattern="GlmOcrProcessor|Glm46VProcessor", path="src/transformers/models/glm_ocr")
```

**21 times**, and another grep **44 times**, each returning the same `no matches`.
It hit the 2M cumulative-input-token cap after ~55 turns and 60s of LLM wall
time, so the loop forced a tool-less final answer from a model that had never
reasoned about the fix — and GPU verify returned `not_fixed`. All three verify
rounds burned out identically, at the same cap.

The tool calls are cheap; the *turn* around each is not. Every repeat resends the
whole conversation, ~40k input tokens a time, which is how 55 turns consumed 2M.
So `ToolRepeatGuard`:

- appends a correction to a repeated call's result telling the model it is
  repeating, that the call cannot yield anything new, and naming both ways out
  (different arguments, or answer now);
- trips after `tool_repeat_limit` total repeats (default 6, `0` disables,
  `TOOL_REPEAT_LIMIT` to override), breaking the loop so the rest of the budget
  goes to an answer rather than the 50th identical grep.

Repeats are counted globally rather than per-signature, because the stuck model
alternated between *two* identical greps — a per-signature limit would have
allowed double the waste.

Deliberately **not** a cache: a repeated `read_file` after an `apply_patch` must
see the new content, so every call still executes for real. Identity is a
normalized `(name, arguments)` pair, so key order and whitespace can't disguise a
repeat. The trip reports its own reason so the run log distinguishes a stuck loop
from a real budget exhaustion.

## 3. A one-file fix committed 32 files

The normalizer runs with its fixers on so files the patch *requires* to be
regenerated ride along (the modular coupling: editing `modular_X.py` must
regenerate `modeling_X.py`). But it fixes the whole worktree, not just the patch —
so when the base is not itself normalizer-clean, every unrelated stale file gets
regenerated and lands in the PR.

Task `433e8274` patched exactly one file,
`tests/models/glm_ocr/test_modeling_glm_ocr.py`, and committed **32**. The other
31 were regenerated `modeling_*`/`processing_*` files for bamba, colpali, zamba2,
modernbert and 27 more models the fix never touched. Unreviewable — and the
12 minutes of normalizer time per attempt is also what pushed the final commit
past the token expiry in (1).

Validation still runs repo-wide; only the **commit** is scoped. A
normalizer-changed file is kept when it is related to a patched path: same
directory, the same directory *name* (how `{src/transformers,tests}/models/<model>/`
is coupled), or under a patched directory. On the real 32-file input this keeps 1
and drops 31.

Kept deliberately generous, because dropping a genuinely needed generated file is
the worse failure — #58 shipped an unmergeable PR with a `modular_*.py` and no
regenerated `modeling_*.py`. So: patched paths are always kept, a root-level patch
scopes to the root so a generated file beside its source rides along, an
empty/unparseable patch keeps everything, and the filter never reduces a commit
to nothing. `TASK_COMMIT_ALWAYS_INCLUDE` is the escape hatch for a normalizer
that rewrites cross-cutting generated files; `TASK_SCOPE_COMMIT_TO_PATCH=0` turns
it off. Anything left out is named in the run log, so an incomplete commit is
diagnosable rather than mysterious.

## Tests

564 pass (was 492 on `main`); `ruff format` clean, no new lint. New coverage
includes the exact prod inputs: `create_blob` surviving an expired token, the
21×/44× grep shape stopping after a handful of repeats, and the real 32-file
change list scoping down to 1.

Worth noting one test earned its keep during review: an early version of (3)
excluded the repo root as a coupling scope, which broke
`test_fallback_reruns_normalizer_and_ships_regenerated_files` — the regression
guard from #58. Reverted; the prod churn still drops entirely, since it is never
in the patched file's directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
