### PR TITLE
Never publish a leaked tool call as a review

### DIFF
--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
@@ -527,6 +528,22 @@ class ChatCompletionClient:
                 )
                 time.sleep(2**attempt)
                 continue
+            # Structured `tool_calls` always wins; only fall back to scraping
+            # the content when the provider sent none. Covers both the
+            # streaming and buffered paths, which converge here.
+            if not tool_calls and content:
+                recovered, content = _parse_text_tool_calls(content)
+                if recovered:
+                    tool_calls = recovered
+                    log.warning(
+                        "Model wrote %d tool call(s) into content as special "
+                        "tokens instead of the tool_calls field (model=%s, "
+                        "finish=%s); recovered %s as a tool turn",
+                        len(recovered),
+                        self.model,
+                        finish_reason,
+                        ", ".join(tc.name for tc in recovered),
+                    )
             latency = time.monotonic() - started
             log.info(
                 "LLM call ok in %.1fs (prompt=%s, completion=%s, stream=%s, "
@@ -904,6 +921,90 @@ def _extract_thought_signature(tc: dict[str, Any]) -> Optional[str]:
         return None
     sig = google.get("thought_signature")
     return sig if isinstance(sig, str) and sig else None
+
+
+# Kimi (Moonshot) models served through the HF Router sometimes serialize a
+# tool call into `message.content` as their raw chat-template special tokens
+# and leave the structured `tool_calls` field empty, with
+# `finish_reason="stop"`. The agent loop reads that as "no tool calls, so this
+# is the final answer" and publishes the markup verbatim — that is how a review
+# body of nothing but `<|tool_calls_section_begin|>...` reached serge#79. Parse
+# the markup back into real ToolCall objects so the turn stays a tool turn.
+_TEXT_TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>"
+_TEXT_TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>"
+_TEXT_TOOL_CALL_BEGIN = "<|tool_call_begin|>"
+_TEXT_TOOL_CALL_ARGUMENT_BEGIN = "<|tool_call_argument_begin|>"
+_TEXT_TOOL_CALL_END = "<|tool_call_end|>"
+
+# The id between the begin and argument markers, e.g. `functions.read_file:6`.
+# Both the `functions.` namespace prefix and the `:index` suffix are optional,
+# so a bare `read_file` still parses.
+_TEXT_TOOL_CALL_ID_RE = re.compile(
+    r"\A(?:functions?[.:])?(?P<name>[A-Za-z0-9_.\-]+?)(?::(?P<index>\d+))?\Z"
+)
+
+
+def _split_text_tool_call_id(raw: str) -> str:
+    """The function name out of a Kimi-style text tool-call id, or "" when the
+    id doesn't look like one (so the caller drops the call rather than
+    inventing a tool that doesn't exist)."""
+    match = _TEXT_TOOL_CALL_ID_RE.match(raw.strip())
+    return match.group("name") if match else ""
+
+
+def _parse_text_tool_calls(content: str) -> tuple[list[ToolCall], str]:
+    """Recover tool calls a model wrote into ``content`` as special tokens.
+
+    Returns ``(calls, content_without_the_markup)``. Returns ``([], content)``
+    unchanged when no marker is present, which is every well-behaved
+    provider — so the common path costs one substring check.
+
+    Tolerant of a truncated tail: a trailing call whose ``<|tool_call_end|>``
+    never arrived still yields a ToolCall from the rest of the content, since
+    the arguments are usually complete by then and re-asking would throw the
+    turn away.
+    """
+    if _TEXT_TOOL_CALL_BEGIN not in content:
+        return [], content
+
+    calls: list[ToolCall] = []
+    kept: list[str] = []
+    pos = 0
+    while True:
+        begin = content.find(_TEXT_TOOL_CALL_BEGIN, pos)
+        if begin < 0:
+            break
+        kept.append(content[pos:begin])
+        after_begin = begin + len(_TEXT_TOOL_CALL_BEGIN)
+        arg_sep = content.find(_TEXT_TOOL_CALL_ARGUMENT_BEGIN, after_begin)
+        if arg_sep < 0:
+            # No argument marker after this begin marker — nothing parseable
+            # is left, and whatever follows is not review prose either.
+            pos = len(content)
+            break
+        end = content.find(_TEXT_TOOL_CALL_END, arg_sep)
+        args_start = arg_sep + len(_TEXT_TOOL_CALL_ARGUMENT_BEGIN)
+        arguments = content[args_start : end if end >= 0 else len(content)].strip()
+        raw_id = content[after_begin:arg_sep].strip()
+        name = _split_text_tool_call_id(raw_id)
+        if name:
+            calls.append(
+                ToolCall(
+                    id=raw_id or f"call_{len(calls)}",
+                    name=name,
+                    arguments=arguments,
+                )
+            )
+        if end < 0:
+            pos = len(content)
+            break
+        pos = end + len(_TEXT_TOOL_CALL_END)
+    kept.append(content[pos:])
+
+    cleaned = "".join(kept)
+    for marker in (_TEXT_TOOL_CALLS_SECTION_BEGIN, _TEXT_TOOL_CALLS_SECTION_END):
+        cleaned = cleaned.replace(marker, "")
+    return calls, cleaned.strip()
 
 
 def _parse_tool_calls_from_message(raw: Any) -> list[ToolCall]:

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -9,7 +9,12 @@ from .compression import MessageCompressor
 from .config import Config
 from .context_script import run_context_script
 from .github_client import GitHubClient
-from .llm_client import ChatCompletionClient, ChatResult, ToolCall
+from .llm_client import (
+    ChatCompletionClient,
+    ChatResult,
+    ToolCall,
+    _parse_text_tool_calls,
+)
 from .patch import DiffSnippetLine, ParsedFile, extract_hunk_snippet, parse_patch
 from .prompts import (
     build_followup_system_prompt,
@@ -136,7 +141,9 @@ def _content_preview(text: str, limit: int = _PARSE_PREVIEW_CHARS) -> str:
     return text[:limit] + f"... [+{len(text) - limit} chars truncated]"
 
 
-def _extract_json(content: Optional[str]) -> dict[str, Any]:
+def _extract_json(
+    content: Optional[str], require_any_key: Optional[tuple[str, ...]] = None
+) -> dict[str, Any]:
     """Forgiving JSON extraction. Tries, in order:
 
     1. Direct parse of the stripped content.
@@ -147,6 +154,13 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
     The third pass means trailing prose after the JSON ("Hope this helps!")
     or surrounding chatter ("Sure, here you go: {...}") doesn't break us.
     Raises ValueError with a length-and-preview diagnostic when nothing parses.
+
+    ``require_any_key`` narrows what counts as a hit to objects carrying at
+    least one of those keys. Without it, pass 3 will happily return *any*
+    ``{...}`` in the reply — including a leaked tool call's own argument
+    object, which is how ``{"path": ..., "start_line": ...}`` was once
+    mistaken for a review and published as an empty summary (serge#79).
+    Callers that know their JSON contract should always pass it.
     """
     if not content:
         raise ValueError("LLM response was empty")
@@ -156,9 +170,14 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
 
     decoder = json.JSONDecoder()
 
+    def accept(obj: Any) -> bool:
+        if not isinstance(obj, dict):
+            return False
+        return require_any_key is None or any(k in obj for k in require_any_key)
+
     try:
         result = decoder.decode(text)
-        if isinstance(result, dict):
+        if accept(result):
             return result
     except json.JSONDecodeError:
         pass
@@ -171,7 +190,7 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
             result = json.loads(candidate)
         except json.JSONDecodeError:
             continue
-        if isinstance(result, dict):
+        if accept(result):
             return result
 
     for idx in (i for i, ch in enumerate(text) if ch == "{"):
@@ -179,13 +198,46 @@ def _extract_json(content: Optional[str]) -> dict[str, Any]:
             result, _ = decoder.raw_decode(text[idx:])
         except json.JSONDecodeError:
             continue
-        if isinstance(result, dict):
+        if accept(result):
             return result
 
+    expected = ""
+    if require_any_key is not None:
+        expected = f" with any of the keys {list(require_any_key)}"
     raise ValueError(
-        f"LLM response did not contain a JSON object "
+        f"LLM response did not contain a JSON object{expected} "
         f"(length={len(content)} chars, preview={_content_preview(text)!r})"
     )
+
+
+# The review JSON contract from prompts.py — at least one of these must be
+# present for a decoded object to be a review rather than incidental JSON.
+_REVIEW_JSON_KEYS = ("summary", "comments", "event")
+
+# Chat-template special tokens (`<|im_end|>`, `<|tool_call_begin|>`, …) that a
+# model can leak into its content. `llm_client` recovers leaked tool calls, so
+# reaching here means the leak wasn't a parseable tool call — treat text made of
+# nothing but these as no review at all rather than publishing the markup.
+_SPECIAL_TOKEN_RE = re.compile(r"<\|[^|>]*\|>")
+
+
+def _is_model_markup_only(text: str) -> bool:
+    """True when ``text`` is non-empty but says nothing — it is entirely a
+    leaked tool call, or entirely model special tokens.
+
+    The first check reuses the tool-call parser rather than stripping tokens,
+    because a leaked call leaves its own id and arguments between the tokens
+    (``functions.read_file:6``) and token-stripping alone would read that as
+    substance. Deliberately narrow: a legitimate review may quote
+    ``<|endoftext|>`` while discussing a tokenizer, so we only reject text
+    with *no* substance left — we never rewrite text that has some.
+    """
+    if not text.strip():
+        return False
+    calls, remainder = _parse_text_tool_calls(text)
+    if calls and not remainder.strip():
+        return True
+    return not _SPECIAL_TOKEN_RE.sub("", text).strip()
 
 
 def _prose_outside_json(content: Optional[str]) -> str:
@@ -1295,6 +1347,20 @@ def _load_review_rules(
     return content or cfg.default_review_rules
 
 
+class EmptyReviewError(Exception):
+    """``publish_review`` was handed a review with nothing in it — no summary
+    and no inline comments. Public (unlike ``_UnparseableLLMOutput``) because
+    the web app and the webhook publisher both need to catch it and report the
+    failure instead of posting an empty review."""
+
+    def user_message(self) -> str:
+        return (
+            "The model did not produce a usable review (no summary and no "
+            "inline comments), so nothing was posted. Re-run the review, or "
+            "try a different model."
+        )
+
+
 class _UnparseableLLMOutput(Exception):
     """The LLM returned content we couldn't parse as JSON. Carries the raw
     content + finish_reason + metrics line so the caller can render an
@@ -1511,7 +1577,7 @@ def prepare_review(
         _merge_metrics(total_metrics, chunk_metrics)
 
         try:
-            result = _extract_json(chat.content)
+            result = _extract_json(chat.content, _REVIEW_JSON_KEYS)
         except ValueError as exc:
             metrics_line = _format_aggregated_metrics(total_metrics)
             log.error(
@@ -1546,12 +1612,23 @@ def prepare_review(
             and chat.content
             and chat.content.strip()
         ):
-            summary = _prose_outside_json(chat.content) or chat.content.strip()
-            log.warning(
-                "Parsed JSON yielded empty summary/comments; using "
-                "raw content (%d chars) as summary",
-                len(summary),
-            )
+            salvaged = _prose_outside_json(chat.content) or chat.content.strip()
+            if _is_model_markup_only(salvaged):
+                # Nothing but leaked special tokens — publishing this is how
+                # serge#79 got a review body of raw `<|tool_call_begin|>`
+                # markup. Leave the summary empty so the publish gate refuses.
+                log.warning(
+                    "Discarding salvaged summary: content was only model "
+                    "special-token markup (%d chars)",
+                    len(salvaged),
+                )
+            else:
+                summary = salvaged
+                log.warning(
+                    "Parsed JSON yielded empty summary/comments; using "
+                    "raw content (%d chars) as summary",
+                    len(summary),
+                )
         if event not in ("COMMENT", "REQUEST_CHANGES", "APPROVE"):
             event = cfg.review_event
         if event == "APPROVE" and not cfg.allow_approve:
@@ -1703,15 +1780,33 @@ def publish_review(
 
     Returns the *effective* ReviewDraft that was actually posted (edits
     applied, event downgraded). Callers persist this so the audit log
-    records exactly what GitHub received rather than the raw draft."""
+    records exactly what GitHub received rather than the raw draft.
+
+    Raises :class:`EmptyReviewError` when there is nothing to say — no summary
+    and no inline comments. Such a review is never useful to a human, and
+    posting it is what turned a model malfunction into a public "(no overall
+    summary provided)" (or worse, raw special-token markup) on the PR."""
     effective = effective_draft(draft, edits, allow_approve=cfg.allow_approve)
+
+    summary_text = (effective.summary or "").strip()
+    if _is_model_markup_only(summary_text):
+        summary_text = ""
+    if not summary_text and not effective.comments:
+        raise EmptyReviewError(
+            f"refusing to publish an empty review on {effective.owner}/"
+            f"{effective.repo}#{effective.number}: no summary and no inline "
+            "comments"
+        )
 
     comments_payload: list[dict[str, Any]] = [
         {"path": c.path, "side": c.side, "line": c.line, "body": c.body}
         for c in effective.comments
     ]
 
-    body = effective.summary or "(no overall summary provided)"
+    # `summary_text` (not `effective.summary`) so a markup-only summary that
+    # rode along with real inline comments renders the fallback line rather
+    # than the leaked tokens.
+    body = summary_text or "(no overall summary provided)"
     if cfg.persona_header:
         body = f"{cfg.persona_header}\n\n{body}"
     if effective.rejected_count:
@@ -1779,7 +1874,13 @@ def run_review(
     if draft is None:
         return
     edits = ReviewEdits(event="COMMENT") if force_comment_event else None
-    publish_review(cfg, gh, draft, edits=edits)
+    try:
+        publish_review(cfg, gh, draft, edits=edits)
+    except EmptyReviewError as exc:
+        # Say so in the thread the reviewer is watching; silently posting
+        # nothing looks identical to serge never having run.
+        log.warning("empty review not published: %s", exc)
+        gh.post_issue_comment(req.owner, req.repo, req.number, exc.user_message())
 
 
 _FOLLOWUP_FORCE_FINAL_MESSAGE = (

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -57,6 +57,11 @@ log = logging.getLogger(__name__)
 
 _NORMALIZE_FEEDBACK_CHARS = 80_000
 
+# The task JSON contract from prompts.py. Passed to `_extract_json` so a stray
+# `{...}` in the reply — notably a leaked tool call's own argument object —
+# can't be mistaken for the task result.
+_TASK_JSON_KEYS = ("title", "body", "patch")
+
 # Serge only ever writes inside its own branch namespace. ``existing_pr``
 # mode is rejected for any head branch outside it, so the OIDC
 # ``repository`` claim cannot be leveraged to push to an arbitrary PR.
@@ -404,7 +409,7 @@ def _validate_patch(
     assert command is not None
 
     try:
-        result = _extract_json(content)
+        result = _extract_json(content, _TASK_JSON_KEYS)
     except ValueError:
         # Unparseable — not something the normalizer can speak to. Accept here
         # and let prepare_task's own extraction raise the proper error.
@@ -581,7 +586,7 @@ def prepare_task(
     _emit("log", f"LLM done: {metrics_line}")
 
     try:
-        result = _extract_json(chat.content)
+        result = _extract_json(chat.content, _TASK_JSON_KEYS)
     except ValueError as exc:
         raise _UnparseableLLMOutput(
             content=chat.content or "",

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -71,6 +71,7 @@ from .llm_client import ChatCompletionClient, LLMResponseError
 from .oidc import OIDCError, verify_token
 from .reviewer import (
     DraftComment,
+    EmptyReviewError,
     ReviewDraft,
     ReviewEdits,
     ReviewRequest,
@@ -1023,6 +1024,17 @@ def _execute_review(
         _push_event(job, "step", "error")
         _push_event(job, "error", job.error)
         _push_event(job, "done", "")
+    except EmptyReviewError as exc:
+        # The model produced nothing publishable. A real failure, not a crash:
+        # report it as one rather than posting an empty review to the PR.
+        log.warning("review %s produced nothing publishable: %s", job.id, exc)
+        job.status = "error"
+        job.error = exc.user_message()
+        if auto_publish:
+            _post_webhook_failure_comment(gh, req, job.error)
+        _push_event(job, "step", "error")
+        _push_event(job, "error", job.error)
+        _push_event(job, "done", "")
     except AppNotInstalledError as exc:
         # Expected failure mode — the App isn't installed on the target
         # repo. Surface the actionable message verbatim instead of the
@@ -1735,6 +1747,15 @@ def _webhook_publish_or_report(job: Job) -> None:
             # produced (APPROVE may be downgraded inside publish_review).
             job.published_draft = publish_review(worker_cfg, gh, job.draft)
             job.status = "published"
+        except EmptyReviewError as exc:
+            # Nothing publishable came out of the model. Record it as an error
+            # and tell the human who triggered the review, instead of leaving
+            # the job looking done with no review on the PR.
+            log.warning("webhook auto-publish: %s", exc)
+            job.status = "error"
+            job.error = str(exc)
+            if isinstance(req, ReviewRequest):
+                _post_webhook_failure_comment(gh, req, exc.user_message())
         except Exception:  # noqa: BLE001
             log.exception("webhook auto-publish failed for job %s", job.id)
 
@@ -3685,7 +3706,13 @@ async def publish(
     # Persist exactly what publish_review posted — including any APPROVE ->
     # COMMENT downgrade — instead of re-deriving the draft separately (which
     # could drift from the publish path).
-    job.published_draft = publish_review(cfg, gh, job.draft, edits=edits)
+    try:
+        job.published_draft = publish_review(cfg, gh, job.draft, edits=edits)
+    except EmptyReviewError as exc:
+        # 409: the human can still fix this by editing the summary in the UI
+        # and hitting publish again, so it's a conflict, not a server error.
+        log.warning("publish refused for job %s: %s", job.id, exc)
+        raise HTTPException(status_code=409, detail="empty_review") from exc
     job.status = "published"
     job.review_edits = _review_edits_to_dict(edits)
     _store.update_status(job.id, "published")

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock, patch
 
 import requests
 
-from reviewbot.llm_client import ChatCompletionClient, LLMResponseError
+from reviewbot.llm_client import (
+    ChatCompletionClient,
+    LLMResponseError,
+    _parse_text_tool_calls,
+)
 
 
 def _interrupted_iter_lines(prefix_lines: list[str], exc: Exception):
@@ -805,6 +809,175 @@ class ChatCompletionClientTests(unittest.TestCase):
             ChatCompletionClient("https://api.openai.com/v1", "sk").list_models()
 
         self.assertNotIn("anthropic-version", mock_get.call_args.kwargs["headers"])
+
+
+class TextToolCallRecoveryTests(unittest.TestCase):
+    """Kimi models on the HF Router sometimes write a tool call into
+    `message.content` as raw chat-template special tokens and leave the
+    structured `tool_calls` field empty, with finish_reason="stop". The agent
+    loop then reads it as a final answer — which published a review body of
+    nothing but that markup (serge#79). Recover the call instead."""
+
+    # The exact content moonshotai/Kimi-K2.6 returned on the serge#79 run.
+    PROD_CONTENT = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file:6"
+        '<|tool_call_argument_begin|>{"path": "reviewbot/reviewer.py", '
+        '"start_line": 248, "end_line": 280}<|tool_call_end|>'
+        "<|tool_calls_section_end|>"
+    )
+
+    def test_recovers_the_prod_payload(self) -> None:
+        calls, content = _parse_text_tool_calls(self.PROD_CONTENT)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "read_file")
+        self.assertEqual(calls[0].id, "functions.read_file:6")
+        self.assertEqual(
+            json.loads(calls[0].arguments),
+            {"path": "reviewbot/reviewer.py", "start_line": 248, "end_line": 280},
+        )
+        # Nothing but markup went in, so no content survives.
+        self.assertEqual(content, "")
+
+    def test_content_without_markers_is_returned_untouched(self) -> None:
+        calls, content = _parse_text_tool_calls("A normal review summary.")
+        self.assertEqual(calls, [])
+        self.assertEqual(content, "A normal review summary.")
+
+    def test_recovers_multiple_calls(self) -> None:
+        content = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>functions.read_file:0<|tool_call_argument_begin|>{"path": "a.py"}<|tool_call_end|>'
+            '<|tool_call_begin|>functions.grep:1<|tool_call_argument_begin|>{"q": "x"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>"
+        )
+        calls, _ = _parse_text_tool_calls(content)
+        self.assertEqual([c.name for c in calls], ["read_file", "grep"])
+        self.assertEqual(
+            [c.arguments for c in calls], ['{"path": "a.py"}', '{"q": "x"}']
+        )
+
+    def test_keeps_prose_written_around_the_markup(self) -> None:
+        content = (
+            "Let me check that file.\n"
+            "<|tool_call_begin|>read_file<|tool_call_argument_begin|>"
+            '{"path": "a.py"}<|tool_call_end|>\nThen I will decide.'
+        )
+        calls, cleaned = _parse_text_tool_calls(content)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "read_file")
+        self.assertEqual(cleaned, "Let me check that file.\n\nThen I will decide.")
+
+    def test_truncated_trailing_call_still_recovers(self) -> None:
+        # `<|tool_call_end|>` never arrived — the arguments are complete
+        # anyway, so use them rather than throwing the whole turn away.
+        content = (
+            "<|tool_call_begin|>functions.read_file:2<|tool_call_argument_begin|>"
+            '{"path": "a.py"}'
+        )
+        calls, cleaned = _parse_text_tool_calls(content)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].arguments, '{"path": "a.py"}')
+        self.assertEqual(cleaned, "")
+
+    def test_call_with_no_argument_marker_is_dropped(self) -> None:
+        calls, _ = _parse_text_tool_calls("<|tool_call_begin|>functions.read_file:1")
+        self.assertEqual(calls, [])
+
+    def test_unrecognizable_id_is_dropped_not_invented(self) -> None:
+        content = (
+            "<|tool_call_begin|>not a tool id!<|tool_call_argument_begin|>"
+            "{}<|tool_call_end|>"
+        )
+        calls, _ = _parse_text_tool_calls(content)
+        self.assertEqual(calls, [])
+
+    def test_bare_name_without_namespace_or_index(self) -> None:
+        content = "<|tool_call_begin|>read_file<|tool_call_argument_begin|>{}<|tool_call_end|>"
+        calls, _ = _parse_text_tool_calls(content)
+        self.assertEqual([c.name for c in calls], ["read_file"])
+
+    def test_complete_recovers_on_the_buffered_path(self) -> None:
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                raise_for_status=Mock(),
+                json=Mock(
+                    return_value={
+                        "choices": [
+                            {
+                                "message": {"content": self.PROD_CONTENT},
+                                "finish_reason": "stop",
+                            }
+                        ]
+                    }
+                ),
+            )
+            client = ChatCompletionClient(
+                "https://example.com/v1", "token", "moonshotai/Kimi-K2.6"
+            )
+            result = client.complete([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].name, "read_file")
+        self.assertEqual(result.content, "")
+
+    def test_complete_recovers_on_the_streaming_path(self) -> None:
+        sse_lines = [
+            "data: "
+            + json.dumps({"choices": [{"delta": {"content": self.PROD_CONTENT}}]}),
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                raise_for_status=Mock(),
+                iter_lines=Mock(return_value=iter(sse_lines)),
+            )
+            client = ChatCompletionClient(
+                "https://example.com/v1",
+                "token",
+                "moonshotai/Kimi-K2.6",
+                stream=True,
+            )
+            result = client.complete([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].name, "read_file")
+
+    def test_structured_tool_calls_win_over_text_markup(self) -> None:
+        with patch("reviewbot.llm_client.requests.post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=200,
+                raise_for_status=Mock(),
+                json=Mock(
+                    return_value={
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": self.PROD_CONTENT,
+                                    "tool_calls": [
+                                        {
+                                            "id": "call_a",
+                                            "function": {
+                                                "name": "grep",
+                                                "arguments": '{"q": "x"}',
+                                            },
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ]
+                    }
+                ),
+            )
+            client = ChatCompletionClient("https://example.com/v1", "token", "m")
+            result = client.complete([{"role": "user", "content": "hi"}])
+
+        self.assertEqual([c.name for c in result.tool_calls], ["grep"])
+        # The structured field was authoritative, so content is left alone.
+        self.assertEqual(result.content, self.PROD_CONTENT)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_review.py
+++ b/tests/test_publish_review.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from reviewbot.config import Config
 from reviewbot.reviewer import (
     DraftComment,
+    EmptyReviewError,
     ReviewDraft,
     ReviewEdits,
     ReviewRequest,
@@ -212,6 +213,106 @@ class PublishReviewTests(unittest.TestCase):
         publish_review(cfg, gh, draft)
         body = gh.create_review.call_args.kwargs["body"]
         self.assertIn("(no overall summary provided)", body)
+
+
+class EmptyReviewGateTests(unittest.TestCase):
+    """A review with nothing in it must not reach GitHub. serge#79 published a
+    body of raw `<|tool_call_begin|>` markup with zero inline comments; the
+    fallback line "(no overall summary provided)" with zero comments is just as
+    useless. Refuse both, so the failure is reported instead of posted."""
+
+    # The summary that actually reached the PR on serge#79.
+    LEAKED_MARKUP = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file:6"
+        "<|tool_call_argument_begin|>\n\n<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    )
+
+    def test_leaked_markup_summary_with_no_comments_is_refused(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary=self.LEAKED_MARKUP, comments=[])
+        gh = MagicMock()
+        with self.assertRaises(EmptyReviewError):
+            publish_review(cfg, gh, draft)
+        gh.create_review.assert_not_called()
+
+    def test_no_summary_and_no_comments_is_refused(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="", comments=[])
+        gh = MagicMock()
+        with self.assertRaises(EmptyReviewError) as ctx:
+            publish_review(cfg, gh, draft)
+        self.assertIn("acme/widgets#42", str(ctx.exception))
+        gh.create_review.assert_not_called()
+
+    def test_whitespace_summary_and_no_comments_is_refused(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="   \n\t ", comments=[])
+        gh = MagicMock()
+        with self.assertRaises(EmptyReviewError):
+            publish_review(cfg, gh, draft)
+
+    def test_all_comments_discarded_leaves_nothing_to_publish(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="")
+        gh = MagicMock()
+        edits = ReviewEdits(discarded_comment_ids={"c0", "c1"})
+        with self.assertRaises(EmptyReviewError):
+            publish_review(cfg, gh, draft, edits=edits)
+        gh.create_review.assert_not_called()
+
+    def test_summary_only_review_still_publishes(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="No issues found.", comments=[])
+        gh = MagicMock()
+        publish_review(cfg, gh, draft)
+        self.assertIn("No issues found.", gh.create_review.call_args.kwargs["body"])
+
+    def test_comments_only_review_still_publishes(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="")
+        gh = MagicMock()
+        publish_review(cfg, gh, draft)
+        self.assertEqual(len(gh.create_review.call_args.kwargs["comments"]), 2)
+
+    def test_markup_summary_with_comments_renders_fallback_not_markup(self) -> None:
+        # Real inline comments carry the review, so publishing is right — but
+        # the leaked tokens must not become the body.
+        cfg = _make_cfg()
+        draft = _make_draft(summary=self.LEAKED_MARKUP)
+        gh = MagicMock()
+        publish_review(cfg, gh, draft)
+        body = gh.create_review.call_args.kwargs["body"]
+        self.assertNotIn("tool_call_begin", body)
+        self.assertIn("(no overall summary provided)", body)
+
+    def test_review_quoting_a_special_token_is_published_verbatim(self) -> None:
+        cfg = _make_cfg()
+        summary = "The test appends `<|endoftext|>`, which matches the tokenizer."
+        draft = _make_draft(summary=summary, comments=[])
+        gh = MagicMock()
+        publish_review(cfg, gh, draft)
+        self.assertIn(summary, gh.create_review.call_args.kwargs["body"])
+
+    def test_run_review_reports_an_empty_review_to_the_pr(self) -> None:
+        cfg = _make_cfg()
+        draft = _make_draft(summary="", comments=[])
+        gh = MagicMock()
+        req = ReviewRequest(
+            owner="acme",
+            repo="widgets",
+            number=42,
+            trigger_comment_id=123,
+            trigger_comment_body="@askserge please review",
+            commenter="reviewer",
+        )
+        with patch("reviewbot.reviewer.prepare_review", return_value=draft):
+            run_review(cfg, gh, req)
+
+        gh.create_review.assert_not_called()
+        gh.post_issue_comment.assert_called_once()
+        posted = gh.post_issue_comment.call_args.args[-1]
+        self.assertIn("did not produce a usable review", posted)
 
     def test_run_review_can_force_comment_event_for_direct_publish(self) -> None:
         cfg = _make_cfg()

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,7 +1,10 @@
 import json
+import os
+import tempfile
 import unittest
+from unittest.mock import Mock, patch
 
-from reviewbot.llm_client import ChatResult, ToolCall
+from reviewbot.llm_client import ChatCompletionClient, ChatResult, ToolCall
 from reviewbot.patch import parse_patch
 from reviewbot.tools import ToolEnv
 from reviewbot.reviewer import (
@@ -13,8 +16,10 @@ from reviewbot.reviewer import (
     _content_preview,
     _emit_chat_message,
     _final_recovery_message,
+    _is_model_markup_only,
     _needs_final_salvage,
     _extract_json,
+    _REVIEW_JSON_KEYS,
     _merge_chunk_event,
     _merge_chunk_summaries,
     _prose_outside_json,
@@ -225,6 +230,84 @@ class ExtractJsonTests(unittest.TestCase):
             _extract_json(content),
             {"summary": "use { and } carefully", "comments": []},
         )
+
+
+class ExtractJsonRequiredKeysTests(unittest.TestCase):
+    """`require_any_key` stops the forgiving raw_decode pass from returning
+    incidental JSON. Without it a leaked tool call's own argument object was
+    accepted as a review, yielding an empty summary that got published as raw
+    special-token markup (serge#79)."""
+
+    # The tool-call arguments Kimi leaked into content on the serge#79 run.
+    LEAKED_ARGS = (
+        '{"path": "reviewbot/reviewer.py", "start_line": 248, "end_line": 280}'
+    )
+
+    def test_leaked_tool_arguments_are_rejected_as_a_review(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _extract_json(self.LEAKED_ARGS, _REVIEW_JSON_KEYS)
+        msg = str(ctx.exception)
+        self.assertIn("did not contain a JSON object", msg)
+        self.assertIn("summary", msg)
+
+    def test_same_content_is_still_accepted_without_the_filter(self) -> None:
+        # Default behaviour is unchanged for callers that don't opt in.
+        self.assertEqual(
+            _extract_json(self.LEAKED_ARGS)["path"], "reviewbot/reviewer.py"
+        )
+
+    def test_review_object_passes_the_filter(self) -> None:
+        content = '{"summary": "ok", "comments": [], "event": "COMMENT"}'
+        self.assertEqual(_extract_json(content, _REVIEW_JSON_KEYS)["summary"], "ok")
+
+    def test_any_single_contract_key_is_enough(self) -> None:
+        self.assertEqual(
+            _extract_json('{"event": "APPROVE"}', _REVIEW_JSON_KEYS),
+            {"event": "APPROVE"},
+        )
+
+    def test_skips_a_non_review_object_and_finds_the_review_after_it(self) -> None:
+        content = f'Reading: {self.LEAKED_ARGS}\n\n{{"summary": "the real review"}}'
+        self.assertEqual(
+            _extract_json(content, _REVIEW_JSON_KEYS),
+            {"summary": "the real review"},
+        )
+
+    def test_filter_also_applies_to_fenced_blocks(self) -> None:
+        content = (
+            f'```json\n{self.LEAKED_ARGS}\n```\n```json\n{{"summary": "real"}}\n```'
+        )
+        self.assertEqual(_extract_json(content, _REVIEW_JSON_KEYS), {"summary": "real"})
+
+
+class ModelMarkupOnlyTests(unittest.TestCase):
+    def test_leaked_tool_call_markup_is_markup_only(self) -> None:
+        # What actually got published on serge#79, once `_prose_outside_json`
+        # had removed the JSON arguments from the middle of it.
+        self.assertTrue(
+            _is_model_markup_only(
+                "<|tool_calls_section_begin|><|tool_call_begin|>"
+                "functions.read_file:6<|tool_call_argument_begin|>\n\n"
+                "<|tool_call_end|><|tool_calls_section_end|>"
+            )
+        )
+
+    def test_real_review_is_not_markup_only(self) -> None:
+        self.assertFalse(_is_model_markup_only("This patch looks correct."))
+
+    def test_review_quoting_a_special_token_is_not_markup_only(self) -> None:
+        # A tokenizer review may legitimately mention these tokens; we must
+        # not treat such a review as garbage.
+        self.assertFalse(
+            _is_model_markup_only(
+                "The test asserts `<|endoftext|>` is appended, which is right."
+            )
+        )
+
+    def test_empty_and_whitespace_are_not_markup_only(self) -> None:
+        # "" means "no summary", which the publish gate handles separately.
+        self.assertFalse(_is_model_markup_only(""))
+        self.assertFalse(_is_model_markup_only("   \n\t "))
 
 
 class ProseOutsideJsonTests(unittest.TestCase):
@@ -845,6 +928,83 @@ class TruncationRecoveryTests(unittest.TestCase):
         # Initial answer + _MAX_TRUNCATION_RETRIES recovery attempts.
         self.assertEqual(len(llm.calls), 1 + _MAX_TRUNCATION_RETRIES)
         self.assertEqual(chat.finish_reason, "length")
+
+
+class LeakedTextToolCallLoopTests(unittest.TestCase):
+    """End-to-end regression for serge#79: Kimi wrote a tool call into
+    `message.content` as special tokens with an empty `tool_calls` field and
+    finish_reason="stop". The loop read that as the final answer and the markup
+    was published as the review body. Drives the *real* client (mocked HTTP) so
+    the whole chain — parse, recover, execute, continue — is covered."""
+
+    LEAKED = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file:6"
+        '<|tool_call_argument_begin|>{"path": "hello.py"}<|tool_call_end|>'
+        "<|tool_calls_section_end|>"
+    )
+
+    @staticmethod
+    def _response(body: dict) -> Mock:
+        return Mock(
+            status_code=200, raise_for_status=Mock(), json=Mock(return_value=body)
+        )
+
+    def _turn(self, content: str) -> Mock:
+        return self._response(
+            {
+                "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10},
+            }
+        )
+
+    def test_leaked_tool_call_keeps_the_loop_going(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, "hello.py"), "w") as fh:
+                fh.write("print('the file the model asked for')\n")
+
+            final = '{"summary": "reviewed hello.py", "comments": []}'
+            with patch(
+                "reviewbot.llm_client.requests.post",
+                side_effect=[self._turn(self.LEAKED), self._turn(final)],
+            ) as mock_post:
+                llm = ChatCompletionClient(
+                    "https://example.com/v1", "token", "moonshotai/Kimi-K2.6"
+                )
+                chat, metrics = _run_agentic_loop(
+                    llm,
+                    [{"role": "user", "content": "review this"}],
+                    cfg=_CfgStub(),  # type: ignore[arg-type]
+                    tool_env=ToolEnv(repo_root=repo),
+                )
+
+            # The turn was treated as a tool turn, not as the final answer.
+            self.assertEqual(metrics.tool_calls, 1)
+            self.assertEqual(chat.content, final)
+            self.assertEqual(mock_post.call_count, 2)
+
+            # The second request carried the executed tool's output back, so the
+            # model actually got the file it asked for.
+            follow_up = json.loads(mock_post.call_args_list[1].kwargs["data"])
+            tool_msgs = [m for m in follow_up["messages"] if m["role"] == "tool"]
+            self.assertEqual(len(tool_msgs), 1)
+            self.assertEqual(tool_msgs[0]["name"], "read_file")
+            self.assertIn("the file the model asked for", tool_msgs[0]["content"])
+
+            # The assistant turn that requested it round-trips as a structured
+            # tool_calls message, with the markup stripped from its content.
+            assistant = [
+                m
+                for m in follow_up["messages"]
+                if m["role"] == "assistant" and m.get("tool_calls")
+            ]
+            self.assertEqual(len(assistant), 1)
+            self.assertIsNone(assistant[0]["content"])
+
+    def test_final_review_is_parsed_not_the_leaked_tool_arguments(self) -> None:
+        # The second half of the serge#79 chain: even if the markup does reach
+        # the parser, the leaked arguments must not pass as a review.
+        with self.assertRaises(ValueError):
+            _extract_json(self.LEAKED, _REVIEW_JSON_KEYS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What happened

[This review](https://github.com/huggingface/serge/pull/79#pullrequestreview-4796014147) was published on #79 with a body of nothing but Kimi's raw tool-call markup and zero inline comments:

```
🤗 **Serge** says:

<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file:6<|tool_call_argument_begin|>

<|tool_call_end|><|tool_calls_section_end|>
```

## Root cause — three defects compounding

1. **The provider leaked a tool call as text.** On turn 8, `moonshotai/Kimi-K2.6` via the HF Router serialized its tool call into `message.content` using chat-template special tokens, left `message.tool_calls` empty, and returned `finish_reason: "stop"`. `_run_agentic_loop` took the `not chat.tool_calls` branch and treated it as the final answer. `_needs_final_salvage` didn't fire either — the content wasn't blank and the finish reason wasn't `length`.

2. **`_extract_json` accepted the tool arguments as the review.** Its third pass (`raw_decode` at every `{`) parsed the leaked call's own argument object, `{"path": "reviewbot/reviewer.py", "start_line": 248, "end_line": 280}`, so no `_UnparseableLLMOutput` was raised.

3. **The empty-summary salvage published the markup.** With `summary=""` and no comments, the stub-JSON fallback called `_prose_outside_json`, which stripped the JSON and returned the surrounding special tokens as the summary. `publish_review` posted it.

Reproduced byte-for-byte against the persisted job row before fixing.

## Scope

The serge#79 review is the one confirmed occurrence. A first scan of the prod jobs DB also flagged a `/tasks` run (Kimi-K2.7-Code, ended `no_fix`, nothing published), but that row has since been evicted by `WEB_JOB_RETENTION=25` — the table is a rolling window of the 25 most recent jobs — so it can no longer be verified. Treat the prevalence as "seen more than once on Kimi, never on another model", not as a measured rate.

## The fix

Each defect is fixed at its own layer, so no single one has to hold alone.

**`llm_client`** — recover text-serialized tool calls into real `ToolCall` objects and strip the markup from the content, so the turn stays a tool turn and the model gets the file it asked for. Covers the streaming and buffered paths (they converge on one place). Structured `tool_calls` still wins whenever the provider sends them. Tolerant of a truncated tail; drops a call whose id isn't recognizable rather than inventing a tool name.

**`_extract_json`** — new optional `require_any_key`. The review caller passes `("summary", "comments", "event")` and the task callers pass `("title", "body", "patch")`, so incidental JSON can't pass as a result. **Default behaviour is unchanged** for any caller that doesn't opt in.

**`publish_review`** — raises the new `EmptyReviewError` instead of posting a review with no summary and no inline comments, and a summary that is only leaked markup counts as no summary. A markup-only summary that arrives *with* real inline comments still publishes, but renders the `(no overall summary provided)` line rather than the tokens. All three publish paths report the failure rather than swallowing it:

- webhook auto-publish → marks the job `error` and posts a failure comment
- `run_review` → posts a comment in the thread
- the UI publish endpoint → `409 empty_review`, so the human can edit the summary and retry

A legitimate review that quotes a special token (`<|endoftext|>` while discussing a tokenizer) is deliberately left untouched — the check only rejects text with no substance left, it never rewrites text that has some.

## Tests

29 new tests; 596 pass, `make format` clean.

- `TextToolCallRecoveryTests` — the exact prod payload, multiple calls, prose around the markup, truncated tail, unrecognizable id, both HTTP paths, structured-wins
- `LeakedTextToolCallLoopTests` — end-to-end through the *real* client with mocked HTTP: the leaked turn executes `read_file`, the output comes back as a `tool` message, the loop reaches a proper review
- `ExtractJsonRequiredKeysTests` — the leaked arguments are rejected as a review but still accepted without the filter
- `ModelMarkupOnlyTests`, `EmptyReviewGateTests` — the publish gate, including the quoted-special-token case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
