### PR TITLE
Retry transient GitHub errors, where replaying is safe

### DIFF
--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import time
 from typing import Any, Callable, Optional
 
 import requests
@@ -15,48 +16,165 @@ SERGE_GIT_NAME = "serge[bot]"
 SERGE_GIT_EMAIL = "serge[bot]@users.noreply.github.com"
 
 
+# api.github.com returns these when a gateway or backend hiccups, with no bearing
+# on the request itself — a replay usually succeeds. Prod lost a finished,
+# GPU-verified fix to a single `502 Bad Gateway` on a *read*
+# (``GET /git/commits/<sha>``) at the commit step (transformers#47605).
+_TRANSIENT_STATUSES = frozenset({500, 502, 503, 504})
+_TRANSIENT_EXCEPTIONS = (
+    requests.ConnectionError,
+    requests.Timeout,
+    requests.exceptions.ChunkedEncodingError,
+)
+# POST endpoints where a replay cannot duplicate anything: both are
+# content-addressed, so re-sending identical bytes returns the same SHA and
+# creates nothing new. Everything else that writes is left alone — see
+# :func:`_is_replay_safe`.
+_REPLAY_SAFE_POST_PATHS = ("/git/blobs", "/git/trees")
+_MAX_ATTEMPTS = 3
+_BACKOFF_SECONDS = (1.0, 3.0)
+_MAX_RETRY_AFTER = 30.0
+
+
+def _is_replay_safe(method: str, url: str) -> bool:
+    """Whether replaying this request cannot duplicate a side effect.
+
+    Reads are always safe. Writes are deliberately *not*, because a 5xx is
+    ambiguous — the write may well have landed and only the response got lost, so
+    a blind replay could double-post a review comment or turn a successful
+    ``create_ref`` into a confusing 422. The two exceptions are blobs and trees:
+    Git object creation is content-addressed, so replaying returns the identical
+    SHA and creates nothing.
+
+    Consequence: a 502 on ``create_ref``/``create_commit``/a comment still fails
+    the task. That is the safe direction — a lost run is recoverable, a duplicate
+    comment or a mangled branch is noise a human has to clean up."""
+    verb = method.upper()
+    if verb in ("GET", "HEAD"):
+        return True
+    if verb == "POST":
+        return any(url.endswith(path) for path in _REPLAY_SAFE_POST_PATHS)
+    return False
+
+
+def _retry_delay(response: Optional[requests.Response], attempt: int) -> float:
+    """Backoff before attempt ``attempt`` (1-based), honouring ``Retry-After``."""
+    if response is not None:
+        raw = response.headers.get("Retry-After")
+        if raw:
+            try:
+                return min(float(raw), _MAX_RETRY_AFTER)
+            except (TypeError, ValueError):
+                pass
+    index = min(attempt - 1, len(_BACKOFF_SECONDS) - 1)
+    return _BACKOFF_SECONDS[index]
+
+
 class _AuthRetrySession(requests.Session):
-    """A session that re-mints its token on a ``401`` and replays the request.
+    """A session that repairs the two failures that cost prod finished work.
 
-    GitHub App installation tokens are valid for **one hour**. A ``/tasks`` run
-    that spends longer than that in the agentic loop plus the repo normalizer
-    reaches the publish step holding a dead token, and every write fails with
-    ``401 Bad credentials`` — the fix is finished but unpublishable, and the
-    whole run is wasted. Observed repeatedly in prod on runs of 65-67 minutes.
+    **Expired token (401).** GitHub App installation tokens are valid for exactly
+    one hour. A ``/tasks`` run that spends longer than that in the agentic loop
+    plus the repo normalizer reaches the publish step holding a dead token, and
+    every write fails ``401 Bad credentials`` — the fix is written, validated and
+    GPU-verified, then thrown away. Rather than refresh on a timer (which needs a
+    clock nobody owns and still races a request in flight), the request that
+    *discovers* the expiry fixes it: ask ``token_provider`` for a fresh token,
+    restamp the header, replay. Confirmed firing in prod at 60m01s.
 
-    Rather than refresh on a timer (which needs a clock nobody owns and still
-    races a request in flight), let the request that *discovers* the expiry fix
-    it: ask ``token_provider`` for a fresh token, restamp the header, replay
-    once. Overriding :meth:`requests.Session.request` — the single funnel every
+    **Transient gateway error (5xx / dropped connection).** Same shape, different
+    cause: a single ``502 Bad Gateway`` from api.github.com killed a finished
+    qwen3_omni_moe fix at its commit step (transformers#47605). Retried with a
+    short backoff, but *only* where a replay cannot duplicate a side effect (see
+    :func:`_is_replay_safe`).
+
+    Overriding :meth:`requests.Session.request` — the single funnel every
     ``get``/``post``/``patch`` helper goes through — covers every call site in
     :class:`GitHubClient`, present and future, with no per-method plumbing.
 
-    Only ever replays once, and only when the fresh token actually differs: a
-    401 from a genuinely bad token (wrong App, revoked install) must surface as
-    a 401 rather than double every request."""
+    The two cases are replayed under deliberately different rules. A **401 is
+    unambiguous**: the request was rejected, so nothing happened, so replaying any
+    method is safe — including a comment or a ref update. A **5xx is ambiguous**:
+    the write may have landed with only the response lost, so replaying is
+    restricted to requests where that cannot matter.
+
+    The token is re-minted at most once per request, and only when the fresh one
+    actually differs: a 401 from a genuinely bad token (wrong App, revoked
+    install) must surface as a 401 rather than double every request."""
 
     def __init__(self, token_provider: Optional[Callable[[], str]] = None):
         super().__init__()
         self._token_provider = token_provider
 
-    def request(  # type: ignore[override]
-        self, method: str, url: str, **kwargs: Any
-    ) -> requests.Response:
-        response = super().request(method, url, **kwargs)
-        if response.status_code != 401 or self._token_provider is None:
-            return response
+    def _refreshed_token(self) -> Optional[str]:
+        """A replacement token that differs from the one in use, else ``None``."""
+        if self._token_provider is None:
+            return None
         try:
             token = self._token_provider()
         except Exception:  # noqa: BLE001
-            # Refresh is best-effort: on failure return the original 401 so the
-            # caller reports the real GitHub error, not a refresh stacktrace.
+            # Refresh is best-effort: on failure keep the original response so
+            # the caller reports the real GitHub error, not a refresh stacktrace.
             log.warning("token refresh after 401 failed", exc_info=True)
-            return response
+            return None
         if not token or self.headers.get("Authorization") == f"Bearer {token}":
+            return None
+        return token
+
+    def request(  # type: ignore[override]
+        self, method: str, url: str, **kwargs: Any
+    ) -> requests.Response:
+        refreshed = False
+        attempt = 0
+        while True:
+            try:
+                response: Optional[requests.Response] = super().request(
+                    method, url, **kwargs
+                )
+            except _TRANSIENT_EXCEPTIONS as exc:
+                attempt += 1
+                if attempt >= _MAX_ATTEMPTS or not _is_replay_safe(method, url):
+                    raise
+                delay = _retry_delay(None, attempt)
+                log.warning(
+                    "%s %s failed (%s); retrying in %.1fs (attempt %d/%d)",
+                    method,
+                    url,
+                    exc.__class__.__name__,
+                    delay,
+                    attempt + 1,
+                    _MAX_ATTEMPTS,
+                )
+                time.sleep(delay)
+                continue
+
+            assert response is not None
+            if response.status_code == 401 and not refreshed:
+                refreshed = True
+                token = self._refreshed_token()
+                if token is not None:
+                    log.info("got 401 from %s; re-minted the token and retrying", url)
+                    self.headers["Authorization"] = f"Bearer {token}"
+                    continue
+                return response
+
+            if response.status_code in _TRANSIENT_STATUSES:
+                attempt += 1
+                if attempt < _MAX_ATTEMPTS and _is_replay_safe(method, url):
+                    delay = _retry_delay(response, attempt)
+                    log.warning(
+                        "%s %s returned %d; retrying in %.1fs (attempt %d/%d)",
+                        method,
+                        url,
+                        response.status_code,
+                        delay,
+                        attempt + 1,
+                        _MAX_ATTEMPTS,
+                    )
+                    time.sleep(delay)
+                    continue
+
             return response
-        log.info("got 401 from %s; re-minted the token and retrying once", url)
-        self.headers["Authorization"] = f"Bearer {token}"
-        return super().request(method, url, **kwargs)
 
 
 class GitHubClient:

--- a/tests/test_github_token_refresh.py
+++ b/tests/test_github_token_refresh.py
@@ -1,10 +1,15 @@
-"""Tests for surviving GitHub installation-token expiry mid-task.
+"""Tests for surviving the two mid-task failures that cost prod finished work.
 
-Installation tokens last one hour. A ``/tasks`` run longer than that reached the
-publish step with a dead token and lost all its work to ``401 Bad credentials``
-(observed on three prod runs of 65-67 minutes). Two pieces cover it: the client
-session replays a 401 once with a re-minted token, and the runner asks serge for
-that token over the existing authenticated callback channel.
+**Expired token.** Installation tokens last one hour. A ``/tasks`` run longer
+than that reached the publish step with a dead token and lost everything to
+``401 Bad credentials`` (three prod runs of 65-67 minutes). The client session
+replays a 401 with a re-minted token, which the runner fetches from serge over
+the existing authenticated callback channel. Confirmed firing in prod at 60m01s.
+
+**Transient gateway error.** A single ``502 Bad Gateway`` on a *read*
+(``GET /git/commits/<sha>``) killed a finished, GPU-verified qwen3_omni_moe fix at
+its commit step (transformers#47605). Retried with backoff — but only where a
+replay cannot duplicate a side effect.
 """
 
 import unittest
@@ -12,16 +17,21 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from reviewbot.github_client import GitHubClient, _AuthRetrySession
+from reviewbot.github_client import (
+    GitHubClient,
+    _AuthRetrySession,
+    _is_replay_safe,
+)
 from reviewbot.task_runner import TokenRefresher
 
 
-def _resp(status: int, payload=None, text=""):
+def _resp(status: int, payload=None, text="", headers=None):
     r = MagicMock()
     r.status_code = status
     r.ok = 200 <= status < 300
     r.json.return_value = payload if payload is not None else {}
     r.text = text
+    r.headers = headers if headers is not None else {}
     return r
 
 
@@ -163,6 +173,202 @@ class GitHubClientRefreshTests(unittest.TestCase):
         ) as inner:
             gh.get_pr("o", "r", 1)
         self.assertEqual(inner.call_count, 1)
+
+
+class ReplaySafetyTests(unittest.TestCase):
+    """Which requests may be replayed. A 5xx is ambiguous — the write may have
+    landed and only the response got lost — so writes are excluded unless
+    replaying them is provably a no-op."""
+
+    def test_reads_are_safe(self):
+        self.assertTrue(_is_replay_safe("GET", "https://api.github.com/repos/o/r"))
+        self.assertTrue(_is_replay_safe("get", "https://api.github.com/repos/o/r"))
+        self.assertTrue(_is_replay_safe("HEAD", "https://api.github.com/repos/o/r"))
+
+    def test_content_addressed_writes_are_safe(self):
+        # Same bytes -> same SHA, so a replay creates nothing new.
+        self.assertTrue(
+            _is_replay_safe("POST", "https://api.github.com/repos/o/r/git/blobs")
+        )
+        self.assertTrue(
+            _is_replay_safe("POST", "https://api.github.com/repos/o/r/git/trees")
+        )
+
+    def test_side_effecting_writes_are_not_safe(self):
+        for method, url in (
+            # A replay would 422 ("already exists") or move a branch twice.
+            ("POST", "https://api.github.com/repos/o/r/git/refs"),
+            ("PATCH", "https://api.github.com/repos/o/r/git/refs/heads/x"),
+            # A replay would create a second commit object.
+            ("POST", "https://api.github.com/repos/o/r/git/commits"),
+            # A replay would double-post to the PR.
+            ("POST", "https://api.github.com/repos/o/r/issues/1/comments"),
+            ("POST", "https://api.github.com/repos/o/r/pulls/1/reviews"),
+            ("POST", "https://api.github.com/repos/o/r/pulls"),
+        ):
+            with self.subTest(url=url):
+                self.assertFalse(_is_replay_safe(method, url))
+
+
+class TransientRetryTests(unittest.TestCase):
+    def setUp(self):
+        # Never actually sleep in tests.
+        self._sleep = patch("reviewbot.github_client.time.sleep")
+        self.sleep = self._sleep.start()
+        self.addCleanup(self._sleep.stop)
+
+    def test_502_on_a_read_is_retried(self):
+        """The prod failure verbatim: GET /git/commits/<sha> -> 502."""
+        session = _AuthRetrySession()
+        url = (
+            "https://api.github.com/repos/huggingface/transformers/git/commits/dff4572"
+        )
+        with patch.object(
+            requests.Session, "request", side_effect=[_resp(502), _resp(200)]
+        ) as inner:
+            out = session.get(url)
+        self.assertEqual(out.status_code, 200)
+        self.assertEqual(inner.call_count, 2)
+
+    def test_retries_are_bounded(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", return_value=_resp(503)
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 503)
+        self.assertEqual(inner.call_count, 3)  # _MAX_ATTEMPTS
+        self.assertEqual(self.sleep.call_count, 2)
+
+    def test_backoff_grows(self):
+        session = _AuthRetrySession()
+        with patch.object(requests.Session, "request", return_value=_resp(500)):
+            session.get("https://api.github.com/x")
+        self.assertEqual([c.args[0] for c in self.sleep.call_args_list], [1.0, 3.0])
+
+    def test_retry_after_header_is_honoured(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(503, headers={"Retry-After": "7"}), _resp(200)],
+        ):
+            session.get("https://api.github.com/x")
+        self.sleep.assert_called_once_with(7.0)
+
+    def test_absurd_retry_after_is_capped(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(503, headers={"Retry-After": "99999"}), _resp(200)],
+        ):
+            session.get("https://api.github.com/x")
+        self.sleep.assert_called_once_with(30.0)
+
+    def test_garbage_retry_after_falls_back_to_backoff(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(503, headers={"Retry-After": "soon"}), _resp(200)],
+        ):
+            session.get("https://api.github.com/x")
+        self.sleep.assert_called_once_with(1.0)
+
+    def test_502_on_a_side_effecting_write_is_not_retried(self):
+        """create_ref must not be replayed — the ref may already exist."""
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", return_value=_resp(502)
+        ) as inner:
+            out = session.post("https://api.github.com/repos/o/r/git/refs", json={})
+        self.assertEqual(out.status_code, 502)
+        self.assertEqual(inner.call_count, 1)
+        self.sleep.assert_not_called()
+
+    def test_502_on_a_blob_upload_is_retried(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", side_effect=[_resp(502), _resp(201)]
+        ) as inner:
+            out = session.post("https://api.github.com/repos/o/r/git/blobs", json={})
+        self.assertEqual(out.status_code, 201)
+        self.assertEqual(inner.call_count, 2)
+
+    def test_connection_error_on_a_read_is_retried(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[requests.ConnectionError("reset"), _resp(200)],
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 200)
+        self.assertEqual(inner.call_count, 2)
+
+    def test_timeout_on_a_read_is_retried(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[requests.Timeout("slow"), _resp(200)],
+        ):
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 200)
+
+    def test_persistent_connection_error_raises(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", side_effect=requests.ConnectionError("reset")
+        ) as inner:
+            with self.assertRaises(requests.ConnectionError):
+                session.get("https://api.github.com/x")
+        self.assertEqual(inner.call_count, 3)
+
+    def test_connection_error_on_a_write_is_not_retried(self):
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", side_effect=requests.ConnectionError("reset")
+        ) as inner:
+            with self.assertRaises(requests.ConnectionError):
+                session.post("https://api.github.com/repos/o/r/git/refs", json={})
+        self.assertEqual(inner.call_count, 1)
+
+    def test_404_is_not_retried(self):
+        """Only 5xx is transient; a 404 is an answer."""
+        session = _AuthRetrySession()
+        with patch.object(
+            requests.Session, "request", return_value=_resp(404)
+        ) as inner:
+            session.get("https://api.github.com/x")
+        self.assertEqual(inner.call_count, 1)
+
+    def test_expiry_and_a_gateway_blip_in_the_same_request(self):
+        """Both repairs compose: re-mint on the 401, then ride out the 502."""
+        session = _AuthRetrySession(lambda: "fresh")
+        session.headers["Authorization"] = "Bearer stale"
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(401), _resp(502), _resp(200)],
+        ) as inner:
+            out = session.get("https://api.github.com/x")
+        self.assertEqual(out.status_code, 200)
+        self.assertEqual(inner.call_count, 3)
+        self.assertEqual(session.headers["Authorization"], "Bearer fresh")
+
+    def test_get_commit_tree_sha_survives_a_gateway_blip(self):
+        """End to end through the client method that actually failed in prod."""
+        gh = GitHubClient("tok")
+        with patch.object(
+            requests.Session,
+            "request",
+            side_effect=[_resp(502), _resp(200, {"tree": {"sha": "t1"}})],
+        ):
+            self.assertEqual(
+                gh.get_commit_tree_sha("huggingface", "transformers", "dff4572"), "t1"
+            )
 
 
 class TokenRefresherTests(unittest.TestCase):


### PR DESCRIPTION
Found while verifying #80 on a full nightly triage run
([30352528047](https://github.com/huggingface/transformers/actions/runs/30352528047)).
Two of three tasks published; the third, qwen3_omni_moe
([transformers#47605](https://github.com/huggingface/transformers/issues/47605)),
died at **74.6 min** on:

```
502 Server Error: Bad Gateway for url:
https://api.github.com/repos/huggingface/transformers/git/commits/dff4572dfa4bfa9f00cc8414e4b84877552fefe9
```

It had already reproduced the failure on GPU, classified it, written and validated
a patch, and scoped the commit to 2 files (dropping 86 unrelated). All of it
thrown away by one gateway hiccup on a `GET`.

That is the same shape #80 fixed — work completed, then lost at publish — so it
belongs in the same place: `_AuthRetrySession.request`, the single funnel every
`GitHubClient` method goes through.

## What it does

Retries `500`/`502`/`503`/`504` and dropped connections (`ConnectionError`,
`Timeout`, `ChunkedEncodingError`) up to 3 attempts with 1s then 3s backoff,
honouring `Retry-After` when present (capped at 30s).

## The part worth reviewing: the two repairs are gated differently

- A **401 is unambiguous.** The request was rejected, so nothing happened, so
  replaying *any* method is safe — including a comment or a ref update.
- A **5xx is ambiguous.** The write may well have landed with only the response
  lost. So replay is restricted to requests where a duplicate cannot matter:
  - reads (`GET`/`HEAD`);
  - `POST /git/blobs` and `POST /git/trees`, which are content-addressed —
    identical bytes yield the same SHA and create nothing new.

Everything else that writes is deliberately left to fail: `create_ref`,
`update_ref`, `create_commit`, PR creation, comments, reviews. A blind replay
there could double-post a review comment on someone's PR, or turn a
successful-but-unreported `create_ref` into a confusing 422.

**Stated plainly: a 502 on `create_ref` or on a comment still fails the task.**
This fixes the read that actually bit us and the blob uploads that dominate the
commit step — not every possible 502. A lost run is recoverable; duplicate
comments on a public PR are noise a human has to clean up.

**Not covered:** GitHub secondary rate limits (403/429 with `Retry-After`). Those
need their own handling and are a different failure from a gateway blip.

## Tests

614 pass (was 564). New coverage asserts the prod call verbatim
(`get_commit_tree_sha` surviving a 502), that side-effecting writes are *not*
retried, bounded attempts, `Retry-After` handling including a capped absurd value
and a garbage value, and that both repairs compose in one request
(`401 → re-mint → 502 → retry → 200`).

## Context: #80 is confirmed working in prod

The same run proved the token fix fires for real:

```
11:54:45 re-minted the installation token for job 83398832… (huggingface/transformers)
11:54:46 re-minted the installation token for job 87b74cf5… (huggingface/transformers)
```

Both tasks started at 10:54, so that is 60m01s — exactly the expiry boundary that
killed three runs last week. `83398832` went on to open
[transformers#47607](https://github.com/huggingface/transformers/pull/47607).

Commit scoping is working too, and base drift is worse than measured: 87, 87 and
86 unrelated regenerated files dropped, PRs landing at 1 file each. The
qwen3_omni_moe task correctly *kept* its own model's regenerated
`modeling_qwen3_omni_moe.py` while dropping the other 86 — the same-model coupling
rule doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
