### PR TITLE
Expose the last normalize failure on /tasks/.../status

### DIFF
--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -3834,6 +3834,41 @@ def task_info(request: Request, owner: str, repo: str, job_id: str) -> JSONRespo
     )
 
 
+# Bound on the normalize output returned by /status. The transformers checker
+# output is tail-informative (the failing checker's traceback, then the
+# "N failed: <name>" summary), so keep the END, not the head.
+_NORMALIZE_STATUS_CHARS = 8_000
+
+
+def _last_normalize_error(row: Optional[dict]) -> Optional[str]:
+    """The most recent ``normalize_error`` event from a task's persisted
+    history, tail-bounded — or None when the normalizer never rejected a patch.
+
+    Why /status carries this at all: the normalize gate is the single most
+    common reason a dispatched task opens no PR, and on the ``error`` path the
+    terminal ``error`` string describes only the *last* thing that went wrong
+    (e.g. "LLM returned unparseable output") — the normalizer failure that
+    actually doomed the run is buried in the history and invisible to the
+    caller. Surfacing it lets the dispatcher explain the outcome without a
+    dashboard round trip. Derived from history rather than a new column so it
+    works for jobs already on disk.
+    """
+    history = (row or {}).get("history") or []
+    for event in reversed(history):
+        if isinstance(event, dict) and event.get("kind") == "normalize_error":
+            text = (event.get("text") or "").strip()
+            if not text:
+                return None
+            if len(text) <= _NORMALIZE_STATUS_CHARS:
+                return text
+            omitted = len(text) - _NORMALIZE_STATUS_CHARS
+            return (
+                f"--- omitted {omitted} leading chars of normalize output ---\n\n"
+                + text[-_NORMALIZE_STATUS_CHARS:].lstrip()
+            )
+    return None
+
+
 @app.get("/tasks/{owner}/{repo}/{job_id}/status")
 def task_status(request: Request, owner: str, repo: str, job_id: str) -> JSONResponse:
     """Machine-facing task status, authorized by GitHub Actions OIDC (same as
@@ -3885,6 +3920,7 @@ def task_status(request: Request, owner: str, repo: str, job_id: str) -> JSONRes
             "target": f"{job.target_owner}/{job.target_repo}",
             "result": job.task_result,
             "error": job.error,
+            "normalizer_error": _last_normalize_error(row),
             "model": job.llm_model,
             "prompt_tokens": (row or {}).get("prompt_tokens"),
             "completion_tokens": (row or {}).get("completion_tokens"),

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -247,6 +247,83 @@ class WebappTasksTests(unittest.TestCase):
         self.assertIn("prompt_tokens", body)
         self.assertIn("completion_tokens", body)
 
+    def test_status_endpoint_exposes_last_normalize_error(self):
+        # The normalize gate is the most common reason a task opens no PR, and
+        # on the error path the terminal `error` names only the last symptom
+        # ("unparseable output") — the normalizer failure that actually doomed
+        # the run is only in the history. /status surfaces it so the dispatcher
+        # can explain the outcome without a dashboard round trip.
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._seed_task_job(webapp, status="error")
+        webapp._store.save_terminal(
+            "task-status-1",
+            status="error",
+            error="LLM returned unparseable output (finish_reason=stop)",
+            raw_llm_output=None,
+            draft=None,
+            history=[
+                {
+                    "kind": "normalize_error",
+                    "text": "Normalizer failed (exit 1): first",
+                },
+                {"kind": "log", "text": "noise"},
+                {
+                    "kind": "normalize_error",
+                    "text": "Normalizer failed (exit 1):\n1 failed: docstrings",
+                },
+            ],
+        )
+        with patch.object(webapp, "verify_token", return_value=_Claims()):
+            client = TestClient(webapp.app)
+            r = client.get(
+                "/tasks/acme/widgets/task-status-1/status",
+                headers={"Authorization": "Bearer tok"},
+            )
+        self.assertEqual(r.status_code, 200)
+        # The LAST failure, not the first — that is the one the run died on.
+        self.assertIn("1 failed: docstrings", r.json()["normalizer_error"])
+
+    def test_status_endpoint_normalize_error_null_when_gate_never_failed(self):
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        self._seed_task_job(webapp, status="no_fix")
+        with patch.object(webapp, "verify_token", return_value=_Claims()):
+            client = TestClient(webapp.app)
+            r = client.get(
+                "/tasks/acme/widgets/task-status-1/status",
+                headers={"Authorization": "Bearer tok"},
+            )
+        self.assertIsNone(r.json()["normalizer_error"])
+
+    def test_last_normalize_error_keeps_the_informative_tail(self):
+        # Checker output is tail-informative (traceback, then "N failed: …"),
+        # so a bounded payload must drop the head.
+        webapp = self._import_webapp()
+        text = (
+            "HEAD-MARKER\n"
+            + "x" * webapp._NORMALIZE_STATUS_CHARS
+            + "\n1 failed: docstrings"
+        )
+        out = webapp._last_normalize_error(
+            {"history": [{"kind": "normalize_error", "text": text}]}
+        )
+        self.assertIn("1 failed: docstrings", out)
+        self.assertNotIn("HEAD-MARKER", out)
+        self.assertIn("omitted", out)
+
+    def test_last_normalize_error_tolerates_missing_history(self):
+        webapp = self._import_webapp()
+        self.assertIsNone(webapp._last_normalize_error(None))
+        self.assertIsNone(webapp._last_normalize_error({}))
+        self.assertIsNone(
+            webapp._last_normalize_error(
+                {"history": [{"kind": "normalize_error", "text": "  "}]}
+            )
+        )
+
     def test_status_endpoint_rejects_foreign_repo_claim(self):
         if TestClient is None:
             self.skipTest("fastapi not installed")


### PR DESCRIPTION
## Why

On the 2026-07-29 nightly, the `longcat_flash` integration-failure group was reported in [transformers#47631](https://github.com/huggingface/transformers/issues/47631) as `⚠️ task failed` / "LLM returned unparseable output". That is the last symptom, not the cause.

What actually happened (job `34d4b1f3…`): the model produced a patch, the normalizer rejected it with `1 failed: docstrings`, both corrections hit the same unfixable failure, and the tool-free re-asks then came back empty — so the run surfaced the empty-answer error and the normalizer failure was never mentioned. It only existed in the job history, which the dispatcher rendering the triage issue cannot see.

The normalize gate is the single most common reason a dispatched task opens no PR, so the caller should be able to explain the outcome without a dashboard round trip.

## What

`GET /tasks/{owner}/{repo}/{job_id}/status` now returns `normalizer_error`: the most recent persisted `normalize_error` event, tail-bounded to 8k chars (checker output is tail-informative — traceback, then the `N failed: <names>` summary).

Derived from the persisted history rather than a new column, so it works for jobs already on disk and needs no migration. `null` when the normalizer never rejected a patch.

Consumed by a companion transformers-ci PR that renders it in the triage issue's outcome recap.

## Test

`tests/test_webapp_tasks.py`: last-failure-wins when several are recorded, `null` when the gate never failed, tail-preserving bound, and tolerance of missing/blank history. Full suite: 618 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)