### PR TITLE
Task PR body: the CI failure, where to watch it, and prior reports

### DIFF
--- a/docs/tasks-flow.md
+++ b/docs/tasks-flow.md
@@ -140,6 +140,44 @@ review pages use.
   class as a PR body). The prompt marks them untrusted, the model can only emit a
   patch, and the result is a PR a human reviews before merge.
 
+## What the PR body says
+
+serge wraps the model's explanation in the evidence a reviewer needs to judge it
+without opening the CI logs:
+
+1. **Original CI failure** — the failure group, the failing test, and the
+   traceback CI actually produced, in a collapsed `<details>` block.
+2. **Where to watch it** — the links the dispatcher sent in `test_links` (see
+   below) for the tests this PR fixes, typically a per-test dashboard view.
+   Omitted when the task carried none.
+3. **The model's explanation** of the root cause and the patch.
+4. **Verified on GPU** — the runs that failed before and passed after, when the
+   GPU verify gate (`VERIFY_ON_GPU`) is on.
+5. **Possibly related** — existing issues/PRs in the target repo that mention the
+   failing test, found with one `GET /search/issues` call at PR-open time. It is
+   a keyword match, labelled as such: serge does not check that they share a root
+   cause, and it drops its own earlier task PRs. A failed or rate-limited search
+   silently renders nothing rather than holding up the PR.
+
+### `test_links` — where the dispatcher observes its failures
+
+serge does not know which dashboard a caller watches its CI in, and deliberately
+holds no monitoring config of its own. A task may therefore carry an optional
+node-id-keyed map of finished links, which serge renders (and only renders):
+
+```json
+"test_links": {
+  "tests/models/foo/test_modeling_foo.py::FooIntegrationTest::test_bar": [
+    {"label": "Dashboard", "url": "https://grafana.example/d/…?var-test_nodeid=…"}
+  ]
+}
+```
+
+Keyed by node-id because one task can carry several candidate failure groups and
+the PR fixes only the group serge's patch matched — links for the others would be
+noise. Validated on the way in (`http(s)` only, single-line labels, capped
+counts); anything malformed is dropped, never fatal. Absent field, no section.
+
 ## Configuration
 
 | Env var | Default | Description |

--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -542,6 +542,34 @@ class GitHubClient:
             )
         return r.json()
 
+    def search_issues(
+        self,
+        query: str,
+        *,
+        sort: str = "updated",
+        order: str = "desc",
+        per_page: int = 20,
+    ) -> list[dict]:
+        """Issue/PR search (``GET /search/issues``), newest activity first.
+
+        Used to surface existing reports of a CI failure in a task PR body.
+        Search has its own rate budget (30 req/min for an installation token),
+        so callers treat any failure as "no hits" rather than retrying.
+        ``advanced_search`` opts into the current query parser explicitly."""
+        r = self.session.get(
+            "https://api.github.com/search/issues",
+            params={
+                "q": query,
+                "sort": sort,
+                "order": order,
+                "per_page": per_page,
+                "advanced_search": "true",
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        return (r.json() or {}).get("items", [])
+
     def mark_pull_request_ready(self, node_id: str) -> None:
         """Transition a draft PR to ready-for-review via the GraphQL
         ``markPullRequestReadyForReview`` mutation. The REST ``PATCH /pulls``

--- a/reviewbot/pr_links.py
+++ b/reviewbot/pr_links.py
@@ -1,0 +1,275 @@
+"""Evidence serge attaches to a task PR body: the CI error being fixed, the
+dashboard links the dispatcher supplied for each failing test, and existing
+issues/PRs that already discuss the same failure.
+
+All of it is decoration. Every helper here degrades to ``""``/``[]`` instead of
+raising, so a task dispatched without links or a rate-limited GitHub search never
+costs us a PR that is otherwise ready to open.
+
+The failure report serge receives (``TaskRequest.context``, rendered by
+transformers-ci's ``integration_failure_triage``) lists each failing test as a
+bullet, optionally followed by the CI traceback in a 2-space-indented fenced
+block::
+
+    - `tests/models/foo/test_modeling_foo.py::FooIntegrationTest::test_bar` [single-gpu] (output_mismatch, seen 5/7)
+      ```
+      E   AssertionError: Tensor-likes are not close!
+      ```
+
+``tasks._failure_blocks`` deliberately stops at that fence — it feeds the
+GPU-verify target selection, which must stay keyed on the bullets alone — so the
+traceback is parsed separately here and re-attached only when the PR body is
+rendered.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+_FENCE = "```"
+
+# Bounds on the dispatcher-supplied ``test_links`` (see sanitize_test_links).
+# Generous enough for the real callers, tight enough that a malformed payload
+# cannot bloat a PR body.
+MAX_LINKS_PER_TEST = 4
+MAX_LINKED_TESTS = 60
+MAX_LABEL_CHARS = 60
+MAX_URL_CHARS = 2000
+
+# Tail of the CI traceback kept in the PR body. The triage already caps each
+# traceback (~3000 chars); this is the second belt so a pathological report
+# cannot push the fix itself below the fold.
+TRACEBACK_CHARS = 2500
+
+# A serge PR is not a "related report" — it is this bot's own earlier attempt.
+_SERGE_MARKERS = ("serge-task:", "produced automatically by serge")
+
+
+def failure_tracebacks(context: str) -> dict[str, str]:
+    """Map each failing test's node-id to the fenced CI traceback under it.
+
+    Only the first fenced block after a bullet is taken; tests rendered without
+    one (the triage gives full tracebacks to the first N failures of a group)
+    are simply absent from the mapping.
+    """
+    out: dict[str, str] = {}
+    node_id: Optional[str] = None
+    collecting = False
+    buf: list[str] = []
+    for line in context.splitlines():
+        stripped = line.strip()
+        if not collecting and line.startswith("- `"):
+            match = _BACKTICK_RE.search(line)
+            node_id = match.group(1).strip() if match else None
+            continue
+        if stripped == _FENCE and line.startswith(" "):
+            if collecting:
+                if node_id and buf:
+                    out.setdefault(node_id, "\n".join(buf).strip())
+                buf, collecting = [], False
+            elif node_id and node_id not in out:
+                collecting = True
+            continue
+        if collecting:
+            buf.append(line[2:] if line.startswith("  ") else line)
+    return out
+
+
+def trim_traceback(traceback: str, max_chars: int = TRACEBACK_CHARS) -> str:
+    """Keep the *tail* — the assertion and the raising frame live at the end."""
+    text = (traceback or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return "…(truncated)…\n" + text[-max_chars:].lstrip()
+
+
+def error_section(context: str, node_ids: list[str]) -> str:
+    """A collapsed ``<details>`` block holding the CI traceback of the failing
+    tests, so a reviewer sees the actual error without leaving the PR."""
+    tracebacks = failure_tracebacks(context)
+    parts: list[str] = []
+    for node_id in node_ids:
+        traceback = tracebacks.get(node_id)
+        if not traceback:
+            continue
+        parts.append(
+            "<details>\n"
+            f"<summary>CI traceback — <code>{node_id}</code></summary>\n\n"
+            f"```\n{trim_traceback(traceback)}\n```\n\n"
+            "</details>"
+        )
+    return "\n\n".join(parts)
+
+
+def sanitize_test_links(raw: Any) -> dict[str, list[dict[str, str]]]:
+    """Validate an inbound ``test_links`` mapping (node-id → list of links).
+
+    The dispatcher that files the task knows where its failures are observable —
+    which dashboard, which UID, which template variables — and serge does not
+    want to. It sends the finished URLs; serge only renders them, so no
+    deployment's monitoring stack leaks into this codebase.
+
+    Anything malformed is dropped rather than raising: links are decoration, and
+    a bad entry must not cost a PR. Only ``http(s)`` URLs survive, and labels are
+    forced to a single short line — this text lands in an outward-facing PR body.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, list[dict[str, str]]] = {}
+    for node_id, links in raw.items():
+        if not isinstance(node_id, str) or not node_id.strip():
+            continue
+        if not isinstance(links, list):
+            continue
+        clean: list[dict[str, str]] = []
+        for link in links[:MAX_LINKS_PER_TEST]:
+            if not isinstance(link, dict):
+                continue
+            url = str(link.get("url") or "").strip()
+            if not url.startswith(("http://", "https://")) or len(url) > MAX_URL_CHARS:
+                continue
+            if any(ch.isspace() for ch in url) or ")" in url:
+                continue  # would break out of the markdown link
+            label = " ".join(str(link.get("label") or "").split())[:MAX_LABEL_CHARS]
+            clean.append({"label": label or "Dashboard", "url": url})
+        if clean:
+            out[node_id.strip()] = clean
+        if len(out) >= MAX_LINKED_TESTS:
+            break
+    return out
+
+
+def test_links_section(
+    test_links: dict[str, list[dict[str, str]]], node_ids: list[str]
+) -> str:
+    """Render the dispatcher's links for the failing tests this PR claims to fix
+    — the failure's own history (how long it has been red, how its duration
+    moved) next to the fix.
+
+    Only ``node_ids`` are rendered: a task can carry several candidate failure
+    groups, and the PR fixes just the one :func:`tasks._select_failure_block`
+    picked. Links for the other groups' tests would be noise.
+    """
+    if not test_links:
+        return ""
+    lines: list[str] = []
+    for node_id in node_ids:
+        for link in test_links.get(node_id) or []:
+            test = node_id.rsplit("::", 1)[-1]
+            lines.append(f"- [{test} — {link['label']}]({link['url']})")
+    if not lines:
+        return ""
+    return "\n".join(["**Where to watch it:**", *lines])
+
+
+def _test_functions(node_ids: list[str], limit: int = 3) -> list[str]:
+    """Distinct test-function names from pytest node-ids, parametrization
+    stripped (``test_x[bf16-cuda]`` and ``test_x[fp32-cpu]`` are one test)."""
+    names: list[str] = []
+    for node_id in node_ids:
+        name = node_id.rsplit("::", 1)[-1].split("[", 1)[0].strip()
+        if name and name not in names:
+            names.append(name)
+        if len(names) >= limit:
+            break
+    return names
+
+
+def related_search_query(owner: str, repo: str, node_ids: list[str], model: str) -> str:
+    """The GitHub search query for prior reports of this failure.
+
+    The failing test's function name is the discriminating token — it is
+    distinctive enough to quote and match on its own, and it is what a human
+    filing the same bug pastes into the issue. Only when no node-id could be
+    parsed do we fall back to the model name, restricted to titles so the query
+    does not return every issue that merely mentions the architecture.
+    """
+    functions = _test_functions(node_ids)
+    if functions:
+        terms = " OR ".join(f'"{name}"' for name in functions)
+        if len(functions) > 1:
+            terms = f"({terms})"
+        return f"repo:{owner}/{repo} {terms}"
+    if model:
+        return f'repo:{owner}/{repo} "{model}" in:title'
+    return ""
+
+
+def _is_serge_item(item: dict[str, Any]) -> bool:
+    login = ((item.get("user") or {}).get("login") or "").lower()
+    if login.startswith("serge"):
+        return True
+    body = (item.get("body") or "").lower()
+    return any(marker in body for marker in _SERGE_MARKERS)
+
+
+def find_related_issues(
+    gh: Any,
+    owner: str,
+    repo: str,
+    *,
+    node_ids: list[str],
+    model: str = "",
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Existing issues/PRs that mention the failing test, newest activity first.
+
+    Best-effort: a failed or rate-limited search (the search API has its own
+    30 req/min budget) is logged and reported as "no hits". serge's own task
+    PRs are dropped — they are this bot's earlier attempts at the same group,
+    already linked by the triage fingerprint.
+    """
+    query = related_search_query(owner, repo, node_ids, model)
+    if not query:
+        return []
+    try:
+        items = gh.search_issues(query, per_page=20)
+    except Exception:  # noqa: BLE001 — decoration must never fail a PR
+        log.warning("related-issue search failed for %r", query, exc_info=True)
+        return []
+    related: list[dict[str, Any]] = []
+    for item in items:
+        if _is_serge_item(item):
+            continue
+        related.append(
+            {
+                "number": item.get("number"),
+                "title": (item.get("title") or "").strip(),
+                "url": item.get("html_url") or "",
+                "state": item.get("state") or "",
+                "is_pr": item.get("pull_request") is not None,
+                "updated_at": (item.get("updated_at") or "")[:10],
+            }
+        )
+        if len(related) >= limit:
+            break
+    return related
+
+
+def related_section(items: list[dict[str, Any]], node_ids: list[str]) -> str:
+    """Render the related issues/PRs, flagged as the keyword match they are —
+    serge does not verify that they share a root cause."""
+    if not items:
+        return ""
+    functions = _test_functions(node_ids)
+    matched = ", ".join(f"`{name}`" for name in functions) or "the failing test"
+    lines = [
+        "### Possibly related",
+        "",
+        f"Existing issues/PRs mentioning {matched} (keyword match — not verified "
+        "to share a root cause):",
+        "",
+    ]
+    for item in items:
+        kind = "PR" if item["is_pr"] else "issue"
+        title = item["title"]
+        lines.append(
+            f"- [#{item['number']}]({item['url']}) — {title} "
+            f"({kind}, {item['state']}, updated {item['updated_at']})"
+        )
+    return "\n".join(lines)

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -25,7 +25,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
-from . import __version__
+from . import __version__, pr_links
 from .clone_cache import Checkout, CloneCache, FileChange
 from .commit_scope import describe_dropped, scope_paths
 from .compression import MessageCompressor
@@ -117,6 +117,11 @@ class TaskRequest:
     # confirmed the failure at the base commit. Surfaced in the PR body as the
     # "failed before" evidence.
     reproduce_run_url: Optional[str] = None
+    # Optional, from the /tasks payload: node-id → [{label, url}] links to where
+    # the dispatcher observes each failing test (a dashboard, a run page). serge
+    # renders them in the PR body and knows nothing about what they point at —
+    # see :func:`pr_links.sanitize_test_links`.
+    test_links: dict[str, list[dict[str, str]]] = field(default_factory=dict)
 
     @property
     def repo_full_name(self) -> str:
@@ -268,6 +273,7 @@ def build_task_request(
         slack_channel=slack_channel,
         slack_notify_pr_created=slack_notify_pr_created,
         slack_notify_task_finished=slack_notify_task_finished,
+        test_links=pr_links.sanitize_test_links(payload.get("test_links")),
     )
 
 
@@ -660,24 +666,42 @@ def _failure_blocks(context: str) -> list[list[str]]:
 def _select_failure_block(req: TaskRequest, plan: TaskPlan) -> list[str]:
     """The single failure block most relevant to the produced patch (scored by
     word overlap with the patch/title/body). Shared by the PR-body decorator and
-    the GPU verify gate, so both target the same group's node-ids."""
+    the GPU verify gate, so both target the same group's node-ids.
+
+    Scoring reads the bullet *and* the CI traceback rendered under it. The
+    traceback is not part of the block (:func:`_failure_blocks` stops at the
+    fence, so the verify targets stay the bullets alone), but it is where the
+    identifiers a patch echoes actually live — without it every fenced bullet
+    scores zero and the group's first failure wins by position."""
     blocks = _failure_blocks(req.context)
     if not blocks:
         return []
     haystack = f"{plan.title}\n{plan.body}\n{plan.patch}".lower()
+    tracebacks = pr_links.failure_tracebacks(req.context)
 
     def _score(block: list[str]) -> int:
-        words = set(re.findall(r"[a-z0-9_]{5,}", "\n".join(block).lower()))
+        node_ids, _, _ = extract_verify_targets(block, "")
+        text = "\n".join(block + [tracebacks.get(nid, "") for nid in node_ids])
+        words = set(re.findall(r"[a-z0-9_]{5,}", text.lower()))
         return sum(1 for word in words if word in haystack)
 
     return max(blocks, key=_score)
 
 
 def _selected_failure_context(req: TaskRequest, plan: TaskPlan) -> str:
+    """The "Original CI failure" header of the PR body: which group this fixes,
+    the failing test, the error CI actually raised, and where to watch it.
+
+    The bullet alone says a test failed; the traceback (parsed separately, since
+    :func:`_failure_blocks` stops at the fence) says *how*, which is what a
+    reviewer needs to judge the patch without opening the CI log."""
     heading = ""
     for line in req.context.splitlines():
         if _CANDIDATE_HEADING_RE.match(line):
             heading = line.removeprefix("## Serge candidate failure group ").strip()
+            # Drop the dispatcher's "3/5: " counter — it means nothing to a
+            # reviewer, who only sees this one group's PR.
+            heading = re.sub(r"^\d+/\d+:\s*", "", heading)
             break
 
     selected = _select_failure_block(req, plan)
@@ -688,11 +712,41 @@ def _selected_failure_context(req: TaskRequest, plan: TaskPlan) -> str:
     if heading:
         lines.append(f"- Failure group: `{heading}`")
     lines.extend(selected)
+
+    node_ids, _, _ = extract_verify_targets(selected, "")
+    error = pr_links.error_section(req.context, node_ids)
+    if error:
+        lines += ["", error]
+    links = pr_links.test_links_section(req.test_links, node_ids)
+    if links:
+        lines += ["", links]
     return "\n".join(lines)
 
 
+def _related_issues_section(
+    gh: Optional[GitHubClient], req: TaskRequest, plan: TaskPlan
+) -> str:
+    """Prior reports of this failure, looked up when the PR is opened so the
+    reviewer sees them at their freshest. Never blocks the PR: no client, no
+    node-ids or a failing search all render nothing."""
+    if gh is None:
+        return ""
+    selected = _select_failure_block(req, plan)
+    if not selected:
+        return ""
+    node_ids, model, _ = extract_verify_targets(selected, "")
+    related = pr_links.find_related_issues(
+        gh, req.owner, req.repo, node_ids=node_ids, model=model
+    )
+    return pr_links.related_section(related, node_ids)
+
+
 def _decorate_body(
-    cfg: Config, plan: TaskPlan, req: TaskRequest, verification_footer: str = ""
+    cfg: Config,
+    plan: TaskPlan,
+    req: TaskRequest,
+    verification_footer: str = "",
+    gh: Optional[GitHubClient] = None,
 ) -> str:
     body = plan.body or "Automated fix produced by serge."
     failure_context = _selected_failure_context(req, plan)
@@ -703,6 +757,9 @@ def _decorate_body(
     # the serge footer (not tacked on after them).
     if verification_footer:
         body += f"\n{verification_footer}"
+    related = _related_issues_section(gh, req, plan)
+    if related:
+        body += f"\n\n{related}"
     body += (
         "\n\n---\n_This change was produced automatically by serge from a "
         "CI failure report. The patch was generated by an LLM and applied by "
@@ -967,6 +1024,7 @@ def _commit_changes(
             verification_footer=_verification_footer(
                 verify_run_url, req.reproduce_run_url, runs=verify_runs
             ),
+            gh=gh,
         ),
         draft=True,
     )

--- a/tests/test_pr_links.py
+++ b/tests/test_pr_links.py
@@ -1,0 +1,237 @@
+import types
+import unittest
+
+from reviewbot import pr_links, tasks
+
+GEMMA = "tests/models/gemma3/test_modeling_gemma3.py"
+NODE = f"{GEMMA}::Gemma3IntegrationTest::test_dynamic_sliding_window_is_default"
+OTHER = "tests/models/foo/test_modeling_foo.py::FooTest::test_a"
+DASH = "https://transformers-ci.lor-e.huggingface.cool/d/pytest-test/test"
+# What a dispatcher sends: finished links, keyed by node-id. serge renders them
+# without knowing what they point at.
+LINKS = {NODE: [{"label": "Dashboard", "url": f"{DASH}?var-test_nodeid=x"}]}
+
+# A failure report as transformers-ci's triage renders it: bullet, then the CI
+# traceback in a 2-space-indented fence.
+CONTEXT = (
+    "## Serge candidate failure group 1/1: gemma3 · output_mismatch\n"
+    "\n"
+    "Failing tests (with the actual-vs-expected detail from the CI trace):\n"
+    f"- `{OTHER}` [single-gpu] (output_mismatch, seen 5/7)\n"
+    "  - AssertionError: ordinary mismatch\n"
+    f"- `{NODE}` [single-gpu] (output_mismatch, seen 5/7)\n"
+    "  ```\n"
+    "  self = <tests.models.gemma3.test_modeling_gemma3.Gemma3IntegrationTest>\n"
+    "  E   AssertionError: 'DynamicSlidingWindowLayer' unexpectedly found in "
+    "'DynamicCache(...)'\n"
+    "  ```\n"
+)
+
+
+class FailureTracebackTests(unittest.TestCase):
+    def test_traceback_is_keyed_by_node_id(self):
+        tracebacks = pr_links.failure_tracebacks(CONTEXT)
+        self.assertEqual(list(tracebacks), [NODE])
+        self.assertIn("DynamicSlidingWindowLayer", tracebacks[NODE])
+        # The report's 2-space indent is stripped so the fence renders as code.
+        self.assertTrue(tracebacks[NODE].startswith("self = <tests.models"))
+
+    def test_no_fence_means_no_entry(self):
+        self.assertEqual(pr_links.failure_tracebacks(f"- `{OTHER}` [single-gpu]"), {})
+
+    def test_trim_keeps_the_tail(self):
+        trimmed = pr_links.trim_traceback("x" * 50 + "the assertion", max_chars=20)
+        self.assertTrue(trimmed.endswith("the assertion"))
+        self.assertIn("truncated", trimmed)
+
+    def test_error_section_only_covers_requested_tests(self):
+        section = pr_links.error_section(CONTEXT, [NODE])
+        self.assertIn("<details>", section)
+        self.assertIn("DynamicSlidingWindowLayer", section)
+        self.assertEqual(pr_links.error_section(CONTEXT, [OTHER]), "")
+
+
+class TestLinkTests(unittest.TestCase):
+    def test_section_renders_only_the_requested_tests(self):
+        links = {**LINKS, OTHER: [{"label": "Dashboard", "url": f"{DASH}?other"}]}
+        section = pr_links.test_links_section(links, [NODE])
+        self.assertIn("test_dynamic_sliding_window_is_default — Dashboard", section)
+        self.assertIn("var-test_nodeid=x", section)
+        # The other candidate group's link is not this PR's business.
+        self.assertNotIn("?other", section)
+
+    def test_no_links_no_section(self):
+        self.assertEqual(pr_links.test_links_section({}, [NODE]), "")
+        self.assertEqual(pr_links.test_links_section(LINKS, [OTHER]), "")
+
+    def test_sanitize_keeps_well_formed_links(self):
+        clean = pr_links.sanitize_test_links(LINKS)
+        self.assertEqual(clean, LINKS)
+
+    def test_sanitize_drops_non_http_urls(self):
+        for url in ("javascript:alert(1)", "/d/pytest-test/test", "ftp://x/y"):
+            self.assertEqual(
+                pr_links.sanitize_test_links({NODE: [{"url": url}]}), {}, url
+            )
+
+    def test_sanitize_drops_urls_that_break_the_markdown_link(self):
+        bad = {NODE: [{"url": f"{DASH}?a=b) [x](javascript:0"}]}
+        self.assertEqual(pr_links.sanitize_test_links(bad), {})
+
+    def test_sanitize_flattens_the_label_and_defaults_it(self):
+        raw = {NODE: [{"label": "two\nlines", "url": DASH}, {"url": DASH}]}
+        labels = [link["label"] for link in pr_links.sanitize_test_links(raw)[NODE]]
+        self.assertEqual(labels, ["two lines", "Dashboard"])
+
+    def test_sanitize_tolerates_junk(self):
+        for raw in (None, [], "x", {NODE: "x"}, {"": [{"url": DASH}]}, {NODE: [1]}):
+            self.assertEqual(pr_links.sanitize_test_links(raw), {}, repr(raw))
+
+    def test_sanitize_caps_links_per_test(self):
+        many = {NODE: [{"url": f"{DASH}?i={i}"} for i in range(20)]}
+        clean = pr_links.sanitize_test_links(many)
+        self.assertEqual(len(clean[NODE]), pr_links.MAX_LINKS_PER_TEST)
+
+
+class _FakeSearchGH:
+    def __init__(self, items=None, exc=None):
+        self.items = items or []
+        self.exc = exc
+        self.queries: list[str] = []
+
+    def search_issues(self, query, **kwargs):
+        self.queries.append(query)
+        if self.exc is not None:
+            raise self.exc
+        return self.items
+
+
+def _item(number, **over):
+    item = {
+        "number": number,
+        "title": f"issue {number}",
+        "html_url": f"https://github.com/huggingface/transformers/issues/{number}",
+        "state": "open",
+        "updated_at": "2026-08-01T10:00:00Z",
+        "user": {"login": "someone"},
+        "body": "",
+    }
+    item.update(over)
+    return item
+
+
+class RelatedIssueTests(unittest.TestCase):
+    def test_query_matches_the_test_function(self):
+        query = pr_links.related_search_query(
+            "huggingface", "transformers", [NODE], "gemma3"
+        )
+        self.assertEqual(
+            query,
+            'repo:huggingface/transformers "test_dynamic_sliding_window_is_default"',
+        )
+
+    def test_parametrized_ids_collapse_to_one_term(self):
+        query = pr_links.related_search_query(
+            "o", "r", [f"{NODE}[bf16]", f"{NODE}[fp32]"], ""
+        )
+        self.assertEqual(query.count("OR"), 0)
+
+    def test_falls_back_to_the_model_name(self):
+        self.assertEqual(
+            pr_links.related_search_query("o", "r", [], "gemma3"),
+            'repo:o/r "gemma3" in:title',
+        )
+        self.assertEqual(pr_links.related_search_query("o", "r", [], ""), "")
+
+    def test_serge_own_prs_are_dropped(self):
+        gh = _FakeSearchGH(
+            [
+                _item(1, user={"login": "sergereview[bot]"}),
+                _item(2, body="<!-- serge-task:integration-failure-triage -->"),
+                _item(3),
+            ]
+        )
+        related = pr_links.find_related_issues(
+            gh, "o", "r", node_ids=[NODE], model="gemma3"
+        )
+        self.assertEqual([r["number"] for r in related], [3])
+
+    def test_search_failure_is_not_fatal(self):
+        gh = _FakeSearchGH(exc=RuntimeError("rate limited"))
+        self.assertEqual(
+            pr_links.find_related_issues(gh, "o", "r", node_ids=[NODE]), []
+        )
+
+    def test_results_are_capped(self):
+        gh = _FakeSearchGH([_item(n) for n in range(10)])
+        related = pr_links.find_related_issues(gh, "o", "r", node_ids=[NODE], limit=3)
+        self.assertEqual(len(related), 3)
+
+    def test_section_flags_the_match_as_unverified(self):
+        gh = _FakeSearchGH([_item(42, pull_request={"url": "..."}, state="closed")])
+        section = pr_links.related_section(
+            pr_links.find_related_issues(gh, "o", "r", node_ids=[NODE]), [NODE]
+        )
+        self.assertIn("Possibly related", section)
+        self.assertIn("#42", section)
+        self.assertIn("PR, closed, updated 2026-08-01", section)
+        self.assertIn("not verified", section)
+
+    def test_no_hits_no_section(self):
+        self.assertEqual(pr_links.related_section([], [NODE]), "")
+
+
+class BodyDecorationTests(unittest.TestCase):
+    def setUp(self):
+        self.req = types.SimpleNamespace(
+            context=CONTEXT,
+            owner="huggingface",
+            repo="transformers",
+            test_links=LINKS,
+        )
+        self.plan = tasks.TaskPlan(
+            title="Keep the explicit cache_implementation",
+            body="Preserve cache_implementation when it is explicit.",
+            patch="DynamicSlidingWindowLayer",
+        )
+        self.cfg = types.SimpleNamespace(is_staging=False)
+
+    def test_failure_header_carries_error_and_links(self):
+        context = tasks._selected_failure_context(self.req, self.plan)
+        self.assertIn("Original CI failure", context)
+        # Picked over the other bullet because the patch echoes an identifier
+        # from this one's traceback — the bullet itself shares nothing.
+        self.assertNotIn("FooTest", context)
+        self.assertIn("DynamicSlidingWindowLayer' unexpectedly found", context)
+        self.assertIn("/d/pytest-test/test?", context)
+
+    def test_a_task_without_links_keeps_the_error(self):
+        req = types.SimpleNamespace(
+            context=CONTEXT, owner="huggingface", repo="transformers", test_links={}
+        )
+        context = tasks._selected_failure_context(req, self.plan)
+        self.assertIn("CI traceback", context)
+        self.assertNotIn("Where to watch it", context)
+
+    def test_related_section_sits_above_the_disclaimer(self):
+        gh = _FakeSearchGH([_item(47281)])
+        body = tasks._decorate_body(self.cfg, self.plan, self.req, gh=gh)
+        self.assertIn("Possibly related", body)
+        self.assertLess(
+            body.index("Possibly related"),
+            body.index("This change was produced automatically"),
+        )
+        self.assertEqual(
+            gh.queries,
+            ['repo:huggingface/transformers "test_dynamic_sliding_window_is_default"'],
+        )
+
+    def test_no_github_client_no_search(self):
+        body = tasks._decorate_body(self.cfg, self.plan, self.req)
+        self.assertNotIn("Possibly related", body)
+        # The error + dashboard link do not depend on the search.
+        self.assertIn("CI traceback", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -393,6 +393,29 @@ class RunnerConfigPassthroughTest(unittest.TestCase):
             f"classify_* Config fields not threaded to the runner pod: {missing}",
         )
 
+    def test_test_links_reach_the_runner_pod(self):
+        # The runner pod is what opens the PR, so the "where to watch it" links
+        # are rendered there, from the request rather than from config. They ride
+        # the serialized TaskRequest (dataclasses.asdict in webapp) — a field the
+        # dataclass does not declare would be dropped on the way in.
+        import dataclasses
+        import types
+
+        from reviewbot.task_runner import build_task_request
+        from reviewbot.tasks import TaskRequest
+
+        links = {"tests/a.py::T::test_x": [{"label": "Dashboard", "url": "https://x"}]}
+        req = TaskRequest(
+            owner="huggingface",
+            repo="transformers",
+            base_ref="main",
+            instruction="fix it",
+            context="",
+            test_links=links,
+        )
+        spec = types.SimpleNamespace(request=dataclasses.asdict(req))
+        self.assertEqual(build_task_request(spec).test_links, links)
+
     def test_classify_bail_on_environment_is_threaded_to_the_runner(self):
         # `_maybe_reproduce_first` reads this in the runner pod to decide whether an
         # `environment_issue` verdict stops the flow; unthreaded, the pod would

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -153,6 +153,42 @@ class BuildTaskRequestTests(unittest.TestCase):
         with self.assertRaises(TaskError):
             build_task_request({"context": "x"}, owner="a", repo="b")
 
+    def test_test_links_are_accepted_and_sanitized(self):
+        req = build_task_request(
+            {
+                "instruction": "x",
+                "test_links": {
+                    "tests/a.py::T::test_x": [
+                        {"label": "Dashboard", "url": "https://grafana/d/x?a=b"},
+                        {"label": "bad", "url": "javascript:alert(1)"},
+                    ]
+                },
+            },
+            owner="a",
+            repo="b",
+        )
+        self.assertEqual(
+            req.test_links,
+            {
+                "tests/a.py::T::test_x": [
+                    {"label": "Dashboard", "url": "https://grafana/d/x?a=b"}
+                ]
+            },
+        )
+
+    def test_test_links_are_optional_and_junk_is_not_fatal(self):
+        # Links are decoration: a caller that sends none, or sends nonsense, still
+        # gets its task run.
+        self.assertEqual(
+            build_task_request({"instruction": "x"}, owner="a", repo="b").test_links, {}
+        )
+        self.assertEqual(
+            build_task_request(
+                {"instruction": "x", "test_links": "not-a-map"}, owner="a", repo="b"
+            ).test_links,
+            {},
+        )
+
     def test_bad_mode(self):
         with self.assertRaises(TaskError):
             build_task_request(


### PR DESCRIPTION
A task PR asks a human to review an LLM-authored patch. Today the body carries the model's explanation and a bullet naming the failing test — judging the fix means opening the CI log to find out what actually broke. This puts the evidence in the body.

## What the body gains

1. **Original CI failure** — the failure group, the failing test, and the traceback CI raised, in a collapsed `<details>`. Parsed separately from the bullet: `_failure_blocks` deliberately stops at the fence because its output drives the GPU verify targets, which must stay the bullets alone.
2. **Where to watch it** — links supplied by the dispatcher (see below).
3. The model's explanation (unchanged).
4. **Verified on GPU** (unchanged, when `VERIFY_ON_GPU` is on).
5. **Possibly related** — existing issues/PRs mentioning the failing test, from one `GET /search/issues` at PR-open time so the list is fresh. Labelled as the keyword match it is; serge's own earlier task PRs are dropped.

## The `test_links` field

serge holds **no** monitoring config: no Grafana URL, no dashboard UID, no template-variable names. A dispatcher may send finished links in a new optional field, and serge only renders them:

```json
"test_links": {
  "tests/models/foo/test_modeling_foo.py::FooIntegrationTest::test_bar": [
    {"label": "Test dashboard", "url": "https://grafana.example/d/…?var-test_nodeid=…"}
  ]
}
```

Keyed by node-id because one task can carry several candidate failure groups and the PR fixes only the group `_select_failure_block` matched — links for the others would be noise. Validated on the way in (`http(s)` only, no markdown-breaking characters, single-line labels, capped counts); malformed entries are dropped rather than raising, and an absent field renders no section.

The producing side is huggingface/transformers-ci#66. Either can merge first: `build_task_request` ignores unknown keys, so a dispatcher sending `test_links` to an older serge simply loses the links.

## Also

`_select_failure_block` now scores each candidate group against its traceback as well as its bullet. The identifiers a patch echoes live in the traceback, so without it every fenced bullet scored zero and the group's first failure won by position.

Every helper degrades to `""`/`[]` instead of raising — decoration must never cost a PR that is otherwise ready.

## Testing

`645 passed` (full suite), `ruff check` clean, `make format` a no-op. New coverage: link rendering and group scoping, `javascript:`/markdown-breaking URLs rejected, label flattening, junk tolerance, per-test cap, payload acceptance, and the runner-pod hop (links ride the serialized `TaskRequest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)