### PR TITLE
Never dispatch the verify workflow with an empty `model` input

### DIFF
--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -37,6 +37,19 @@ _MODEL_RE = re.compile(r"tests/models/([^/]+)/")
 _MULTI_GPU = "aws-g5-12xlarge-cache"
 _SINGLE_GPU = "aws-g5-4xlarge-cache"
 
+# What to send as the workflow's `model` input when the group's tests do not live
+# under `tests/models/<model>/` — e.g. `tests/generation/test_utils.py`.
+#
+# The input is only used to pick the optional collateral suite (and to label the
+# run), and `run_collateral` is already forced off without a model, so any
+# placeholder works. It must NOT be empty: `model` is `required: true` on
+# serge-verify-caller.yml, and GitHub's workflow_dispatch API counts an empty
+# string as absent, answering 422 `Required input 'model' not provided`. That
+# fails BOTH the reproduce dispatch (which then fails open) and the verify
+# dispatch, so the 2026-08-16 nightly spent 904k tokens investigating the
+# `generation` group blind and threw the resulting patch away for want of a PR.
+_NO_MODEL = "none"
+
 # GitHub's run-scoped artifact listing lags the run's "completed" status: the
 # artifact is uploaded before completion, but `GET /runs/{id}/artifacts` can keep
 # returning an empty list for MINUTES afterwards (observed ~3 min in prod across a
@@ -194,7 +207,7 @@ def run_gpu_verify(
         "base_sha": base_sha,
         "commit_sha": commit_sha,
         "test_nodeids": " ".join(node_ids),
-        "model": model,
+        "model": model or _NO_MODEL,
         "machine_type": machine_type,
         "run_collateral": "true" if (run_collateral and model) else "false",
         "transformersci_ref": transformersci_ref,
@@ -259,7 +272,7 @@ def run_gpu_reproduce(
         "mode": "reproduce",
         "base_sha": base_sha,
         "test_nodeids": " ".join(node_ids),
-        "model": model,
+        "model": model or _NO_MODEL,
         "machine_type": machine_type,
         "run_collateral": "false",
         "transformersci_ref": transformersci_ref,

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -324,3 +324,57 @@ def test_run_reproduce_no_targets_skips_dispatch():
 def test_run_reproduce_dispatch_failed():
     gh = FakeGH(dispatch_exc=RuntimeError("no actions:write"))
     assert _run_repro(gh).verdict == verify.DISPATCH_FAILED
+
+
+# ---- groups whose tests are not under tests/models/<model>/ ------------------
+
+# `tests/generation/test_utils.py` has no model folder, so extract_verify_targets
+# returns model="". Sending that empty string is a hard 422 from GitHub
+# ("Required input 'model' not provided"), which broke both dispatches for this
+# group on the 2026-08-16 nightly.
+NO_MODEL_BLOCK = [
+    "- `tests/generation/test_utils.py::GenerationIntegrationTests"
+    "::test_green_red_watermark_generation` [multi-gpu] (other, seen 7/7)",
+]
+
+
+def test_extract_targets_has_no_model_outside_tests_models():
+    nodeids, model, _machine = verify.extract_verify_targets(
+        NO_MODEL_BLOCK, "default-mt"
+    )
+    assert nodeids == [
+        "tests/generation/test_utils.py::GenerationIntegrationTests"
+        "::test_green_red_watermark_generation"
+    ]
+    assert model == ""
+
+
+def test_verify_sends_a_placeholder_model_never_an_empty_string():
+    # The clock jumps past the deadline so the poll gives up immediately; the
+    # dispatch is already recorded and its inputs are all we assert on here.
+    gh, clock = FakeGH(), Clock([0, 10**6])
+    _run(gh, block_lines=NO_MODEL_BLOCK, monotonic=clock)
+    (_o, _r, _wf, _ref, inputs) = gh.dispatched[0]
+    assert inputs["model"] == verify._NO_MODEL
+    assert inputs["model"]  # the point: `model` is required: true on the caller
+    # No model folder means there is no collateral suite to run either.
+    assert inputs["run_collateral"] == "false"
+
+
+def test_reproduce_sends_a_placeholder_model_never_an_empty_string():
+    # The clock jumps past the deadline so the poll gives up immediately; the
+    # dispatch is already recorded and its inputs are all we assert on here.
+    gh, clock = FakeGH(), Clock([0, 10**6])
+    _run_repro(gh, block_lines=NO_MODEL_BLOCK, monotonic=clock)
+    (_o, _r, _wf, _ref, inputs) = gh.dispatched[0]
+    assert inputs["model"] == verify._NO_MODEL
+
+
+def test_a_real_model_is_still_passed_through():
+    # The clock jumps past the deadline so the poll gives up immediately; the
+    # dispatch is already recorded and its inputs are all we assert on here.
+    gh, clock = FakeGH(), Clock([0, 10**6])
+    _run(gh, block_lines=BLOCK, run_collateral=True, monotonic=clock)
+    (_o, _r, _wf, _ref, inputs) = gh.dispatched[0]
+    assert inputs["model"] == "whisper"
+    assert inputs["run_collateral"] == "true"


### PR DESCRIPTION
`serge-verify-caller.yml` declares `model` as `required: true`, and GitHub's
workflow_dispatch API counts an empty string as absent:

```
422 dispatching serge-verify-caller.yml on huggingface/transformers:
  {"message":"Required input 'model' not provided","status":"422"}
```

`extract_verify_targets` derives the model from `tests/models/<model>/`, so **any
group whose tests live elsewhere cannot be dispatched at all** — `tests/generation/
test_utils.py`, `tests/trainer/`, `tests/quantization/`, …

## What it cost on the 2026-08-16 nightly

The `generation` group (task `d8cda8555f49`, tracking issue
huggingface/transformers#48004) hit it twice:

1. The **reproduce** dispatch failed first. `dispatch_failed` is not
   `not_reproduced`, so `_maybe_reproduce_first` failed open and serge
   investigated **blind** — the exact thing reproduce-first exists to prevent.
   (There is no `serge reproduce generation` run in the workflow list, only the
   four for florence2/phimoe/emu3/exaone4_5.)
2. That blind run: 44 turns, 50 tool calls, **904,008 input tokens**, ending in
   the tool-repeat guard (`read_file×3, grep×3, grep×3`) being forced to answer
   without tools.
3. It still produced a plausible patch — watermarking_config dict handling in
   `GenerationConfig.update`, one file, normalizer clean — committed to
   `serge/fix/itf-464770b803d3-d8cda855`.
4. The **verify** dispatch then failed the same way → no PR. The branch was never
   pushed (65 `serge/fix/*` branches exist on the remote; that fingerprint is not
   among them), so the patch is gone.

## The fix

Send `"none"` instead of `""`. The input only selects the optional collateral
suite and labels the run, and `run_collateral` is already forced false when there
is no model folder, so nothing changes for groups that do have one. A named
constant carries the 422 explanation so it does not get "simplified" back.

Tests: `extract_verify_targets` really does return `model == ""` for a
`tests/generation/…` block (the input the fallback exists for), both dispatch
paths send a non-empty model, and a real model still passes through with
`run_collateral` intact. 649 tests pass.

## Not fixed here — worth deciding separately

`dispatch_failed` still fails open into a blind investigation. A 422 is
deterministic: no retry and no blind run can help, so treating it as a hard skip
would have made this incident cost nothing. A **timeout** is different and should
keep failing open. That is a behaviour change in the reproduce gate, so it is not
bundled into a bug fix.

Relatedly, `model: required: true` could be relaxed to `required: false` +
`default: ""` on both `serge-verify-caller.yml` (transformers) and
`serge-verify-slow.yml` (transformers-ci) so the whole class of bug cannot recur —
but the caller is behind the maintainer allow-list, hence the serge-side fallback
first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
