### PR TITLE
Tell a broken normalize gate apart from a bad patch

### DIFF
--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -97,6 +97,29 @@ class TaskError(Exception):
         self.status_code = status_code
 
 
+class NormalizeGateBroken(TaskError):
+    """The repo normalizer fails on the *pristine* checkout, before any patch
+    is applied — the gate is broken, so no patch can ever pass it.
+
+    Raised instead of feeding the failure back to the model, because the model
+    cannot fix it: every correction is rejected by the same environment error
+    and the task ends with a misleading "the patch does not pass the
+    normalizer" after burning the whole correction budget. Observed 2026-08-17
+    (transformers#48037): transformers' `main` moved its `tokenizers` pin to
+    >=0.23.1 while the task-runner image still had 0.22.2, and the gate's
+    `uv pip install -e . --no-deps` cannot upgrade a dependency, so every
+    checker that imports transformers died on the version guard. Three groups
+    reported "no fix" and ~3.5M input tokens were spent on an error no patch
+    could address.
+
+    Deliberately NOT status 422: 422 means "this candidate's patch does not
+    apply", which makes the runner move on to the next candidate group. A
+    broken gate breaks every group, so the task must fail loudly instead."""
+
+    def __init__(self, message: str):
+        super().__init__(message, status_code=500)
+
+
 @dataclass
 class TaskRequest:
     owner: str
@@ -389,6 +412,62 @@ def _run_repo_normalizer(
         return None, ""
 
 
+def _check_normalizer_baseline(
+    cfg: Config,
+    *,
+    checkout: Checkout,
+    clone_cache: CloneCache,
+    emit: Callable[[str, str], None],
+    state: dict,
+) -> None:
+    """Tell a bad patch apart from a broken gate, after a normalizer failure.
+
+    Resets the worktree to the pristine checkout and runs the normalizer on it.
+    A clean exit means the gate works and the patch really is at fault, so this
+    returns and the caller feeds the failure back to the model. A non-zero exit
+    means the normalizer rejects the *unpatched* base too — no patch can pass —
+    so this raises :class:`NormalizeGateBroken`.
+
+    Runs at most once per task: the answer is cached in ``state`` and replayed,
+    because the normalizer is the expensive step (transformers' takes minutes).
+    Only ever called on the failure path, so a healthy task pays nothing.
+
+    Leaves the worktree pristine either way — the normalizer's fixers rewrite
+    files, and a base that is not itself normalizer-clean legitimately produces
+    changes here, which is why the *exit code* is the signal and not the diff.
+    """
+    if state.get("checked"):
+        broken = state.get("broken")
+        if broken:
+            raise NormalizeGateBroken(broken)
+        return
+    state["checked"] = True
+
+    emit(
+        "log",
+        "Normalizer rejected the patch; re-running it on the unpatched "
+        "checkout to tell a bad patch from a broken gate…",
+    )
+    clone_cache.reset_worktree(checkout)
+    returncode, output = _run_repo_normalizer(cfg, checkout, emit)
+    clone_cache.reset_worktree(checkout)
+    if returncode in (None, 0):
+        return
+
+    cmd = " ".join(cfg.task_normalize_command or [])
+    message = (
+        f"The repository's normalizer (`{cmd}`) fails on the unpatched "
+        f"checkout (exit {returncode}), so no patch can pass it — this is a "
+        "broken gate, not a bad patch, and it needs an operator. Common cause: "
+        "the task-runner image has drifted from the target repo's `main` (a "
+        "dependency pin moved, and the gate's editable install runs with "
+        f"`--no-deps`).\n\n{_bounded_normalize_feedback(output)}"
+    )
+    state["broken"] = message
+    emit("normalize_error", f"Normalizer fails on the pristine checkout:\n{output}")
+    raise NormalizeGateBroken(message)
+
+
 def _validate_patch(
     cfg: Config,
     *,
@@ -396,6 +475,7 @@ def _validate_patch(
     clone_cache: CloneCache,
     content: Optional[str],
     emit: Callable[[str, str], None],
+    baseline_state: Optional[dict] = None,
 ) -> tuple[Optional[str], bool]:
     """Validate the model's final answer by applying its patch to a clean
     worktree and running the repo normalizer.
@@ -452,6 +532,15 @@ def _validate_patch(
         emit(
             "normalize_error",
             f"Normalizer failed (exit {returncode}) for `{cmd}`:\n{output}",
+        )
+        # Before spending a correction on it, make sure the patch is actually
+        # what the normalizer is unhappy about (raises when it is not).
+        _check_normalizer_baseline(
+            cfg,
+            checkout=checkout,
+            clone_cache=clone_cache,
+            emit=emit,
+            state=baseline_state if baseline_state is not None else {},
         )
         msg = (
             f"Your patch applied cleanly, but the repository's normalizer "
@@ -561,6 +650,9 @@ def prepare_task(
     # closure records whether the accepted answer left the worktree prepared.
     normalize_configured = bool(cfg.task_normalize_command)
     outcome = {"prepared": False}
+    # Shared across corrections so the pristine-checkout baseline (which costs a
+    # full normalizer run) is paid at most once per task.
+    baseline_state: dict = {}
 
     def _validate(chat) -> Optional[str]:
         feedback, prepared = _validate_patch(
@@ -569,6 +661,7 @@ def prepare_task(
             clone_cache=clone_cache,
             content=chat.content,
             emit=_emit,
+            baseline_state=baseline_state,
         )
         outcome["prepared"] = prepared
         return feedback
@@ -1115,6 +1208,16 @@ def publish_task(
                 _emit(
                     "normalize_error",
                     f"Normalizer failed (exit {returncode}) for `{cmd}`:\n{output}",
+                )
+                # Same distinction as the in-loop gate: if the normalizer also
+                # rejects the pristine checkout this is an operator problem,
+                # and reporting it as "the budget was exhausted" hides that.
+                _check_normalizer_baseline(
+                    cfg,
+                    checkout=checkout,
+                    clone_cache=clone_cache,
+                    emit=_emit,
+                    state={},
                 )
                 _emit("log", "Normalizer rejected the patch; not opening a PR.")
                 return TaskResult(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,6 +13,7 @@ from reviewbot.clone_cache import Checkout, CloneCache
 from reviewbot.config import Config
 from reviewbot.github_client import SERGE_GIT_EMAIL
 from reviewbot.tasks import (
+    NormalizeGateBroken,
     TaskError,
     TaskPlan,
     TaskRequest,
@@ -41,6 +42,17 @@ def _git(cwd, *args):
             "GIT_COMMITTER_EMAIL": "t@example.com",
         },
     )
+
+
+# Normalize commands for the gate tests. The distinction matters: a normalizer
+# that fails only once the patch is in the tree is rejecting the PATCH (feed it
+# back to the model), while one that fails on the pristine checkout is a BROKEN
+# GATE (no patch can pass; raise NormalizeGateBroken). Both test suites' _PATCH
+# rewrites hello.txt to "hi patched", so grepping for it tells them apart.
+_REJECTS_THE_PATCH = (
+    'grep -q "hi patched" hello.txt && { echo boom >&2; exit 3; }; exit 0'
+)
+_REJECTS_EVERYTHING = "echo boom >&2; exit 3"
 
 
 def _make_cfg(**overrides) -> Config:
@@ -736,9 +748,12 @@ class PublishFallbackNormalizeTests(unittest.TestCase):
 
     def test_fallback_refuses_when_normalizer_rejects(self):
         # Normalizer exits non-zero on the raw patch -> no PR, worktree reset.
+        # It must reject the PATCH specifically: one that fails on the pristine
+        # checkout too is a broken gate, which raises instead (see
+        # NormalizeBaselineTests).
         co = self._checkout()
         cfg = self._cfg(
-            task_normalize_command=["sh", "-c", "echo boom >&2; exit 3"],
+            task_normalize_command=["sh", "-c", _REJECTS_THE_PATCH],
             task_normalize_timeout=30,
         )
         plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
@@ -757,6 +772,30 @@ class PublishFallbackNormalizeTests(unittest.TestCase):
         self.assertIn("normalizer", result.message.lower())
         self.assertIn("exit 3", result.message)
         # Worktree restored to the pristine checkout.
+        self.assertEqual(self.cache.collect_changes(co), [])
+
+    def test_fallback_raises_when_the_gate_itself_is_broken(self):
+        # The raw-apply fallback makes the same distinction: a normalizer that
+        # rejects the pristine checkout too is an operator problem, and
+        # reporting it as "the correction budget was exhausted" would hide it.
+        co = self._checkout()
+        cfg = self._cfg(
+            task_normalize_command=["sh", "-c", _REJECTS_EVERYTHING],
+            task_normalize_timeout=30,
+        )
+        plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        with self.assertRaises(NormalizeGateBroken):
+            publish_task(
+                cfg,
+                gh,
+                self._req(),
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+            )
+        self.assertIsNone(gh.created_pr)
         self.assertEqual(self.cache.collect_changes(co), [])
 
     def test_no_normalizer_configured_commits_raw_patch(self):
@@ -853,10 +892,10 @@ class ValidatePatchTests(unittest.TestCase):
         self.assertEqual(changed, ["extra.txt", "hello.txt"])
 
     def test_normalizer_failure_feeds_back_and_resets(self):
-        # Non-zero normalizer exit -> feedback to the model, worktree reset
-        # clean (so the next attempt starts pristine).
+        # Non-zero normalizer exit ON THE PATCH -> feedback to the model,
+        # worktree reset clean (so the next attempt starts pristine).
         cfg = self._cfg(
-            task_normalize_command=["sh", "-c", "echo boom >&2; exit 3"],
+            task_normalize_command=["sh", "-c", _REJECTS_THE_PATCH],
             task_normalize_timeout=30,
         )
         events = []
@@ -885,13 +924,99 @@ class ValidatePatchTests(unittest.TestCase):
 
     def test_operator_guidance_is_appended_to_feedback(self):
         cfg = self._cfg(
-            task_normalize_command=["sh", "-c", "echo boom >&2; exit 3"],
+            task_normalize_command=["sh", "-c", _REJECTS_THE_PATCH],
             task_normalize_timeout=30,
             task_normalize_guidance="HOUSE RULE: never add new dependencies.",
         )
         feedback, prepared = self._validate(cfg, self._content(self._PATCH))
         self.assertFalse(prepared)
         self.assertIn("HOUSE RULE: never add new dependencies.", feedback)
+
+    def test_broken_gate_raises_instead_of_blaming_the_patch(self):
+        # The prod shape (transformers#48037): the normalizer fails for a reason
+        # that has nothing to do with the patch — a stale dependency in the
+        # runner image — so it fails on the pristine checkout too. Feeding that
+        # back would burn the whole correction budget and then report "the patch
+        # does not pass the normalizer", so it must raise instead.
+        cfg = self._cfg(
+            task_normalize_command=["sh", "-c", _REJECTS_EVERYTHING],
+            task_normalize_timeout=30,
+        )
+        events = []
+        with self.assertRaises(NormalizeGateBroken) as caught:
+            _validate_patch(
+                cfg,
+                checkout=self.co,
+                clone_cache=self.cache,
+                content=self._content(self._PATCH),
+                emit=lambda kind, text: events.append((kind, text)),
+            )
+        message = str(caught.exception)
+        self.assertIn("unpatched checkout", message)
+        self.assertIn("boom", message)
+        # Not 422: that would make the runner skip to the next candidate group,
+        # but a broken gate fails every group.
+        self.assertEqual(caught.exception.status_code, 500)
+        self.assertTrue(
+            any(
+                kind == "normalize_error" and "pristine checkout" in text
+                for kind, text in events
+            )
+        )
+        # Worktree still pristine for whatever runs next.
+        self.assertEqual(self.cache.collect_changes(self.co), [])
+
+    def test_baseline_runs_once_per_task(self):
+        # The baseline costs a full normalizer run, so the answer is cached
+        # across corrections rather than re-run for each one.
+        marker = os.path.join(self._tmp.name, "runs")
+        cfg = self._cfg(
+            task_normalize_command=[
+                "sh",
+                "-c",
+                f'echo x >> "{marker}"; echo boom >&2; exit 3',
+            ],
+            task_normalize_timeout=30,
+        )
+        state: dict = {}
+
+        def _run():
+            return _validate_patch(
+                cfg,
+                checkout=self.co,
+                clone_cache=self.cache,
+                content=self._content(self._PATCH),
+                emit=lambda *a: None,
+                baseline_state=state,
+            )
+
+        with self.assertRaises(NormalizeGateBroken):
+            _run()
+        with open(marker) as f:
+            after_first = len(f.read().split())
+        # Patch run + baseline run.
+        self.assertEqual(after_first, 2)
+
+        # A second correction attempt replays the cached verdict: it still
+        # raises, but without paying for another baseline run.
+        with self.assertRaises(NormalizeGateBroken):
+            _run()
+        with open(marker) as f:
+            after_second = len(f.read().split())
+        self.assertEqual(after_second, 3)
+
+    def test_healthy_gate_pays_nothing_on_the_happy_path(self):
+        # A clean normalizer never triggers the baseline check at all.
+        marker = os.path.join(self._tmp.name, "runs")
+        cfg = self._cfg(
+            task_normalize_command=["sh", "-c", f'echo x >> "{marker}"; exit 0'],
+            task_normalize_timeout=30,
+        )
+        feedback, prepared = self._validate(cfg, self._content(self._PATCH))
+        self.assertIsNone(feedback)
+        self.assertTrue(prepared)
+        with open(marker) as f:
+            self.assertEqual(len(f.read().split()), 1)
 
     def test_unapplyable_patch_feeds_back(self):
         cfg = self._cfg(


### PR DESCRIPTION
## The problem

When the repo normalizer rejects a patch, the in-loop gate feeds the failure back to the model and spends a correction. That is correct when the patch is at fault, and useless when **the gate itself is broken**: every correction is rejected by the same environment error, the budget runs out, and the task reports *"the proposed patch does not pass the repository's normalizer"* — pointing the reader at the model rather than at the runner image.

That is exactly what the 2026-08-17 nightly triage hit ([transformers#48037](https://github.com/huggingface/transformers/issues/48037)):

- transformers' `main` moved its `tokenizers` pin to `>=0.23.1,<0.24.0` (`242f5df9`, 2026-08-17 01:35 UTC);
- the task-runner image still had `tokenizers==0.22.2`;
- so **every** checker that imports transformers died on `dependency_versions_check` — 6 of them, while the 2 that don't import transformers passed;
- three groups (`cosmos3_omni`, `generation`, `cwm`) reported 🚫 no fix, and **~3.5M input tokens** were spent on an error no patch could address.

The gate installs the worktree with `--no-deps`, and it has to: the task pod's egress allowlist has no PyPI. So it cannot repair a dependency drift on its own — it can only notice it.

## The change

On a normalizer failure, re-run the normalizer once on the **pristine** checkout:

- clean exit → the gate works, the patch really is at fault → unchanged behavior (feedback to the model);
- non-zero → no patch can pass → raise `NormalizeGateBroken`, so the task fails loudly with the likely cause named.

Properties:

- **Failure path only** — a healthy task pays nothing.
- **Cached per task** — the extra normalizer run is paid at most once, no matter how many corrections follow.
- **Not a 422** — 422 makes the runner skip to the next candidate group, but a broken gate breaks every group.
- **Both call sites** — the in-loop gate and `publish_task`'s raw-apply fallback (the one that produced the message quoted above).
- Exit code, not diff, is the signal: a base that isn't itself normalizer-clean legitimately produces changes, and the worktree is left pristine either way.

## Tests

`653 passed`, ruff clean. The existing "normalizer rejects the patch" tests used a normalizer that failed *unconditionally* — which is now the broken-gate case — so they were switched to a patch-sensitive one and still test what they claim to. New: broken gate raises (with status 500 and the `normalize_error` event), the baseline runs once per task, and a healthy gate never triggers it.

## Not in this PR

The image drift itself. `serge-task-runner` needs a rebuild on a current `transformers-quality` base so prod stops failing on `tokenizers`; this PR only makes the next occurrence legible instead of expensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)