### PR TITLE
Resolve the quality toolchain from transformers main at image build

### DIFF
--- a/docker/Dockerfile.task-runner
+++ b/docker/Dockerfile.task-runner
@@ -32,6 +32,24 @@ RUN if ! (command -v git >/dev/null && command -v make >/dev/null); then \
       && rm -rf /var/lib/apt/lists/*; \
     fi
 
+# Re-resolve the target repo's quality toolchain from its main branch.
+#
+# LOAD-BEARING, do not drop. The base image installs `transformers[quality]` at
+# ITS OWN build time (nightly), so every pin in it freezes on that date. When a
+# pin then moves on main, the normalize gate fails for EVERY task on a checker
+# unrelated to the patch, and the gate cannot repair it: it installs the worktree
+# with `--no-deps` (mandatory — the task pod's egress allowlist has no PyPI).
+# Twice in two days:
+#   2026-08-17  tokenizers 0.22.2 in-image vs main's new >=0.23.1 pin
+#               -> 6 checkers dead on the version guard, 3 groups lost, ~3.5M tokens
+#   2026-08-18  transformers-mlinter 0.1.2 in-image vs main's 0.1.4 rule schema
+#               -> "Invalid rule spec for TRF054: default_enabled must be bool"
+# Resolving here makes the gate's env only as stale as *this* image, which a
+# rebuild fixes on demand — instead of waiting for the base's next nightly.
+ARG TRANSFORMERS_REF=main
+RUN pip install --no-cache-dir --upgrade \
+      "transformers[quality] @ git+https://github.com/huggingface/transformers@${TRANSFORMERS_REF}"
+
 # Layer serge on top of the toolchain, into the base image's Python environment
 # so `reviewbot-task-runner` is on PATH and its imports resolve. Only the base
 # deps are needed (requests/pyjwt/flask) — not the [web] server extras.


### PR DESCRIPTION
## Why

The task-runner image gets transformers' lint/checker toolchain from `huggingface/transformers-quality`, which installs `transformers[quality]` **at its own build time** (nightly, 00:06 UTC). Every pin in it therefore freezes on that date. When a pin then moves on `main`, the normalize gate fails for **every** task on a checker unrelated to the patch — and the gate cannot repair it, because it installs the worktree with `--no-deps` (mandatory: the task pod's egress allowlist has no PyPI).

Twice in two days:

| Date | Drift | Effect |
| --- | --- | --- |
| 2026-08-17 | `tokenizers` 0.22.2 in-image vs main's new `>=0.23.1` | every checker importing transformers died on the version guard — 3 groups lost, ~3.5M input tokens ([transformers#48037](https://github.com/huggingface/transformers/issues/48037)) |
| 2026-08-18 | `transformers-mlinter` 0.1.2 in-image vs the 0.1.4 rule schema main moved to at 06:45 UTC (`d032a44a9e`) | `ValueError: Invalid rule spec for TRF054: default_enabled must be bool` |

Reproduced locally against main's `utils/rules.toml`:

```
mlinter 0.1.2 → ValueError: Invalid rule spec for TRF054: default_enabled must be bool
mlinter 0.1.4 → parsed OK — 56 rules
```

The second one appeared on the very morning the image was rebuilt for the first: the base was built 00:21 UTC, main moved at 06:45 UTC. So **a rebuild alone is not a fix**, and waiting for the base's next nightly (00:06 UTC) misses tonight's 22:00 UTC triage.

Worth noting the guard from #88 did its job here — instead of burning three correction budgets and reporting "the patch does not pass the normalizer", the three dispatched groups failed loudly as a broken gate and named the checker. That is how this was diagnosed in minutes.

## What

Re-resolve the quality extra from transformers `main` in `Dockerfile.task-runner`, after the base. The gate's environment is then only as stale as *this* image, which a rebuild fixes on demand instead of waiting on the base. `TRANSFORMERS_REF` is a build arg so an operator can pin a ref when `main` itself is the problem.

Costs a little build time and image size; buys an environment we can actually refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)