### PR TITLE
Survive a rate limit instead of losing the task to it

### DIFF
--- a/reviewbot/github_client.py
+++ b/reviewbot/github_client.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import time
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Sequence
 
 import requests
 
@@ -541,6 +541,47 @@ class GitHubClient:
                 response=r,
             )
         return r.json()
+
+    def request_reviewers(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        reviewers: Sequence[str],
+    ) -> list[str]:
+        """Request reviews on a PR. Returns the logins GitHub accepted.
+
+        **Fail-soft by contract**: a reviewer request is a courtesy on top of an
+        already-published PR, so every failure is logged and swallowed rather
+        than raised. GitHub 422s the whole call for reasons that are none of the
+        PR's business — the login is not a collaborator, it is the PR's own
+        author, it no longer exists — and losing the PR over that would be
+        absurd. Returns ``[]`` when nothing was requested."""
+        if not reviewers:
+            return []
+        try:
+            r = self.session.post(
+                f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/requested_reviewers",
+                json={"reviewers": list(reviewers)},
+                timeout=60,
+            )
+        except requests.RequestException as exc:
+            log.warning(
+                "could not request reviewers on %s/%s#%s: %s", owner, repo, number, exc
+            )
+            return []
+        if not r.ok:
+            log.warning(
+                "%d requesting reviewers %s on %s/%s#%s: %s",
+                r.status_code,
+                list(reviewers),
+                owner,
+                repo,
+                number,
+                r.text[:300],
+            )
+            return []
+        return list(reviewers)
 
     def search_issues(
         self,

--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -124,6 +124,112 @@ class ChatResult:
         return v if isinstance(v, int) else None
 
 
+# Rate-limit headers, in the spellings the OpenAI-compatible endpoints serge
+# talks to actually use. Request budgets only: a token budget resets on a
+# different clock and pacing on it would stall the loop for a limit it is not
+# hitting.
+_REMAINING_HEADERS = (
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-remaining",
+    "ratelimit-remaining",
+)
+_RESET_HEADERS = (
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset",
+    "ratelimit-reset",
+)
+# "6m0s", "1.5s", "300ms" — the duration form OpenAI-style resets use.
+_DURATION_RE = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h)")
+# A reset given as an absolute epoch rather than a duration. Anything past this
+# is a timestamp, not "wait 1.7 billion seconds".
+_EPOCH_THRESHOLD = 1_000_000_000
+
+
+def _header(response: Optional["requests.Response"], names: tuple[str, ...]) -> str:
+    """First present value among ``names``, or ``""``. Tolerates a Mock
+    ``headers`` (tests) and a response that never arrived."""
+    headers = getattr(response, "headers", None)
+    if not hasattr(headers, "get"):
+        return ""
+    for name in names:
+        value = headers.get(name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _parse_duration(raw: str) -> Optional[float]:
+    """Seconds from a rate-limit reset value: ``"20"``, ``"6m0s"``, ``"300ms"``,
+    or an absolute epoch. ``None`` when it is not any of those."""
+    if not raw:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        pass
+    else:
+        if value >= _EPOCH_THRESHOLD:  # absolute timestamp
+            return max(0.0, value - time.time())
+        return max(0.0, value)
+    total = 0.0
+    matched = False
+    for amount, unit in _DURATION_RE.findall(raw):
+        matched = True
+        total += float(amount) * {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}[unit]
+    return total if matched else None
+
+
+def _retry_after_seconds(response: Optional["requests.Response"]) -> Optional[float]:
+    """``Retry-After`` in seconds, from either the delta or HTTP-date form."""
+    raw = _header(response, ("Retry-After", "retry-after"))
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+    try:
+        from email.utils import parsedate_to_datetime
+
+        return max(0.0, parsedate_to_datetime(raw).timestamp() - time.time())
+    except Exception:  # noqa: BLE001 - a malformed date is simply no answer
+        return None
+
+
+def _reset_seconds(response: Optional["requests.Response"]) -> Optional[float]:
+    """Seconds until the request budget resets, per the server's own headers."""
+    return _parse_duration(_header(response, _RESET_HEADERS))
+
+
+def _budget_interval(response: Optional["requests.Response"]) -> Optional[float]:
+    """Spacing that spends the *reported* remaining requests evenly over the
+    window they reset in — the provider's own numbers, not a guess.
+
+    ``None`` when the endpoint publishes no budget (most do not), or when there
+    is enough headroom that pacing would only slow the loop down for nothing."""
+    remaining_raw = _header(response, _REMAINING_HEADERS)
+    if not remaining_raw:
+        return None
+    try:
+        remaining = int(float(remaining_raw))
+    except ValueError:
+        return None
+    reset = _reset_seconds(response)
+    if reset is None or reset <= 0:
+        return None
+    if remaining <= 0:
+        # Budget spent: the whole window is the wait.
+        return reset
+    if remaining > _PACE_WHEN_REMAINING_BELOW:
+        return None
+    return reset / remaining
+
+
+# Only pace when the reported headroom is this tight. Above it the loop runs at
+# full speed: a limit we are nowhere near is not worth a single second.
+_PACE_WHEN_REMAINING_BELOW = 10
+
+
 class ChatCompletionClient:
     """Minimal OpenAI-compatible /v1/chat/completions client.
 
@@ -147,6 +253,11 @@ class ChatCompletionClient:
         self.bill_to = bill_to or None
         self.stream = stream
         self.compressor = compressor
+        # Adaptive pacing, learned from 429s (see :meth:`_throttle_wait`). One
+        # client serves one agentic loop, so this is per-task state: the loop
+        # that tripped a rate limit is the loop that must slow down.
+        self._min_interval = 0.0
+        self._next_earliest = 0.0
 
     def _api_base_v1(self) -> str:
         if self.api_base.endswith("/v1"):
@@ -327,30 +438,96 @@ class ChatCompletionClient:
     # without letting a misbehaving upstream pin a worker forever.
     _RETRY_WAIT_CEILING_SECONDS = 120.0
 
+    # A 429 gets its OWN, much larger budget than the 3 attempts a 5xx or a
+    # dropped connection gets, because it is a different kind of failure. A
+    # server error may never clear, so failing fast is right. A rate limit
+    # clears by *waiting* — and what we throw away by giving up is the whole
+    # agentic loop that came before it: one 429 ended the `deepseek_vl` task on
+    # 2026-08-18 after it had already spent 1.13M input tokens (transformers#48050).
+    # 6 attempts of backed-off waiting is minutes of patience against an hour of
+    # wasted work.
+    _RATE_LIMIT_ATTEMPTS = 6
+    # Pacing after a rate limit. Retrying the one rejected call is not enough:
+    # the loop is about to issue the same burst of tool turns that tripped the
+    # limit, so the next calls have to be spaced out too. The interval doubles
+    # per 429 and decays on success, which converges on whatever rate the
+    # provider is actually willing to serve without needing to know its limit.
+    _THROTTLE_FIRST_SECONDS = 2.0
+    _THROTTLE_CEILING_SECONDS = 30.0
+    _THROTTLE_DECAY = 0.5
+    # Below this the pacing is noise; drop it entirely so a loop that hit one
+    # transient 429 returns to full speed instead of limping forever.
+    _THROTTLE_FLOOR_SECONDS = 0.25
+
+    def _throttle_wait(self) -> None:
+        """Block until this client is allowed to issue its next request.
+
+        No-op until a 429 has been seen — an endpoint that never rate-limits us
+        is never slowed down."""
+        if self._min_interval <= 0.0:
+            return
+        remaining = self._next_earliest - time.monotonic()
+        if remaining > 0:
+            log.info("pacing LLM call: waiting %.1fs after a rate limit", remaining)
+            time.sleep(remaining)
+
+    def _note_rate_limited(self, response: "requests.Response") -> None:
+        """Widen the spacing between requests after a 429.
+
+        Prefer what the server said. ``Retry-After`` (or an ``x-ratelimit-reset``
+        family header) is the window it wants us to sit out, which beats any
+        number we could invent; the doubling heuristic is only the fallback for
+        providers that send neither."""
+        told = _retry_after_seconds(response)
+        if told is None:
+            told = _reset_seconds(response)
+        if told is not None:
+            self._min_interval = min(
+                max(told, self._THROTTLE_FLOOR_SECONDS), self._THROTTLE_CEILING_SECONDS
+            )
+            return
+        widened = max(self._min_interval * 2, self._THROTTLE_FIRST_SECONDS)
+        self._min_interval = min(widened, self._THROTTLE_CEILING_SECONDS)
+
+    def _note_request_done(
+        self, response: Optional["requests.Response"] = None, *, rate_limited: bool
+    ) -> None:
+        """Record when the next request may go out.
+
+        When the provider publishes its budget (the ``x-ratelimit-*`` family),
+        pace from it directly: spreading the remaining allowance over the window
+        it resets in keeps the loop UNDER the limit instead of discovering the
+        limit by being rejected. Only headroom the server reports as tight
+        actually slows anything down.
+
+        Otherwise a successful call decays the spacing, so the loop speeds back
+        up as the provider lets it — driven by real successes rather than
+        wall-clock optimism."""
+        paced = None if rate_limited else _budget_interval(response)
+        if paced is not None:
+            self._min_interval = min(paced, self._THROTTLE_CEILING_SECONDS)
+        elif not rate_limited and self._min_interval > 0.0:
+            self._min_interval *= self._THROTTLE_DECAY
+            if self._min_interval < self._THROTTLE_FLOOR_SECONDS:
+                self._min_interval = 0.0
+        self._next_earliest = time.monotonic() + self._min_interval
+
     @staticmethod
     def _retry_delay(attempt: int, response: "requests.Response") -> float:
-        """Compute how long to sleep before retrying. Honors ``Retry-After``
-        (seconds or HTTP-date form) when the server provides one; otherwise
-        falls back to exponential backoff (2,4,8,...)."""
-        ra = response.headers.get("Retry-After")
-        # Guard against non-string values (e.g. Mock objects in tests).
-        # Real ``requests.Response`` only ever returns ``str | None`` here.
-        if isinstance(ra, str) and ra:
-            try:
-                return min(float(ra), ChatCompletionClient._RETRY_WAIT_CEILING_SECONDS)
-            except ValueError:
-                # HTTP-date form (rare on LLM endpoints) — parse it.
-                try:
-                    from email.utils import parsedate_to_datetime
+        """How long to sleep before retrying.
 
-                    target = parsedate_to_datetime(ra)
-                    secs = target.timestamp() - time.time()
-                    if secs > 0:
-                        return min(
-                            secs, ChatCompletionClient._RETRY_WAIT_CEILING_SECONDS
-                        )
-                except Exception:  # noqa: BLE001
-                    pass
+        Ask the server first: ``Retry-After`` (delta or HTTP-date), then the
+        ``x-ratelimit-reset`` family, which says when the budget refills and is
+        the honest answer when the endpoint sends no ``Retry-After``. Exponential
+        backoff (2, 4, 8, …) is the last resort, for a server that says nothing.
+
+        Always bounded by the per-wait ceiling — a server is allowed to be wrong
+        or hostile, and no single wait should pin a worker."""
+        told = _retry_after_seconds(response)
+        if told is None:
+            told = _reset_seconds(response)
+        if told is not None and told > 0:
+            return min(told, ChatCompletionClient._RETRY_WAIT_CEILING_SECONDS)
         return float(2**attempt)
 
     @staticmethod
@@ -397,7 +574,11 @@ class ChatCompletionClient:
         est_input_tokens: int = 0,
     ) -> ChatResult:
         body = json.dumps(payload)
-        for attempt in range(1, attempts + 1):
+        attempt = 0  # 5xx / transport failures, budget `attempts`
+        rate_limits = 0  # 429s, budget `_RATE_LIMIT_ATTEMPTS` — see below
+        while True:
+            attempt += 1
+            self._throttle_wait()
             try:
                 r = requests.post(
                     url,
@@ -406,14 +587,31 @@ class ChatCompletionClient:
                     timeout=300,
                     stream=self.stream,
                 )
-                # 429 (rate limit) and 5xx are retryable. 429 in particular
-                # gets hit during agentic tool loops on providers with
-                # bursty-traffic dynamic limits (e.g. Together.ai via HF
-                # Router, where a few quick tool turns can exceed a 1 RPM
-                # cap). Honor Retry-After when the server provides it.
-                if (
-                    r.status_code == 429 or r.status_code >= 500
-                ) and attempt < attempts:
+                # 429 (rate limit) gets hit during agentic tool loops on
+                # providers with bursty dynamic limits (e.g. Together.ai via HF
+                # Router, where a few quick tool turns can exceed a 1 RPM cap).
+                # It spends its own budget, NOT the error budget: a rate limit
+                # is a "come back later", so waiting it out is the correct
+                # response, and a persistent 5xx must still fail fast.
+                if r.status_code == 429 and rate_limits < self._RATE_LIMIT_ATTEMPTS:
+                    rate_limits += 1
+                    attempt -= 1
+                    # Widen the spacing for the calls that FOLLOW, but let the
+                    # explicit delay below govern this retry — pacing on top of
+                    # Retry-After would just wait twice for the same rejection.
+                    self._note_rate_limited(r)
+                    delay = self._retry_delay(rate_limits, r)
+                    log.warning(
+                        "LLM call rate-limited (429) %d/%d; retrying in %.1fs, "
+                        "then pacing calls %.1fs apart",
+                        rate_limits,
+                        self._RATE_LIMIT_ATTEMPTS,
+                        delay,
+                        self._min_interval,
+                    )
+                    time.sleep(delay)
+                    continue
+                if r.status_code >= 500 and attempt < attempts:
                     delay = self._retry_delay(attempt, r)
                     log.warning(
                         "LLM call attempt %d/%d returned %d; retrying in %.1fs",
@@ -424,6 +622,8 @@ class ChatCompletionClient:
                     )
                     time.sleep(delay)
                     continue
+                # Pace from this response's own budget headers when it has them.
+                self._note_request_done(r, rate_limited=False)
                 if not r.ok:
                     # Surface the upstream error body so the action log
                     # explains *why* the request was rejected (e.g. "tools
@@ -510,7 +710,8 @@ class ChatCompletionClient:
                                 "chunk_callback raised; suppressing", exc_info=True
                             )
             except retryable as exc:
-                if attempt == attempts:
+                self._note_request_done(rate_limited=False)
+                if attempt >= attempts:
                     log.error(
                         "LLM call attempt %d/%d failed during %s: %s; giving up",
                         attempt,

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -145,6 +145,12 @@ class TaskRequest:
     # renders them in the PR body and knows nothing about what they point at —
     # see :func:`pr_links.sanitize_test_links`.
     test_links: dict[str, list[dict[str, str]]] = field(default_factory=dict)
+    # Optional, from the /tasks payload: GitHub logins to request a review from
+    # on a newly opened PR. The dispatcher decides who is relevant — for the
+    # integration-failure triage that is the author of the commit its bisect
+    # blamed — and serge only forwards the request. See
+    # :func:`sanitize_reviewers`.
+    reviewers: tuple[str, ...] = ()
 
     @property
     def repo_full_name(self) -> str:
@@ -297,7 +303,42 @@ def build_task_request(
         slack_notify_pr_created=slack_notify_pr_created,
         slack_notify_task_finished=slack_notify_task_finished,
         test_links=pr_links.sanitize_test_links(payload.get("test_links")),
+        reviewers=sanitize_reviewers(payload.get("reviewers")),
     )
+
+
+# GitHub caps a single review request at 15 logins; stay under it and never ping
+# a crowd because a dispatcher sent a long list.
+MAX_REVIEWERS = 10
+# A GitHub login: 1-39 chars of alphanumerics and single inner hyphens. Bot
+# accounts (`dependabot[bot]`) deliberately fail this — a bot cannot review, and
+# requesting one 422s the whole call, taking the valid logins down with it.
+_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+
+
+def sanitize_reviewers(raw: Any) -> tuple[str, ...]:
+    """Validate an inbound ``reviewers`` list of GitHub logins.
+
+    Anything malformed is dropped rather than raising, for the same reason as
+    :func:`pr_links.sanitize_test_links`: a review request is a courtesy on top
+    of the fix, and a bad entry must not cost a PR. Order is preserved and
+    duplicates collapse (case-insensitively — GitHub logins are unique
+    case-insensitively, and requesting both spellings is one wasted 422)."""
+    if not isinstance(raw, list):
+        return ()
+    out: list[str] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        login = entry.strip().lstrip("@")
+        if not _LOGIN_RE.match(login) or login.lower() in seen:
+            continue
+        seen.add(login.lower())
+        out.append(login)
+        if len(out) == MAX_REVIEWERS:
+            break
+    return tuple(out)
 
 
 def _notification_bool(
@@ -1125,6 +1166,20 @@ def _commit_changes(
     emit_fn(
         "log", f"Opened PR #{pr.get('number')} (draft->ready): {pr.get('html_url')}"
     )
+    # Reviewers the dispatcher named — for the integration-failure triage, the
+    # author of the commit its bisect blamed for the regression. They are the one
+    # person who knows what the change was meant to do, so a fix PR that touches
+    # it should land in their queue rather than waiting for someone to notice.
+    #
+    # New PRs only: an existing_pr follow-up pushes onto a branch whose review is
+    # already requested, and re-requesting resets a review the author may have
+    # already given. Requested AFTER draft->ready, so this adds to whatever
+    # `assign-reviewers.yml` routes rather than racing it. Fail-soft (see
+    # `GitHubClient.request_reviewers`) — never lose a published PR over it.
+    if req.reviewers and pr.get("number"):
+        requested = gh.request_reviewers(owner, repo, pr["number"], req.reviewers)
+        if requested:
+            emit_fn("log", f"Requested review from {', '.join(requested)}")
     if req.slack_notify_pr_created:
         post_task_pr_created_notification(
             token=cfg.slack_bot_token,

--- a/tests/test_github_client_gitdata.py
+++ b/tests/test_github_client_gitdata.py
@@ -128,6 +128,33 @@ class GitDataMethodsTests(unittest.TestCase):
         with self.assertRaises(requests.HTTPError):
             self.gh.create_blob("o", "r", b"x")
 
+    def test_request_reviewers(self):
+        self.gh.session.post.return_value = _resp(payload={"number": 7})
+        got = self.gh.request_reviewers("o", "r", 7, ["octocat"])
+        self.assertEqual(got, ["octocat"])
+        url = self.gh.session.post.call_args[0][0]
+        self.assertTrue(url.endswith("/pulls/7/requested_reviewers"))
+        self.assertEqual(
+            self.gh.session.post.call_args.kwargs["json"], {"reviewers": ["octocat"]}
+        )
+
+    def test_request_reviewers_swallows_a_rejection(self):
+        # GitHub 422s the whole call when a login is not a collaborator (or is
+        # the PR's own author). The PR is already published by then, so this
+        # must never raise — it is a courtesy, not part of publishing.
+        self.gh.session.post.return_value = _resp(ok=False, status=422)
+        self.assertEqual(self.gh.request_reviewers("o", "r", 7, ["ghost"]), [])
+
+    def test_request_reviewers_swallows_a_transport_error(self):
+        import requests
+
+        self.gh.session.post.side_effect = requests.ConnectionError("nope")
+        self.assertEqual(self.gh.request_reviewers("o", "r", 7, ["octocat"]), [])
+
+    def test_request_reviewers_skips_the_call_when_empty(self):
+        self.assertEqual(self.gh.request_reviewers("o", "r", 7, []), [])
+        self.gh.session.post.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,4 +1,5 @@
 import json
+import time
 import unittest
 from unittest.mock import Mock, patch
 
@@ -242,7 +243,194 @@ class ChatCompletionClientTests(unittest.TestCase):
         self.assertEqual(result.content, "ok")
         self.assertEqual(mock_post.call_count, 2)
         # Honored the Retry-After: 1 header, capped to the per-wait ceiling.
+        # Only ONE sleep: the pacing this 429 arms governs the calls that
+        # FOLLOW, not the retry the server just told us when to make.
         mock_sleep.assert_called_once_with(1.0)
+
+    def _rate_limited(self, retry_after="1"):
+        return Mock(
+            status_code=429,
+            ok=False,
+            reason="Too Many Requests",
+            text="rate limit",
+            headers={"Retry-After": retry_after},
+        )
+
+    def _ok(self, content="ok"):
+        return Mock(
+            status_code=200,
+            json=Mock(return_value={"choices": [{"message": {"content": content}}]}),
+            raise_for_status=Mock(),
+        )
+
+    def test_rate_limits_do_not_spend_the_error_budget(self) -> None:
+        # The old loop gave 429 the same 3 attempts as a 5xx, so a burst ended
+        # the task — `deepseek_vl` lost 1.13M input tokens of finished work to
+        # one rate limit (transformers#48050). A 429 clears by waiting, so it
+        # gets its own, larger budget.
+        responses = [self._rate_limited() for _ in range(5)] + [self._ok()]
+        with (
+            patch("reviewbot.llm_client.time.sleep"),
+            patch(
+                "reviewbot.llm_client.requests.post", side_effect=responses
+            ) as mock_post,
+        ):
+            client = ChatCompletionClient("https://example.com/v1", "t", "m")
+            result = client.complete([{"role": "user", "content": "hi"}])
+        self.assertEqual(result.content, "ok")
+        self.assertEqual(mock_post.call_count, 6)
+
+    def test_a_persistent_rate_limit_still_gives_up(self) -> None:
+        responses = [
+            self._rate_limited()
+            for _ in range(ChatCompletionClient._RATE_LIMIT_ATTEMPTS + 1)
+        ]
+        with (
+            patch("reviewbot.llm_client.time.sleep"),
+            patch(
+                "reviewbot.llm_client.requests.post", side_effect=responses
+            ) as mock_post,
+        ):
+            client = ChatCompletionClient("https://example.com/v1", "t", "m")
+            with self.assertRaises(LLMResponseError) as caught:
+                client.complete([{"role": "user", "content": "hi"}])
+        self.assertEqual(caught.exception.status_code, 429)
+        self.assertEqual(
+            mock_post.call_count, ChatCompletionClient._RATE_LIMIT_ATTEMPTS + 1
+        )
+
+    def test_server_errors_keep_their_small_budget(self) -> None:
+        # A 5xx may never clear, so it must still fail fast — the bigger budget
+        # is for rate limits only.
+        error = Mock(
+            status_code=503,
+            ok=False,
+            reason="Service Unavailable",
+            text="down",
+            headers={},
+        )
+        with (
+            patch("reviewbot.llm_client.time.sleep"),
+            patch(
+                "reviewbot.llm_client.requests.post", side_effect=[error] * 4
+            ) as mock_post,
+        ):
+            client = ChatCompletionClient("https://example.com/v1", "t", "m")
+            with self.assertRaises(LLMResponseError):
+                client.complete([{"role": "user", "content": "hi"}])
+        self.assertEqual(mock_post.call_count, 3)
+
+    def test_a_429_paces_the_following_calls(self) -> None:
+        # Retrying the rejected call is not enough: the loop is about to issue
+        # the same burst that tripped the limit, so the NEXT call waits too.
+        with (
+            patch("reviewbot.llm_client.time.sleep") as mock_sleep,
+            patch(
+                "reviewbot.llm_client.requests.post",
+                side_effect=[self._rate_limited(), self._ok(), self._ok("second")],
+            ),
+        ):
+            client = ChatCompletionClient("https://example.com/v1", "t", "m")
+            client.complete([{"role": "user", "content": "hi"}])
+            self.assertGreater(client._min_interval, 0)
+            mock_sleep.reset_mock()
+            result = client.complete([{"role": "user", "content": "again"}])
+        self.assertEqual(result.content, "second")
+        # The second call was paced rather than fired immediately.
+        self.assertTrue(mock_sleep.called)
+
+    def test_pacing_decays_back_to_full_speed(self) -> None:
+        # A server that says nothing: the doubling heuristic is the fallback.
+        silent = Mock(headers={})
+        client = ChatCompletionClient("https://example.com/v1", "t", "m")
+        client._note_rate_limited(silent)
+        self.assertEqual(client._min_interval, client._THROTTLE_FIRST_SECONDS)
+        # Consecutive rate limits widen it, bounded by the ceiling.
+        for _ in range(10):
+            client._note_rate_limited(silent)
+        self.assertEqual(client._min_interval, client._THROTTLE_CEILING_SECONDS)
+        # Successes decay it, and it drops to zero rather than limping forever.
+        for _ in range(20):
+            client._note_request_done(rate_limited=False)
+        self.assertEqual(client._min_interval, 0.0)
+
+    def test_pacing_uses_what_the_server_said_not_a_guess(self) -> None:
+        # Retry-After is the server telling us when to come back; it beats any
+        # interval we could invent, so it sets the pacing directly.
+        client = ChatCompletionClient("https://example.com/v1", "t", "m")
+        client._note_rate_limited(Mock(headers={"Retry-After": "9"}))
+        self.assertEqual(client._min_interval, 9.0)
+
+    def test_pacing_falls_back_to_the_reset_header(self) -> None:
+        # No Retry-After, but the endpoint publishes when the budget refills.
+        client = ChatCompletionClient("https://example.com/v1", "t", "m")
+        client._note_rate_limited(Mock(headers={"x-ratelimit-reset-requests": "6m0s"}))
+        # Bounded by the ceiling — a server may be wrong or hostile.
+        self.assertEqual(client._min_interval, client._THROTTLE_CEILING_SECONDS)
+
+    def test_retry_delay_prefers_the_server_over_backoff(self) -> None:
+        delay = ChatCompletionClient._retry_delay(1, Mock(headers={"Retry-After": "7"}))
+        self.assertEqual(delay, 7.0)
+        # Then the reset family, then exponential backoff as a last resort.
+        delay = ChatCompletionClient._retry_delay(
+            1, Mock(headers={"x-ratelimit-reset": "12"})
+        )
+        self.assertEqual(delay, 12.0)
+        self.assertEqual(ChatCompletionClient._retry_delay(3, Mock(headers={})), 8.0)
+
+    def test_reset_header_formats(self) -> None:
+        from reviewbot import llm_client as mod
+
+        self.assertEqual(mod._parse_duration("20"), 20.0)
+        self.assertEqual(mod._parse_duration("300ms"), 0.3)
+        self.assertEqual(mod._parse_duration("6m0s"), 360.0)
+        self.assertEqual(mod._parse_duration("1h30m"), 5400.0)
+        self.assertIsNone(mod._parse_duration("soon"))
+        self.assertIsNone(mod._parse_duration(""))
+        # An absolute epoch is a deadline, not a 1.7-billion-second wait.
+        self.assertLess(mod._parse_duration(str(int(time.time()) + 30)), 31)
+
+    def test_low_headroom_paces_before_being_rejected(self) -> None:
+        # The whole point of throttling: stay UNDER the limit rather than
+        # discovering it by being refused. 4 requests left in a 20s window ->
+        # ~5s apart.
+        client = ChatCompletionClient("https://example.com/v1", "t", "m")
+        client._note_request_done(
+            Mock(
+                headers={
+                    "x-ratelimit-remaining-requests": "4",
+                    "x-ratelimit-reset-requests": "20",
+                }
+            ),
+            rate_limited=False,
+        )
+        self.assertEqual(client._min_interval, 5.0)
+
+    def test_plenty_of_headroom_is_not_paced(self) -> None:
+        client = ChatCompletionClient("https://example.com/v1", "t", "m")
+        client._note_request_done(
+            Mock(
+                headers={
+                    "x-ratelimit-remaining-requests": "900",
+                    "x-ratelimit-reset-requests": "60",
+                }
+            ),
+            rate_limited=False,
+        )
+        self.assertEqual(client._min_interval, 0.0)
+
+    def test_an_endpoint_that_never_rate_limits_is_never_paced(self) -> None:
+        with (
+            patch("reviewbot.llm_client.time.sleep") as mock_sleep,
+            patch(
+                "reviewbot.llm_client.requests.post",
+                side_effect=[self._ok(), self._ok()],
+            ),
+        ):
+            client = ChatCompletionClient("https://example.com/v1", "t", "m")
+            client.complete([{"role": "user", "content": "hi"}])
+            client.complete([{"role": "user", "content": "hi again"}])
+        mock_sleep.assert_not_called()
 
     def test_complete_raises_llmresponseerror_with_status_and_body_after_4xx(
         self,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,6 +13,7 @@ from reviewbot.clone_cache import Checkout, CloneCache
 from reviewbot.config import Config
 from reviewbot.github_client import SERGE_GIT_EMAIL
 from reviewbot.tasks import (
+    MAX_REVIEWERS,
     NormalizeGateBroken,
     TaskError,
     TaskPlan,
@@ -95,6 +96,7 @@ class _FakeGH:
         self.created_pr = None
         self.updated_refs = []
         self.created_refs = []
+        self.requested_reviewers = []
 
     def get_pr(self, owner, repo, number):
         self.calls.append(("get_pr", number))
@@ -149,6 +151,10 @@ class _FakeGH:
     def mark_pull_request_ready(self, node_id):
         self.marked_ready = node_id
 
+    def request_reviewers(self, owner, repo, number, reviewers):
+        self.requested_reviewers.append((number, list(reviewers)))
+        return list(reviewers)
+
 
 class BuildTaskRequestTests(unittest.TestCase):
     def test_minimal_new_pr(self):
@@ -200,6 +206,47 @@ class BuildTaskRequestTests(unittest.TestCase):
             ).test_links,
             {},
         )
+
+    def test_reviewers_are_accepted_and_sanitized(self):
+        req = build_task_request(
+            {
+                "instruction": "x",
+                "reviewers": [
+                    "@octocat",  # a leading @ is stripped
+                    "octocat",  # dupe (case-insensitive) collapses
+                    "OCTOCAT",
+                    "dependabot[bot]",  # a bot cannot review, and 422s the call
+                    "not a login",
+                    "",
+                    42,
+                    "second-user",
+                ],
+            },
+            owner="a",
+            repo="b",
+        )
+        self.assertEqual(req.reviewers, ("octocat", "second-user"))
+
+    def test_reviewers_are_optional_and_junk_is_not_fatal(self):
+        # Same contract as test_links: a review request is a courtesy on top of
+        # the fix, so a malformed field must never cost a PR.
+        self.assertEqual(
+            build_task_request({"instruction": "x"}, owner="a", repo="b").reviewers, ()
+        )
+        self.assertEqual(
+            build_task_request(
+                {"instruction": "x", "reviewers": "octocat"}, owner="a", repo="b"
+            ).reviewers,
+            (),
+        )
+
+    def test_reviewers_are_capped(self):
+        req = build_task_request(
+            {"instruction": "x", "reviewers": [f"user{i}" for i in range(25)]},
+            owner="a",
+            repo="b",
+        )
+        self.assertEqual(len(req.reviewers), MAX_REVIEWERS)
 
     def test_bad_mode(self):
         with self.assertRaises(TaskError):
@@ -447,6 +494,61 @@ class PublishTaskTests(unittest.TestCase):
         self.assertEqual(result.changed_files, ["hello.txt"])
         notify.assert_called_once()
 
+    def test_new_pr_requests_the_reviewers_the_dispatcher_named(self):
+        # The triage blames a commit for the regression; its author is the one
+        # person who knows what that change meant to do, so the fix PR should
+        # land in their queue instead of waiting to be noticed.
+        co = self._checkout("main")
+        req = TaskRequest(
+            owner="acme",
+            repo="widget",
+            base_ref="main",
+            instruction="fix",
+            context="",
+            mode="new_pr",
+            reviewers=("octocat",),
+        )
+        plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        with patch("reviewbot.tasks.post_task_pr_created_notification"):
+            publish_task(
+                self.cfg,
+                gh,
+                req,
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+            )
+        self.assertEqual(gh.requested_reviewers, [(99, ["octocat"])])
+        # After the draft->ready transition, so it adds to whatever the repo's
+        # own reviewer-assignment workflow routes rather than racing it.
+        self.assertEqual(gh.marked_ready, "PR_node_99")
+
+    def test_no_reviewers_means_no_call(self):
+        co = self._checkout("main")
+        req = TaskRequest(
+            owner="acme",
+            repo="widget",
+            base_ref="main",
+            instruction="fix",
+            context="",
+            mode="new_pr",
+        )
+        plan = TaskPlan(title="Fix hello", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        with patch("reviewbot.tasks.post_task_pr_created_notification"):
+            publish_task(
+                self.cfg,
+                gh,
+                req,
+                plan,
+                checkout=co,
+                clone_cache=self.cache,
+                job_id="abcd1234",
+            )
+        self.assertEqual(gh.requested_reviewers, [])
+
     def test_new_pr_notification_uses_request_slack_channel(self):
         co = self._checkout("main")
         req = TaskRequest(
@@ -506,6 +608,34 @@ class PublishTaskTests(unittest.TestCase):
         self.assertEqual(result.branch, "serge/fix-1")
         self.assertEqual(gh.updated_refs[0][0], "heads/serge/fix-1")
         self.assertIsNone(gh.created_pr)
+
+    def test_existing_pr_follow_up_does_not_re_request_reviewers(self):
+        # The review was requested when the PR was opened. Re-requesting on every
+        # follow-up push would reset a review the author may already have given.
+        co = self._checkout("serge/fix-1")
+        req = TaskRequest(
+            owner="acme",
+            repo="widget",
+            base_ref="main",
+            instruction="fix",
+            context="",
+            mode="existing_pr",
+            pr_number=5,
+            head_branch="serge/fix-1",
+            reviewers=("octocat",),
+        )
+        plan = TaskPlan(title="Fix again", body="desc", patch=self._PATCH)
+        gh = _FakeGH()
+        publish_task(
+            self.cfg,
+            gh,
+            req,
+            plan,
+            checkout=co,
+            clone_cache=self.cache,
+            job_id="abcd1234",
+        )
+        self.assertEqual(gh.requested_reviewers, [])
 
     def test_empty_patch_is_no_change(self):
         co = self._checkout("main")


### PR DESCRIPTION
## Why

One 429 ended the `deepseek_vl` task on 2026-08-18 *after it had already spent 1.13M input tokens* ([transformers#48050](https://github.com/huggingface/transformers/issues/48050)):

```
LLM endpoint returned 429 Too Many Requests: {"error":"Rate limit exceeded"}
```

Two causes, both fixed here.

**A 429 shared the error budget.** `attempts = 3` covered 5xx, dropped connections *and* rate limits, with 2s/4s backoff — about six seconds of patience before throwing away half an hour of finished work. But they are not alike: a server error may never clear, while a rate limit **clears by waiting**. Rate limits now get their own, larger budget; a persistent 5xx still fails fast at 3.

**Retrying the rejected call isn't enough.** The loop that tripped the limit is about to issue the same burst of tool turns, so the next call gets refused too. The client now paces itself.

## The numbers come from the server, not from me

- the retry waits what **`Retry-After`** says; failing that, what the **`x-ratelimit-reset`** family says; exponential backoff is only the last resort for an endpoint that says nothing;
- that same value sets the spacing for the calls that *follow*;
- on a **successful** response carrying `x-ratelimit-remaining-requests`, the spacing spreads the remaining allowance over the window it resets in — so the loop stays *under* the limit instead of discovering it by being refused. Only headroom the server reports as tight (<10 requests left) slows anything down.

Reset values are parsed in the forms providers actually send: plain seconds, `6m0s` / `300ms` durations, and absolute epochs (a deadline, not a 1.7-billion-second wait).

## Guard rails

- Spacing **decays on success**, so a loop that hit one transient 429 returns to full speed rather than limping forever.
- An endpoint that never rate-limits us is **never paced** — asserted by a test.
- Every wait stays bounded by the existing per-wait ceiling: a server is allowed to be wrong or hostile, and no single wait should pin a worker.
- Pacing is per-client, i.e. per task pod. Cross-pod coordination would need shared state; this fixes the burst *within* a loop, which is the shape that failed.

675 tests pass (11 new), `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)