### PR TITLE
Stop the grep tool from returning partial and empty results that look complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it whenever the output was under 8000 chars — i.e. on exactly the results
   that looked trustworthy. A single match line is also clipped at 300
   characters so one minified line cannot spend the whole output budget.
+- `grep` runs Perl-compatible patterns where git supports PCRE2, falling back
+  to POSIX ERE otherwise. Under `-E` a pattern like `TRF\d+` or
+  `\bViolation\b` matched nothing and returned `no matches`, which reads as
+  "not in this repo" — worse than a truncated answer, because it invents an
+  absence. The result header now names the flag actually used, and a no-match
+  answer under ERE says so when the pattern needed a feature ERE lacks.
+- `grep` searches untracked files too, so a file created by an applied patch
+  is visible to the search that follows it (`/tasks` greps after patching).
+  Gitignored paths stay excluded, and matches under a denylisted directory
+  (`node_modules`, `.venv`, …) are dropped rather than handed to a model that
+  `read_file` would then refuse.
 
 ## [0.1.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v1/models` is called with the `anthropic-version` header it requires.
 - The trigger gate now ignores comments authored by a bot, so the App never
   reacts to its own output (no self-trigger loops in App mode).
+- `grep` no longer under-reports silently. It ran `git grep --max-count=10`, a
+  cap that applies *per file* and left no trace in the output, so a
+  single-file search returned ten matches that looked like the complete set —
+  a rules file with 57 `description` lines came back as ten. The per-file cap
+  is now derived from `max_results` (one above it, so a partial answer is
+  distinguishable from a complete one), the output is streamed and stopped at
+  the cap instead of captured whole and sliced, and a truncated result ends
+  with an explicit note telling the model not to treat the count as final. The
+  note used to be passed to the 8000-char truncator as a suffix, which dropped
+  it whenever the output was under 8000 chars — i.e. on exactly the results
+  that looked trustworthy. A single match line is also clipped at 300
+  characters so one minified line cannot spend the whole output budget.
 
 ## [0.1.0] - 2026-06-17
 

--- a/reviewbot/tools.py
+++ b/reviewbot/tools.py
@@ -45,6 +45,18 @@ MAX_TOOL_OUTPUT_CHARS = 8000
 # even if the model asks for more.
 MAX_READ_LINES = 400
 
+# Grep bounds. ``max_results`` is the model-facing cap; this is the ceiling
+# it may ask for. A single match line is clipped too: one minified bundle or
+# generated fixture line must not spend the whole output budget by itself.
+MAX_GREP_RESULTS = 200
+DEFAULT_GREP_RESULTS = 50
+MAX_MATCH_LINE_CHARS = 300
+GREP_TIMEOUT_SECONDS = 20
+# Room reserved inside MAX_TOOL_OUTPUT_CHARS for the header and the
+# "there are more matches" note, so the note can never be the thing that
+# gets cut off.
+GREP_NOTE_RESERVE_CHARS = 400
+
 # Directories we never expose to the model. ``.git`` would let it read
 # refs / object data; the rest are caches that bloat output without
 # adding signal.
@@ -242,7 +254,11 @@ TOOL_SPECS: list[dict[str, Any]] = [
             "description": (
                 "Search for a regex pattern across the checked-out PR head "
                 "using git grep. Returns matches as `path:line:text`. Use this "
-                "to find call sites, definitions, or references not visible in the diff."
+                "to find call sites, definitions, or references not visible in "
+                "the diff. At most `max_results` matches come back, and when "
+                "more exist the result says so on its last line — a result "
+                "without that note is the complete set of matches, so you can "
+                "count them and rely on the count."
             ),
             "parameters": {
                 "type": "object",
@@ -258,7 +274,12 @@ TOOL_SPECS: list[dict[str, Any]] = [
                     },
                     "max_results": {
                         "type": "integer",
-                        "description": "Cap on returned matches. Defaults to 50, hard max 200.",
+                        "description": (
+                            f"Cap on returned matches. Defaults to "
+                            f"{DEFAULT_GREP_RESULTS}, hard max {MAX_GREP_RESULTS}. "
+                            f"Raise it when you need to count every match rather "
+                            f"than find one."
+                        ),
                     },
                 },
                 "required": ["pattern"],
@@ -683,6 +704,93 @@ def _list_dir(env: ToolEnv, args: dict[str, Any]) -> str:
 _SAFE_PATTERN_RE = re.compile(r"^[\x20-\x7E]+$")
 
 
+@dataclass
+class _GrepResult:
+    lines: list[str]
+    # True when we stopped early: there is at least one match we did not
+    # return. Observed, never guessed.
+    more: bool = False
+    timed_out: bool = False
+    returncode: int | None = None
+    stderr: str = ""
+
+
+def _clip_match_line(line: str) -> str:
+    if len(line) <= MAX_MATCH_LINE_CHARS:
+        return line
+    return f"{line[:MAX_MATCH_LINE_CHARS]} [... line clipped ...]"
+
+
+def _stream_grep(cmd: list[str], max_lines: int, char_budget: int) -> _GrepResult:
+    """Run ``cmd``, reading its output until one of the caps is reached.
+
+    Streamed rather than captured whole: a pattern that matches half of a
+    monorepo would otherwise land in memory in full, only to be sliced down
+    to fifty lines. Stopping at the cap also means ``more`` is something we
+    saw (the line after the last one we kept exists) instead of something we
+    inferred, which is what lets the caller tell the model the truth.
+    """
+    timed_out = threading.Event()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+    except FileNotFoundError as exc:
+        raise _ToolError("git is not installed in the runner") from exc
+
+    def _on_timeout() -> None:
+        timed_out.set()
+        proc.kill()
+
+    timer = threading.Timer(GREP_TIMEOUT_SECONDS, _on_timeout)
+    timer.start()
+    lines: list[str] = []
+    used = 0
+    more = False
+    try:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            if len(lines) >= max_lines:
+                more = True
+                break
+            line = _clip_match_line(raw.rstrip("\n"))
+            if used + len(line) + 1 > char_budget and lines:
+                more = True
+                break
+            lines.append(line)
+            used += len(line) + 1
+        stderr = ""
+        if proc.stderr is not None:
+            try:
+                stderr = proc.stderr.read(1000)
+            except OSError:
+                stderr = ""
+        if more:
+            # We are done reading but git is still producing matches; it
+            # would otherwise block on a full pipe until the timer fires.
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    finally:
+        timer.cancel()
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None:
+                stream.close()
+    return _GrepResult(
+        lines=lines,
+        more=more,
+        timed_out=timed_out.is_set(),
+        returncode=proc.returncode,
+        stderr=stderr.strip(),
+    )
+
+
 def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
     pattern = args.get("pattern")
     if not isinstance(pattern, str) or not pattern:
@@ -694,8 +802,8 @@ def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
     path_arg = args.get("path")
     pathspec = _resolve_path(env, path_arg, default=".") if path_arg else env.repo_root
     rel_pathspec = os.path.relpath(pathspec, env.repo_root) or "."
-    max_results = int(args.get("max_results") or 50)
-    max_results = max(1, min(max_results, 200))
+    max_results = int(args.get("max_results") or DEFAULT_GREP_RESULTS)
+    max_results = max(1, min(max_results, MAX_GREP_RESULTS))
     cmd = [
         "git",
         "-C",
@@ -704,35 +812,39 @@ def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
         "-n",
         "-I",
         "-E",
-        "--max-count=10",
+        # Per-file backstop, not the real cap: it keeps one pathological
+        # file from filling the whole result set. Deliberately one *above*
+        # max_results, so a file that genuinely holds more matches than was
+        # asked for still emits the extra line that proves there are more.
+        # A cap at or below max_results would make a partial answer
+        # indistinguishable from a complete one.
+        f"--max-count={max_results + 1}",
         "--",
         pattern,
     ]
     if path_arg:
         cmd.append(rel_pathspec)
-    try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=20,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise _ToolError("grep timed out (20s)") from exc
-    except FileNotFoundError as exc:
-        raise _ToolError("git is not installed in the runner") from exc
-    if proc.returncode == 1 and not proc.stdout:
-        return f"no matches for {pattern!r} in {rel_pathspec}"
-    if proc.returncode > 1:
-        return f"error: git grep exited {proc.returncode}: {proc.stderr.strip()[:300]}"
-    lines = proc.stdout.splitlines()
-    truncated = len(lines) > max_results
-    lines = lines[:max_results]
-    body = "\n".join(lines) if lines else "(no output)"
-    suffix = f"showing {len(lines)} of {len(lines)}+ matches" if truncated else ""
+
     header = f"git grep -E {pattern!r} -- {rel_pathspec}:"
-    return _truncate(f"{header}\n{body}", suffix_note=suffix)
+    char_budget = MAX_TOOL_OUTPUT_CHARS - len(header) - GREP_NOTE_RESERVE_CHARS
+    result = _stream_grep(cmd, max_results, max(1, char_budget))
+    if result.timed_out:
+        raise _ToolError(f"grep timed out ({GREP_TIMEOUT_SECONDS}s)")
+    if not result.lines:
+        if result.returncode is not None and result.returncode > 1:
+            return f"error: git grep exited {result.returncode}: {result.stderr[:300]}"
+        return f"no matches for {pattern!r} in {rel_pathspec}"
+    body = "\n".join(result.lines)
+    if not result.more:
+        return f"{header}\n{body}"
+    note = (
+        f"[serge] Showing the first {len(result.lines)} matches; there are "
+        f"more that are not listed. This is NOT the complete set — do not "
+        f"count these and conclude that is all there is. Narrow the pattern "
+        f"or the path, or re-call with a higher max_results "
+        f"(hard max {MAX_GREP_RESULTS})."
+    )
+    return f"{header}\n{body}\n{note}"
 
 
 def _fetch_url(args: dict[str, Any]) -> str:

--- a/reviewbot/tools.py
+++ b/reviewbot/tools.py
@@ -57,6 +57,16 @@ GREP_TIMEOUT_SECONDS = 20
 # gets cut off.
 GREP_NOTE_RESERVE_CHARS = 400
 
+# Constructs a model reaches for out of PCRE habit and which POSIX ERE does
+# not have. Under -E they do not error: `TRF\d+` simply matches nothing, so
+# "no matches" reads as "not in the repo". Detected so the no-match answer
+# can say which it was.
+_PCRE_ONLY_RE = re.compile(r"\\[dDwWsSbBAZ]|\(\?")
+
+# Resolved once per process: whether this git is built with PCRE2. Probing
+# costs a process, so we let the first real -P call answer it instead.
+_git_grep_pcre: bool | None = None
+
 # Directories we never expose to the model. ``.git`` would let it read
 # refs / object data; the rest are caches that bloat output without
 # adding signal.
@@ -253,9 +263,13 @@ TOOL_SPECS: list[dict[str, Any]] = [
             "name": "grep",
             "description": (
                 "Search for a regex pattern across the checked-out PR head "
-                "using git grep. Returns matches as `path:line:text`. Use this "
-                "to find call sites, definitions, or references not visible in "
-                "the diff. At most `max_results` matches come back, and when "
+                "using git grep, Perl-compatible (`\\d`, `\\b`, lookaround) "
+                "where git supports it. Returns matches as `path:line:text`. "
+                "Use this to find call sites, definitions, or references not "
+                "visible in the diff. The result header echoes the regex flag "
+                "actually used, and a no-match answer says so if the pattern "
+                "needed a feature the dialect lacks. "
+                "At most `max_results` matches come back, and when "
                 "more exist the result says so on its last line — a result "
                 "without that note is the complete set of matches, so you can "
                 "count them and rely on the count."
@@ -721,6 +735,22 @@ def _clip_match_line(line: str) -> str:
     return f"{line[:MAX_MATCH_LINE_CHARS]} [... line clipped ...]"
 
 
+def _is_denylisted_match(line: str) -> bool:
+    """True for a `path:line:text` match under a hidden directory.
+
+    ``--untracked`` widened grep past the tracked set, so grep can now reach
+    paths that ``read_file`` would refuse to open. Returning a match the model
+    cannot then read is worse than not returning it.
+    """
+    path = line.split(":", 1)[0]
+    return any(part in DENY_DIR_NAMES for part in path.split(os.sep))
+
+
+def _pcre_unavailable(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return "libpcre" in lowered or "perl-compatible" in lowered
+
+
 def _stream_grep(cmd: list[str], max_lines: int, char_budget: int) -> _GrepResult:
     """Run ``cmd``, reading its output until one of the caps is reached.
 
@@ -804,6 +834,11 @@ def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
     rel_pathspec = os.path.relpath(pathspec, env.repo_root) or "."
     max_results = int(args.get("max_results") or DEFAULT_GREP_RESULTS)
     max_results = max(1, min(max_results, MAX_GREP_RESULTS))
+    global _git_grep_pcre
+    # Perl-compatible where git has it: a model writes `\d`, `\b` and
+    # lookaround by reflex, and ERE answers those with a confident, wrong
+    # "no matches". Falls back to -E on a git built without PCRE2.
+    dialect = "-E" if _git_grep_pcre is False else "-P"
     cmd = [
         "git",
         "-C",
@@ -811,7 +846,11 @@ def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
         "grep",
         "-n",
         "-I",
-        "-E",
+        # Tracked files miss anything a patch just created, and /tasks greps
+        # after applying one. Ignored files stay out: --untracked honours
+        # .gitignore unless --no-exclude-standard is passed.
+        "--untracked",
+        dialect,
         # Per-file backstop, not the real cap: it keeps one pathological
         # file from filling the whole result set. Deliberately one *above*
         # max_results, so a file that genuinely holds more matches than was
@@ -825,15 +864,42 @@ def _grep(env: ToolEnv, args: dict[str, Any]) -> str:
     if path_arg:
         cmd.append(rel_pathspec)
 
-    header = f"git grep -E {pattern!r} -- {rel_pathspec}:"
+    header = f"git grep {dialect} {pattern!r} -- {rel_pathspec}:"
     char_budget = MAX_TOOL_OUTPUT_CHARS - len(header) - GREP_NOTE_RESERVE_CHARS
     result = _stream_grep(cmd, max_results, max(1, char_budget))
+    if (
+        dialect == "-P"
+        and result.returncode is not None
+        and result.returncode > 1
+        and _pcre_unavailable(result.stderr)
+    ):
+        # First -P call on a git without PCRE2. Remember it, redo the search
+        # in ERE, and let the no-match path below explain the dialect if the
+        # pattern needed the features we just lost.
+        log.info("git grep has no PCRE2 support; falling back to -E")
+        _git_grep_pcre = False
+        dialect = "-E"
+        cmd[cmd.index("-P")] = "-E"
+        header = f"git grep {dialect} {pattern!r} -- {rel_pathspec}:"
+        result = _stream_grep(cmd, max_results, max(1, char_budget))
+    elif dialect == "-P" and _git_grep_pcre is None and result.returncode in (0, 1):
+        _git_grep_pcre = True
     if result.timed_out:
         raise _ToolError(f"grep timed out ({GREP_TIMEOUT_SECONDS}s)")
+    result.lines = [ln for ln in result.lines if not _is_denylisted_match(ln)]
     if not result.lines:
         if result.returncode is not None and result.returncode > 1:
             return f"error: git grep exited {result.returncode}: {result.stderr[:300]}"
-        return f"no matches for {pattern!r} in {rel_pathspec}"
+        answer = f"no matches for {pattern!r} in {rel_pathspec}"
+        if dialect == "-E" and _PCRE_ONLY_RE.search(pattern):
+            answer += (
+                "\n[serge] This git has no PCRE support, so the pattern ran as "
+                "POSIX ERE, which has no \\d, \\w, \\s, \\b or (?...) — they "
+                "match nothing rather than erroring, so this result does not "
+                "mean the text is absent. Re-run with bracket expressions "
+                "([0-9], [A-Za-z_]) instead."
+            )
+        return answer
     body = "\n".join(result.lines)
     if not result.more:
         return f"{header}\n{body}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,6 +12,7 @@ from reviewbot.tools import (
     ALLOWED_FETCH_HOSTS,
     DENY_DIR_NAMES,
     MAX_FETCH_BODY_CHARS,
+    MAX_MATCH_LINE_CHARS,
     MAX_READ_LINES,
     MAX_TOOL_OUTPUT_CHARS,
     HelperInstallResult,
@@ -164,6 +165,76 @@ class ResolvePathTests(_TempRepo):
     def test_grep_rejects_non_ascii_pattern(self) -> None:
         out = run_tool(self.env, "grep", {"pattern": "héllo"})
         self.assertTrue(out.startswith("error:"), out)
+
+    @staticmethod
+    def _match_lines(out: str, name: str) -> int:
+        """Match lines only — the header echoes the pathspec too."""
+        return sum(1 for line in out.splitlines() if line.startswith(f"{name}:"))
+
+    def _write_tracked(self, name: str, body: str) -> None:
+        with open(os.path.join(self.repo_root, name), "w") as f:
+            f.write(body)
+        subprocess.run(["git", "add", name], cwd=self.repo_root, check=True)
+
+    def test_grep_returns_every_match_in_one_file_up_to_the_cap(self) -> None:
+        # The bug this covers: a per-file `git grep --max-count` well below
+        # max_results cut a single-file search down to a handful of matches
+        # and said nothing about it. A rules file with 57 `description =`
+        # lines came back looking like it had 10.
+        self._write_tracked(
+            "many.toml", "".join(f"description = {i}\n" for i in range(57))
+        )
+        out = run_tool(
+            self.env, "grep", {"pattern": "^description", "path": "many.toml"}
+        )
+        self.assertEqual(self._match_lines(out, "many.toml"), 50)
+        self.assertIn("not listed", out)
+
+    def test_grep_reports_all_matches_when_they_fit(self) -> None:
+        self._write_tracked(
+            "few.toml", "".join(f"description = {i}\n" for i in range(7))
+        )
+        out = run_tool(
+            self.env, "grep", {"pattern": "^description", "path": "few.toml"}
+        )
+        self.assertEqual(self._match_lines(out, "few.toml"), 7)
+        self.assertNotIn("not listed", out)
+
+    def test_grep_honours_raised_max_results_within_one_file(self) -> None:
+        self._write_tracked(
+            "many.toml", "".join(f"description = {i}\n" for i in range(57))
+        )
+        out = run_tool(
+            self.env,
+            "grep",
+            {"pattern": "^description", "path": "many.toml", "max_results": 200},
+        )
+        self.assertEqual(self._match_lines(out, "many.toml"), 57)
+        self.assertNotIn("not listed", out)
+
+    def test_grep_says_so_when_the_char_budget_stops_it(self) -> None:
+        # Truncation used to be handed to _truncate as a suffix_note, which
+        # only surfaced once the 8000-char cap tripped — so a result cut
+        # short by the match cap alone carried no note at all. Both limits
+        # must now announce themselves.
+        wide = "x" * 200
+        self._write_tracked(
+            "wide.txt", "".join(f"needle {wide} {i}\n" for i in range(120))
+        )
+        out = run_tool(
+            self.env,
+            "grep",
+            {"pattern": "needle", "path": "wide.txt", "max_results": 200},
+        )
+        self.assertLessEqual(len(out), MAX_TOOL_OUTPUT_CHARS)
+        self.assertIn("not listed", out)
+        self.assertLess(self._match_lines(out, "wide.txt"), 120)
+
+    def test_grep_clips_a_single_enormous_match_line(self) -> None:
+        self._write_tracked("minified.js", "var needle=" + "a" * 20000 + ";\n")
+        out = run_tool(self.env, "grep", {"pattern": "needle", "path": "minified.js"})
+        self.assertIn("line clipped", out)
+        self.assertLess(len(out), MAX_MATCH_LINE_CHARS + 1000)
 
     def test_unknown_tool_returns_error_message(self) -> None:
         out = run_tool(self.env, "delete_repo", {})

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
@@ -235,6 +236,67 @@ class ResolvePathTests(_TempRepo):
         out = run_tool(self.env, "grep", {"pattern": "needle", "path": "minified.js"})
         self.assertIn("line clipped", out)
         self.assertLess(len(out), MAX_MATCH_LINE_CHARS + 1000)
+
+    def test_grep_supports_perl_classes(self) -> None:
+        # ERE answers `\d` with a confident "no matches", which reads as
+        # "the identifier is not in this repo".
+        self._write_tracked("ids.txt", "TRF058 = 1\nTRF012 = 2\n")
+        out = run_tool(self.env, "grep", {"pattern": r"TRF\d+", "path": "ids.txt"})
+        self.assertEqual(self._match_lines(out, "ids.txt"), 2)
+
+    def test_grep_finds_a_file_created_since_the_last_commit(self) -> None:
+        # /tasks applies a patch and then searches; a tracked-files-only grep
+        # cannot see a file the patch created.
+        with open(os.path.join(self.repo_root, "brand_new.py"), "w") as f:
+            f.write("def freshly_added():\n    pass\n")
+        out = run_tool(self.env, "grep", {"pattern": "freshly_added"})
+        self.assertIn("brand_new.py:1:", out)
+
+    def test_grep_skips_gitignored_files(self) -> None:
+        self._write_tracked(".gitignore", "build/\n")
+        os.makedirs(os.path.join(self.repo_root, "build"), exist_ok=True)
+        with open(os.path.join(self.repo_root, "build", "generated.py"), "w") as f:
+            f.write("GENERATED_MARKER = 1\n")
+        out = run_tool(self.env, "grep", {"pattern": "GENERATED_MARKER"})
+        self.assertIn("no matches", out)
+
+    def test_grep_hides_matches_under_denylisted_dirs(self) -> None:
+        # read_file refuses these paths, so returning them as matches would
+        # hand the model a lead it cannot follow.
+        os.makedirs(os.path.join(self.repo_root, "node_modules"), exist_ok=True)
+        with open(os.path.join(self.repo_root, "node_modules", "dep.js"), "w") as f:
+            f.write("var vendored_marker = 1;\n")
+        out = run_tool(self.env, "grep", {"pattern": "vendored_marker"})
+        self.assertIn("no matches", out)
+
+    def test_grep_falls_back_to_ere_and_explains_the_dialect(self) -> None:
+        self._write_tracked("ids.txt", "TRF058 = 1\n")
+        real_popen = subprocess.Popen
+
+        def fake_popen(cmd, *a, **kw):  # type: ignore[no-untyped-def]
+            if "-P" in cmd:
+                # What a git built without PCRE2 actually says.
+                cmd = [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stderr.write('fatal: cannot use "
+                    "Perl-compatible regexes when not compiled with "
+                    "USE_LIBPCRE\\n'); sys.exit(128)",
+                ]
+            return real_popen(cmd, *a, **kw)
+
+        with (
+            patch.object(tools_mod, "_git_grep_pcre", None),
+            patch.object(tools_mod.subprocess, "Popen", side_effect=fake_popen),
+        ):
+            out = run_tool(self.env, "grep", {"pattern": r"TRF\d+", "path": "ids.txt"})
+        self.assertIn("no matches", out)
+        self.assertIn("POSIX ERE", out)
+        self.assertIn("[0-9]", out)
+
+    def test_grep_header_names_the_dialect(self) -> None:
+        out = run_tool(self.env, "grep", {"pattern": "def hello", "path": "src"})
+        self.assertIn("git grep -P", out)
 
     def test_unknown_tool_returns_error_message(self) -> None:
         out = run_tool(self.env, "delete_repo", {})


### PR DESCRIPTION
The `grep` tool returned partial and empty results that were indistinguishable from
complete and genuine ones. Three bugs, all measured against
[huggingface/transformers-mlinter](https://github.com/huggingface/transformers-mlinter),
whose `mlinter/rules.toml` holds 50+ lint rules in one 1000-line file.

## 1. `--max-count=10` is per file, and silent

git's own help: `-m, --max-count <n>  maximum number of results per file`. So a
single-file search returned ten matches that read as the complete set:

| query over `mlinter/rules.toml` | returned | actual |
|---|---|---|
| `^description` | 10 | 57 |
| `^\[rules\.TRF` | 10 | 113 |

A reviewer asked to check a new lint rule against the existing ones compared against
a tenth of the file with no way to know.

The overall `max_results` cap was no better off: its "there are more" note was passed
to `_truncate` as `suffix_note`, and `_truncate` returns text untouched below 8000
chars — so the note appeared only when the *character* cap also tripped, and was
dropped on precisely the results small enough to look trustworthy.

**Fixed:** per-file `--max-count` is now `max_results + 1` — one *above*, so a file
holding more matches than requested still emits the line that proves it (a cap at
`max_results` would make a partial answer indistinguishable from a complete one).
Output is streamed and stopped at the cap rather than captured whole and sliced, so
`more` is observed rather than inferred, and a pattern matching half a monorepo no
longer lands in memory in full first. Both caps now end the result with an explicit
note — and an *unannotated* result is therefore reliable, which is the useful half:
the model can grep, count, and act on the total. A single match line is clipped at
300 chars so one minified bundle line can't spend the whole 8000-char budget.

## 2. `-E` is POSIX ERE, so `\d` silently matches nothing

`\d`, `\w`, `\s`, `\b`, `(?...)` don't error under ERE — they match nothing:

```
git grep -E 'TRF\d+'        → no matches, exit 1     ← reads as "not in this repo"
git grep -E 'TRF[0-9]+'     → 118 matches
git grep -E '\bViolation\b' → no matches
```

A model writes those by reflex. This is worse than truncation: it invents an absence,
and unlike truncation there's no note that could warn you.

**Fixed:** `-P` where git has PCRE2, resolved once per process, falling back to `-E`
on the single call that discovers it doesn't (recognised from git's
`USE_LIBPCRE` message). The result header echoes the flag actually used, and a
no-match answer under `-E` explains the dialect when the pattern contained something
ERE can't express.

## 3. Tracked-files-only grep can't see a file a patch just created

`/tasks` applies a patch and then searches. `git grep` without `--untracked` misses
any file the patch created.

**Fixed:** `--untracked` added. Ignored paths stay out — `--untracked` honours
`.gitignore` unless `--no-exclude-standard` is passed (verified: an ignored file needs
the extra flag to show up, so `.venv` / `node_modules` remain invisible). Since the
search now reaches past the tracked set, matches under `DENY_DIR_NAMES` are filtered
out: grep shouldn't hand back a path `read_file` will then refuse to open.

## Verification

`TRF\d+` → 118 (was 0). `\bViolation\b` → matches (was 0). `^description` at the
default cap → 50 plus an explicit note; at `max_results: 200` → all 57, no note.

680 → 686 tests, ruff clean. New tests cover: all matches in one file up to the cap,
no note when they fit, a raised `max_results` returning all 57, the char budget
announcing itself, a clipped enormous line, PCRE classes working, a file created since
the last commit being found, gitignored files staying out, denylisted matches being
dropped, and a faked no-PCRE2 git taking the `-E` fallback and explaining it.

## Follow-up

#94 tracks moving to ripgrep, which provides natively most of what this PR hand-rolls
(`--json` for exact counts, `--max-columns` for line clipping, `-g` for path scoping,
and a regex dialect that doesn't depend on how git was built).
