### PR TITLE
Count what a session spent, and what ended it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[web]' pytest
+          python -m pip install -e '.[web]' pytest prometheus_client
 
       - name: Run tests
         run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Per-job agent-loop metrics, exported for Prometheus at `GET /metrics`
+  (unauthenticated, like `/healthz`; scraped in-cluster over the pod port).
+  Every finished job now records how many turns and tool calls it ran, what it
+  spent, how many of its tool calls re-opened a path it had already read, and —
+  the one that reorders the rest — **which guard ended the session**, with
+  `answered` meaning the model finished on its own terms and every other value
+  meaning it did not. The exposition is a rolling window over the jobs the store
+  still holds (`WEB_JOB_RETENTION`, 25); Prometheus is the durable side, so read
+  history with a range query rather than by curling the endpoint. The same
+  record is returned on `GET /tasks/{owner}/{repo}/{id}/status`, so a dispatcher
+  can say *why* a group came back `no_fix`.
+
 - GitHub App mode is documented as the zero-config default: installed repos need
   no workflow file or secret, with instructions for overriding gating via an
   explicit workflow and a note on the forked-PR limitation.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(VENV)/.installed: pyproject.toml
 	  exit 1; }
 	$(PYTHON) -m venv $(VENV)
 	$(VENV_PYTHON) -m pip install --upgrade pip
-	$(VENV_PYTHON) -m pip install -e '.[web]' pytest ruff
+	$(VENV_PYTHON) -m pip install -e '.[web]' pytest ruff prometheus_client
 	touch $(VENV)/.installed
 
 format: $(VENV)/.installed

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -121,6 +121,11 @@ The label that matters most is `stop_reason` on `serge_job_info`:
 | `chunk_input_token_cap` | a chunked review skipped chunks it could not afford |
 | `no_llm_turns` | the job finished (or failed) without ever running the loop — e.g. reproduce-first classified the group ENVIRONMENT |
 
+Every label on `serge_job_info` is immutable for the life of a job — `status` is
+the session's outcome frozen when the loop ended, not the row's live status, so a
+review a human later publishes does not fork into a second series and double its
+row in a table.
+
 Identity lives on `serge_job_info` alone (always `1`) and the numeric series are
 keyed by `job_id` only, so a job's numbers don't fork into a new series when its
 status changes. Join them back with `on(job_id) group_left(...)`:

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -94,3 +94,48 @@ progress in the web UI.
 | `WEB_CLONE_DEPTH` | `50` | Shallow fetch depth |
 
 Point `WEB_CLONE_CACHE_DIR` at durable storage in production.
+
+## Metrics
+
+`GET /metrics` serves a Prometheus text exposition of the jobs the store still
+holds. Unauthenticated, like `/healthz` — it is meant to be scraped in-cluster
+over the pod port, and it carries no review content: job ids, the repo and PR
+number, the model name, and counters.
+
+Per finished job it exports turns, tool calls, input/output tokens, LLM seconds,
+retries, and two numbers about how the budget was spent browsing:
+
+| Metric | Meaning |
+| ------ | ------- |
+| `serge_job_repeat_calls` | Tool calls that re-ran an *earlier call verbatim* — what `TOOL_REPEAT_LIMIT` counts. |
+| `serge_job_path_revisits` | Calls that re-opened a *path already opened*, counted per path as visits−1. A second `read_file` of the same file at a different line range is a revisit but not a verbatim repeat, and that is the shape that dominates in practice. |
+
+The label that matters most is `stop_reason` on `serge_job_info`:
+
+| `stop_reason` | The session ended because… |
+| ------------- | -------------------------- |
+| `answered` | the model decided it was done — the only value that means this |
+| `input_token_cap` | `LLM_MAX_INPUT_TOKENS` was reached; the answer came from a tool-less final turn |
+| `repeat_guard` | `TOOL_REPEAT_LIMIT` tripped |
+| `blind_turn_cap` / `strict_tool_cap` / `absolute_ceiling` | a `TOOL_MAX_ITERATIONS` bound was reached |
+| `chunk_input_token_cap` | a chunked review skipped chunks it could not afford |
+| `no_llm_turns` | the job finished (or failed) without ever running the loop — e.g. reproduce-first classified the group ENVIRONMENT |
+
+Identity lives on `serge_job_info` alone (always `1`) and the numeric series are
+keyed by `job_id` only, so a job's numbers don't fork into a new series when its
+status changes. Join them back with `on(job_id) group_left(...)`:
+
+```promql
+max by (job_id) (serge_job_input_tokens)
+  * on(job_id) group_left(repo, status, stop_reason) max by (job_id, repo, status, stop_reason) (serge_job_info)
+```
+
+The export is a **rolling window** over `WEB_JOB_RETENTION` jobs (exported as
+`serge_job_retention`), not a history: when a job is pruned its series stops
+being exported and goes stale, while the samples Prometheus already took stay
+queryable for its full retention. So curling this endpoint tells you about the
+last couple of days only — ask Prometheus for anything older.
+
+The same record is returned in the `session` field of
+`GET /tasks/{owner}/{repo}/{job_id}/status`, so a dispatcher polling its own task
+can report why a group came back `no_fix` without a dashboard round trip.

--- a/reviewbot/metrics.py
+++ b/reviewbot/metrics.py
@@ -1,0 +1,212 @@
+"""Prometheus exposition for finished serge jobs.
+
+Why this exists: ``WEB_JOB_RETENTION`` is 25 jobs — roughly two days of traffic
+— and everything about how a session actually went (how many turns it ran, how
+much of the budget went on re-reading files it had already opened, and whether
+the model finished or a guard cut it off) lived only in that job row. So no
+change to the agent loop could be shown to have helped: the evidence for the
+change was deleted before the change shipped.
+
+This endpoint does not fix retention. It moves the *durable* copy to Prometheus,
+which is already scraping this cluster and already keeps 90 days. The exposition
+is deliberately a **rolling window** over whatever the store still holds: when a
+job is pruned its series simply stops being exported and goes stale, while the
+samples Prometheus already took stay queryable for the full retention. Reading
+this endpoint directly tells you nothing about last week — that is what the range
+query is for.
+
+Shape follows the usual info-metric convention: one ``serge_job_info`` series
+carries the descriptive labels, and the numeric series are keyed by ``job_id``
+alone. Keeping the labels off the values means a job's numbers don't fork into a
+new series when, say, its status moves from ``running`` to ``published``, and a
+table panel joins them back with ``on(job_id) group_left(...)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+
+# (metric name, session key, help text). Everything here is a point-in-time
+# reading of one finished job, so every one is a gauge — none of them are
+# monotonic across scrapes the way a counter must be.
+_JOB_GAUGES: tuple[tuple[str, str, str], ...] = (
+    ("serge_job_turns", "turns", "LLM turns the job's agent loop(s) ran."),
+    ("serge_job_tool_calls", "tool_calls", "Tool calls the job made."),
+    (
+        "serge_job_input_tokens",
+        "prompt_tokens",
+        "Cumulative input tokens billed to the job. The per-loop cap is "
+        "LLM_MAX_INPUT_TOKENS; a job running several rounds can exceed it.",
+    ),
+    (
+        "serge_job_output_tokens",
+        "completion_tokens",
+        "Cumulative output tokens billed to the job.",
+    ),
+    ("serge_job_llm_seconds", "seconds", "Wall time spent inside LLM calls."),
+    (
+        "serge_job_repeat_calls",
+        "repeats",
+        "Tool calls that were an exact re-run of an earlier call in the same "
+        "session — what the tool-repeat guard counts.",
+    ),
+    (
+        "serge_job_distinct_paths",
+        "distinct_paths",
+        "Distinct files/directories the job opened.",
+    ),
+    (
+        "serge_job_path_revisits",
+        "path_revisits",
+        "Calls spent re-opening a path already opened in the same session, "
+        "counted per path as visits-1. Not the same as repeat_calls: a re-read "
+        "of a different line range of the same file is a revisit but not an "
+        "exact repeat, and that is the shape that dominates.",
+    ),
+    (
+        "serge_job_validation_retries",
+        "validation_retries",
+        "Times the patch/normalize gate rejected an answer and re-asked.",
+    ),
+    (
+        "serge_job_truncation_retries",
+        "truncation_retries",
+        "Times a truncated or empty final answer was salvaged by re-asking.",
+    ),
+    (
+        "serge_job_rounds",
+        "rounds",
+        "Agent loops the job ran: one per candidate group, plus one per GPU "
+        "verify retry. 0 means the job never reached the LLM.",
+    ),
+)
+
+_INFO_HELP = (
+    "One series per finished job, always 1. Carries the labels the numeric "
+    "series deliberately omit; join with `on(job_id) group_left(...)`."
+)
+
+_FINISHED_HELP = (
+    "Unix time the job reached its terminal state. Lets a range query order "
+    "jobs even though the series are gauges."
+)
+
+
+def _escape(value: str) -> str:
+    """Escape a Prometheus label value (backslash, quote, newline)."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _labels(pairs: Iterable[tuple[str, Any]]) -> str:
+    rendered = ",".join(
+        f'{name}="{_escape("" if value is None else str(value))}"'
+        for name, value in pairs
+    )
+    return "{" + rendered + "}"
+
+
+def _number(value: Any) -> Optional[float]:
+    """Coerce a stored counter to a float, or None when it isn't one.
+
+    Session records are JSON written by an older build as easily as this one, so
+    a missing or junk value must skip its sample rather than break the scrape.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _format(value: float) -> str:
+    return str(int(value)) if value.is_integer() else repr(value)
+
+
+def render_job_metrics(
+    sessions: list[dict[str, Any]],
+    *,
+    retention: Optional[int] = None,
+    version: Optional[str] = None,
+    commit: Optional[str] = None,
+) -> str:
+    """Render ``store.list_sessions()`` rows as Prometheus text exposition.
+
+    ``retention`` is exported alongside so a dashboard can say how far back the
+    live window reaches — a gap in the series means the job aged out of the
+    store, not that serge stopped working.
+    """
+    lines: list[str] = []
+
+    if version is not None or commit is not None:
+        lines.append("# HELP serge_build_info The running serge build.")
+        lines.append("# TYPE serge_build_info gauge")
+        lines.append(
+            "serge_build_info"
+            + _labels((("version", version or ""), ("commit", commit or "")))
+            + " 1"
+        )
+    if retention is not None:
+        lines.append(
+            "# HELP serge_job_retention Jobs the store keeps before pruning "
+            "(WEB_JOB_RETENTION). The export above is a window this wide."
+        )
+        lines.append("# TYPE serge_job_retention gauge")
+        lines.append(f"serge_job_retention {int(retention)}")
+
+    lines.append(f"# HELP serge_job_info {_INFO_HELP}")
+    lines.append("# TYPE serge_job_info gauge")
+    for row in sessions:
+        session = row.get("session") or {}
+        owner = row.get("target_owner") or ""
+        repo = row.get("target_repo") or ""
+        pr_number = row.get("pr_number")
+        lines.append(
+            "serge_job_info"
+            + _labels(
+                (
+                    ("job_id", row.get("id")),
+                    ("kind", row.get("kind") or "review"),
+                    ("repo", f"{owner}/{repo}" if owner or repo else ""),
+                    ("number", row.get("target_number")),
+                    ("status", row.get("status") or ""),
+                    ("model", row.get("llm_model") or "none"),
+                    # "answered" is the only value meaning the model decided it
+                    # was done; every other value is a guard ending the session.
+                    ("stop_reason", session.get("stop_reason") or "unknown"),
+                    ("verify_verdict", row.get("verify_verdict") or "none"),
+                    ("pr", "" if pr_number is None else pr_number),
+                )
+            )
+            + " 1"
+        )
+
+    for name, key, help_text in _JOB_GAUGES:
+        samples = []
+        for row in sessions:
+            value = _number((row.get("session") or {}).get(key))
+            if value is None:
+                continue
+            samples.append(
+                f"{name}" + _labels((("job_id", row.get("id")),)) + f" {_format(value)}"
+            )
+        if not samples:
+            continue
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} gauge")
+        lines.extend(samples)
+
+    finished = []
+    for row in sessions:
+        value = _number(row.get("updated_at"))
+        if value is None:
+            continue
+        finished.append(
+            "serge_job_finished_timestamp_seconds"
+            + _labels((("job_id", row.get("id")),))
+            + f" {_format(value)}"
+        )
+    if finished:
+        lines.append(f"# HELP serge_job_finished_timestamp_seconds {_FINISHED_HELP}")
+        lines.append("# TYPE serge_job_finished_timestamp_seconds gauge")
+        lines.extend(finished)
+
+    return "\n".join(lines) + "\n"

--- a/reviewbot/metrics.py
+++ b/reviewbot/metrics.py
@@ -167,7 +167,10 @@ def render_job_metrics(
                     ("kind", row.get("kind") or "review"),
                     ("repo", f"{owner}/{repo}" if owner or repo else ""),
                     ("number", row.get("target_number")),
-                    ("status", row.get("status") or ""),
+                    # The session's own frozen outcome, not the row's live
+                    # status: a review that a human later publishes must not
+                    # fork into a second series. See _session_with_outcome.
+                    ("status", session.get("outcome") or row.get("status") or ""),
                     ("model", row.get("llm_model") or "none"),
                     # "answered" is the only value meaning the model decided it
                     # was done; every other value is a guard ending the session.

--- a/reviewbot/review_runner.py
+++ b/reviewbot/review_runner.py
@@ -105,12 +105,16 @@ def run(spec: RunnerSpec) -> int:
             return 0
 
         # Ship the draft (serge rebuilds it via store.decode_draft) plus the
-        # token counts, which the draft payload doesn't carry.
+        # token counts and the agent-loop session, neither of which the draft
+        # payload carries. Prod runs reviews in per-review pods, so this is the
+        # only route the session has: without it every review would persist a
+        # zeroed "never ran the loop" record despite having run one.
         result = {
             "draft": encode_draft(draft),
             "prompt_tokens": draft.prompt_tokens,
             "completion_tokens": draft.completion_tokens,
             "truncated_chunks": draft.truncated_chunks,
+            "session": draft.session,
         }
         emitter.finish("done", result=result)
         return 0
@@ -120,6 +124,7 @@ def run(spec: RunnerSpec) -> int:
             "error",
             error="the model returned an unparseable review",
             raw_llm_output=getattr(exc, "content", None),
+            session=getattr(exc, "session", None),
         )
         return 1
     except LLMResponseError as exc:

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -110,6 +110,10 @@ class ReviewDraft:
     # auto-discovery, if llm_model was unset). Surfaced in the published
     # review footer; None when no LLM call was made.
     model: Optional[str] = None
+    # Per-job agent-loop counters (:func:`session_record`). Like the token
+    # counts above, this is a carrier field: it is NOT part of the draft JSON
+    # a review pod ships back, it travels beside it on the terminal callback.
+    session: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -465,6 +469,55 @@ class _AggregateMetrics:
     latency_seconds: float = 0.0
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Why the loop stopped. ``STOP_ANSWERED`` is the *only* value meaning the
+    # model decided it was done; every other value is a guard cutting it off and
+    # forcing an answer out of whatever budget was left. Worth recording per job:
+    # in the one prod window we could still read, all seven sessions that ran LLM
+    # turns ended on a guard and none on the model's own terms, which is not
+    # visible anywhere today.
+    stop_reason: str = "answered"
+    # Copied off the ToolRepeatGuard at every exit (see :func:`_run_agentic_loop`).
+    repeats: int = 0
+    distinct_paths: int = 0
+    path_revisits: int = 0
+    # Times the answer was rejected and re-asked: the normalize/patch gate and
+    # the truncated-final-answer salvage respectively.
+    validation_retries: int = 0
+    truncation_retries: int = 0
+
+
+# Loop-exit reasons, recorded on _AggregateMetrics.stop_reason. Only ANSWERED
+# means the model finished on its own terms.
+STOP_ANSWERED = "answered"
+STOP_INPUT_TOKEN_CAP = "input_token_cap"
+STOP_REPEAT_GUARD = "repeat_guard"
+STOP_BLIND_TURN_CAP = "blind_turn_cap"
+STOP_STRICT_TOOL_CAP = "strict_tool_cap"
+STOP_ABSOLUTE_CEILING = "absolute_ceiling"
+STOP_CHUNK_BUDGET = "chunk_input_token_cap"
+# Not a loop exit: the job finished (or failed) without ever running one. The
+# reproduce-first gate classifying a group ENVIRONMENT is the common case — 3 of
+# the 10 tasks in the measured window — and it has to be countable, otherwise
+# "serge did nothing for 0 turns" and "serge never ran" look identical.
+STOP_NO_LLM_TURNS = "no_llm_turns"
+
+
+def no_llm_session_record() -> dict[str, Any]:
+    """A zeroed session for a job that never reached the agent loop."""
+    return {
+        "turns": 0,
+        "tool_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "seconds": 0.0,
+        "stop_reason": STOP_NO_LLM_TURNS,
+        "repeats": 0,
+        "distinct_paths": 0,
+        "path_revisits": 0,
+        "validation_retries": 0,
+        "truncation_retries": 0,
+        "rounds": 0,
+    }
 
 
 def _format_aggregated_metrics(m: "_AggregateMetrics") -> str:
@@ -480,12 +533,100 @@ def _format_aggregated_metrics(m: "_AggregateMetrics") -> str:
     return " · ".join(parts)
 
 
+def session_record(m: "_AggregateMetrics") -> dict[str, Any]:
+    """The per-job counters worth keeping after the job row is evicted.
+
+    ``WEB_JOB_RETENTION`` is 25 jobs — about two days of traffic — so anything
+    only visible in the job row cannot be used to show that a change to the
+    agent loop helped. These are the numbers that answer "did the model finish,
+    or did a guard cut it off, and what did it spend the budget on?".
+    """
+    return {
+        "turns": m.turns,
+        "tool_calls": m.tool_calls,
+        "prompt_tokens": m.prompt_tokens,
+        "completion_tokens": m.completion_tokens,
+        "seconds": round(m.latency_seconds, 1),
+        "stop_reason": m.stop_reason,
+        "repeats": m.repeats,
+        "distinct_paths": m.distinct_paths,
+        "path_revisits": m.path_revisits,
+        "validation_retries": m.validation_retries,
+        "truncation_retries": m.truncation_retries,
+        "rounds": 1,
+    }
+
+
+# Counters that add up when a job runs the agent loop more than once — a task
+# with several candidate groups, or a GPU-verify retry round.
+_SESSION_SUMS = (
+    "turns",
+    "tool_calls",
+    "prompt_tokens",
+    "completion_tokens",
+    "repeats",
+    "path_revisits",
+    "validation_retries",
+    "truncation_retries",
+)
+
+
+def merge_session_records(
+    total: Optional[dict[str, Any]], part: Optional[dict[str, Any]]
+) -> dict[str, Any]:
+    """Fold one agent-loop session into a job-level total.
+
+    A single task job can run the loop several times (one per candidate group,
+    plus a round per GPU-verify retry), and the thing worth reporting is what the
+    *job* spent — the 2M input-token cap is per loop, but the bill is per job.
+    ``rounds`` counts how many loops were folded in; ``stop_reason`` reports the
+    last loop that a guard cut off, since one cut-off round is what starves the
+    patch that gets published."""
+    if not part:
+        return dict(total or {})
+    if not total:
+        merged = dict(part)
+        # ``part`` may itself already be an accumulation (a candidate that ran
+        # several verify rounds); don't reset its count to one.
+        merged.setdefault("rounds", 1)
+        return merged
+    merged = dict(total)
+    for key in _SESSION_SUMS:
+        merged[key] = int(merged.get(key, 0) or 0) + int(part.get(key, 0) or 0)
+    merged["seconds"] = round(
+        float(merged.get("seconds", 0.0) or 0.0)
+        + float(part.get("seconds", 0.0) or 0.0),
+        1,
+    )
+    merged["distinct_paths"] = max(
+        int(merged.get("distinct_paths", 0) or 0),
+        int(part.get("distinct_paths", 0) or 0),
+    )
+    merged["rounds"] = int(merged.get("rounds", 1) or 1) + int(
+        part.get("rounds", 1) or 1
+    )
+    if part.get("stop_reason", STOP_ANSWERED) != STOP_ANSWERED:
+        merged["stop_reason"] = part["stop_reason"]
+    return merged
+
+
 def _merge_metrics(total: "_AggregateMetrics", part: "_AggregateMetrics") -> None:
     total.turns += part.turns
     total.tool_calls += part.tool_calls
     total.latency_seconds += part.latency_seconds
     total.prompt_tokens += part.prompt_tokens
     total.completion_tokens += part.completion_tokens
+    total.repeats += part.repeats
+    total.path_revisits += part.path_revisits
+    total.validation_retries += part.validation_retries
+    total.truncation_retries += part.truncation_retries
+    # Each chunk browses with a fresh guard, so distinct paths are per-chunk and
+    # summing them double-counts a file two chunks both opened. An upper bound is
+    # the honest reading available without keeping every path around.
+    total.distinct_paths = max(total.distinct_paths, part.distinct_paths)
+    # A cut-off chunk means the session was cut off, whatever later chunks did.
+    if part.stop_reason != STOP_ANSWERED:
+        total.stop_reason = part.stop_reason
 
 
 def _make_tool_env(
@@ -861,6 +1002,18 @@ def _run_agentic_loop(
     blind_tool_turns = 0
     validation_retries = 0
     truncation_retries = 0
+
+    def _finalize(chat: ChatResult) -> tuple[ChatResult, "_AggregateMetrics"]:
+        """Attach the session's browse/retry record to the metrics on the way
+        out. Every ``return`` from this function goes through here so a job's
+        counters are complete no matter which exit it took."""
+        metrics.repeats = repeat_guard.repeats
+        metrics.distinct_paths = repeat_guard.distinct_paths
+        metrics.path_revisits = repeat_guard.path_revisits
+        metrics.validation_retries = validation_retries
+        metrics.truncation_retries = truncation_retries
+        return chat, metrics
+
     # Set for one turn to recover a truncated final answer: disable tools and
     # force minimal reasoning so the whole output budget goes to the JSON.
     force_json_only = False
@@ -871,8 +1024,10 @@ def _run_agentic_loop(
                 "Agent loop hit absolute ceiling of %d iterations; bailing out",
                 ABSOLUTE_ITER_CEILING,
             )
+            metrics.stop_reason = STOP_ABSOLUTE_CEILING
             break
         if iter_cap is not None and blind_tool_turns >= iter_cap:
+            metrics.stop_reason = STOP_BLIND_TURN_CAP
             break
         if (
             iter_cap is not None
@@ -884,6 +1039,7 @@ def _run_agentic_loop(
                 metrics.tool_calls,
                 iter_cap,
             )
+            metrics.stop_reason = STOP_STRICT_TOOL_CAP
             break
         if (
             input_tokens_cap is not None
@@ -901,6 +1057,7 @@ def _run_agentic_loop(
                     f"Input token budget hit ({cumulative} >= {input_tokens_cap}); "
                     "asking for a final review without tools",
                 )
+            metrics.stop_reason = STOP_INPUT_TOKEN_CAP
             break
         if iter_cap is not None:
             if getattr(cfg, "tool_max_iterations_strict", False):
@@ -968,13 +1125,13 @@ def _run_agentic_loop(
                 force_json_only = True
                 continue
             if validate is None:
-                return chat, metrics
+                return _finalize(chat)
             # Verification gate: let the caller check the final answer (for
             # /tasks: apply the patch + run the repo normalizer). A non-empty
             # string is a rejection to feed back; None accepts.
             feedback = validate(chat)
             if feedback is None or validation_retries >= max_validation_retries:
-                return chat, metrics
+                return _finalize(chat)
             validation_retries += 1
             if emit is not None:
                 emit(
@@ -1009,7 +1166,7 @@ def _run_agentic_loop(
                 "content as final answer",
                 len(chat.tool_calls),
             )
-            return chat, metrics
+            return _finalize(chat)
 
         # Append the assistant's tool_calls turn so the next request has
         # the full conversation, then execute each call and append the
@@ -1065,6 +1222,7 @@ def _run_agentic_loop(
                     f"Stuck in a tool-call loop ({repeat_guard.summary()}); "
                     "asking for a final answer without tools",
                 )
+            metrics.stop_reason = STOP_REPEAT_GUARD
             break
 
     # Iteration budget hit — force a final answer with tools disabled.
@@ -1135,10 +1293,10 @@ def _run_agentic_loop(
         # are tool-less: the model fixes its diff from the normalizer's
         # feedback, which needs no browsing.
         if validate is None:
-            return chat, metrics
+            return _finalize(chat)
         feedback = validate(chat)
         if feedback is None or validation_retries >= max_validation_retries:
-            return chat, metrics
+            return _finalize(chat)
         validation_retries += 1
         if emit is not None:
             emit(
@@ -1366,11 +1524,21 @@ class _UnparseableLLMOutput(Exception):
     content + finish_reason + metrics line so the caller can render an
     error to whatever surface they own (GitHub comment, web UI, etc.)."""
 
-    def __init__(self, content: str, finish_reason: Optional[str], metrics_line: str):
+    def __init__(
+        self,
+        content: str,
+        finish_reason: Optional[str],
+        metrics_line: str,
+        session: Optional[dict[str, Any]] = None,
+    ):
         super().__init__("unparseable LLM output")
         self.content = content
         self.finish_reason = finish_reason
         self.metrics_line = metrics_line
+        # These are the sessions we most want counters for: an unparseable
+        # answer is what a starved final turn produces, and the job row records
+        # only the error string.
+        self.session = session or {}
 
     def user_message(self) -> str:
         if self.finish_reason == "length":
@@ -1538,6 +1706,7 @@ def prepare_review(
                 "chunk(s) and finishing early",
             )
             skipped_chunks_for_budget = remaining
+            total_metrics.stop_reason = STOP_CHUNK_BUDGET
             break
         runner_context = _build_runner_context(
             all_files=files,
@@ -1593,6 +1762,7 @@ def prepare_review(
                 content=chat.content or "",
                 finish_reason=chat.finish_reason,
                 metrics_line=metrics_line,
+                session=session_record(total_metrics),
             ) from exc
 
         summary = (result.get("summary") or "").strip()
@@ -1723,6 +1893,7 @@ def prepare_review(
         prompt_tokens=total_metrics.prompt_tokens,
         completion_tokens=total_metrics.completion_tokens,
         model=llm.model,
+        session=session_record(total_metrics),
     )
 
 

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -571,6 +571,16 @@ _SESSION_SUMS = (
 )
 
 
+def _rounds(record: dict[str, Any]) -> int:
+    """A record's loop count, defaulting to one.
+
+    Not ``or 1``: ``rounds: 0`` is a real value — a job that never reached the
+    agent loop — and reading it as 1 would invent a loop that never ran.
+    """
+    value = record.get("rounds")
+    return 1 if value is None else int(value)
+
+
 def merge_session_records(
     total: Optional[dict[str, Any]], part: Optional[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -588,7 +598,7 @@ def merge_session_records(
         merged = dict(part)
         # ``part`` may itself already be an accumulation (a candidate that ran
         # several verify rounds); don't reset its count to one.
-        merged.setdefault("rounds", 1)
+        merged["rounds"] = _rounds(part)
         return merged
     merged = dict(total)
     for key in _SESSION_SUMS:
@@ -602,9 +612,7 @@ def merge_session_records(
         int(merged.get("distinct_paths", 0) or 0),
         int(part.get("distinct_paths", 0) or 0),
     )
-    merged["rounds"] = int(merged.get("rounds", 1) or 1) + int(
-        part.get("rounds", 1) or 1
-    )
+    merged["rounds"] = _rounds(merged) + _rounds(part)
     if part.get("stop_reason", STOP_ANSWERED) != STOP_ANSWERED:
         merged["stop_reason"] = part["stop_reason"]
     return merged

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -57,7 +57,12 @@ CREATE TABLE IF NOT EXISTS jobs (
     -- For tasks: the outcome ({pr_number, branch, url}) once published.
     result_json     TEXT,
     prompt_tokens   INTEGER,
-    completion_tokens INTEGER
+    completion_tokens INTEGER,
+    -- Per-job agent-loop counters (reviewer.session_record) as JSON: turns,
+    -- tool calls, re-opened paths, and which guard ended the loop. Written at
+    -- finish; see GET /metrics, which is what carries these past the 25-job
+    -- retention and into Prometheus.
+    session_json    TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at DESC);
@@ -139,6 +144,7 @@ class JobStore:
             self._ensure_column("kind", "TEXT NOT NULL DEFAULT 'review'")
             self._ensure_column("task_spec_json", "TEXT")
             self._ensure_column("result_json", "TEXT")
+            self._ensure_column("session_json", "TEXT")
             self._ensure_column(
                 "task_write_enabled",
                 "INTEGER NOT NULL DEFAULT 0",
@@ -226,6 +232,7 @@ class JobStore:
         raw_llm_output: Optional[str],
         draft: Optional[ReviewDraft],
         history: list[dict[str, Any]],
+        session: Optional[dict[str, Any]] = None,
     ) -> None:
         """Persist the final state of a job (done/error/published/discarded)
         along with its filtered event history and the resulting draft, if any.
@@ -233,20 +240,30 @@ class JobStore:
         Token counts come from the draft when available; otherwise (error
         path with no draft) we fall back to the latest ``metrics`` event in
         the history so the journal still reports what was consumed before
-        the failure."""
+        the failure.
+
+        ``session`` is the agent-loop record (reviewer.session_record). Passed
+        explicitly on the task path; falls back to the draft's carrier field on
+        the review path. Absent on jobs that never reached the LLM."""
         filtered = [e for e in history if e.get("kind") in PERSIST_EVENT_KINDS]
         if draft is not None:
             prompt_tokens: Optional[int] = draft.prompt_tokens or None
             completion_tokens: Optional[int] = draft.completion_tokens or None
         else:
             prompt_tokens, completion_tokens = _latest_token_counts(history)
+        if not session and draft is not None:
+            session = draft.session
+        session_json = (
+            json.dumps(session, ensure_ascii=False, sort_keys=True) if session else None
+        )
         with self._lock:
             self._conn.execute(
                 """
                 UPDATE jobs
                    SET status = ?, error = ?, raw_llm_output = ?,
                        draft_json = ?, history_json = ?, updated_at = ?,
-                       prompt_tokens = ?, completion_tokens = ?
+                       prompt_tokens = ?, completion_tokens = ?,
+                       session_json = COALESCE(?, session_json)
                  WHERE id = ?
                 """,
                 (
@@ -258,6 +275,7 @@ class JobStore:
                     time.time(),
                     prompt_tokens,
                     completion_tokens,
+                    session_json,
                     job_id,
                 ),
             )
@@ -705,6 +723,39 @@ class JobStore:
             ).fetchall()
         return [dict(r) for r in rows]
 
+    def list_sessions(self, limit: int = 500) -> list[dict[str, Any]]:
+        """Finished jobs that recorded an agent-loop session, newest first.
+
+        The source for ``GET /metrics``. Deliberately a rolling window over
+        whatever the store still holds (``WEB_JOB_RETENTION``, 25 by default):
+        Prometheus is the durable side of this, and a series that stops being
+        exported simply goes stale while its samples stay queryable. Running
+        jobs are excluded — their counters are still moving."""
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT id, target_owner, target_repo, target_number,
+                       status, kind, llm_model, created_at, updated_at,
+                       result_json, session_json
+                  FROM jobs
+                 WHERE session_json IS NOT NULL
+                   AND status != 'running'
+                 ORDER BY created_at DESC
+                 LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            d = dict(row)
+            d["session"] = _decode_session(d.pop("session_json", None))
+            result_raw = d.pop("result_json", None)
+            result = _decode_session(result_raw)
+            d["pr_number"] = result.get("pr_number")
+            d["verify_verdict"] = result.get("verify_verdict")
+            out.append(d)
+        return out
+
 
 # ---------------------------------------------------------------------------
 # (de)serialization helpers
@@ -794,6 +845,19 @@ def decode_draft(s: Optional[str]) -> Optional[ReviewDraft]:
     )
 
 
+def _decode_session(raw: Any) -> dict[str, Any]:
+    """Parse a stored ``session_json``. A malformed or missing record reads as
+    ``{}`` — a job that never reached the LLM legitimately has none, and the
+    metrics endpoint must not fall over on one bad row."""
+    if not isinstance(raw, str) or not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _decode_provider_config(row: sqlite3.Row) -> dict[str, Any]:
     d = dict(row)
     d["task_write_enabled"] = bool(d.get("task_write_enabled"))
@@ -812,6 +876,8 @@ def _decode_provider_config(row: sqlite3.Row) -> dict[str, Any]:
 
 def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
     d = dict(row)
+    session_raw = d.pop("session_json", None)
+    d["session"] = _decode_session(session_raw)
     history_raw = d.pop("history_json", None)
     if history_raw:
         try:

--- a/reviewbot/task_runner.py
+++ b/reviewbot/task_runner.py
@@ -160,9 +160,14 @@ class CallbackEmitter:
         result: Optional[dict[str, Any]] = None,
         error: Optional[str] = None,
         raw_llm_output: Optional[str] = None,
+        session: Optional[dict[str, Any]] = None,
     ) -> None:
         """Send the terminal outcome. serge records ``status`` on the job and
-        stores ``result`` / ``error`` / ``raw_llm_output``."""
+        stores ``result`` / ``error`` / ``raw_llm_output``.
+
+        ``session`` rides alongside on the failure paths, where there is no
+        ``result`` to carry the agent-loop counters — an errored session is
+        exactly one worth counting, so it must not report nothing."""
         self._seq += 1
         log.info("terminal status=%s error=%s", status, (error or "")[:200])
         self._post(
@@ -174,6 +179,7 @@ class CallbackEmitter:
                     "result": result,
                     "error": error,
                     "raw_llm_output": raw_llm_output,
+                    "session": session or {},
                 },
                 "ts": time.time(),
             }
@@ -416,9 +422,14 @@ def run(spec: RunnerSpec) -> int:
         return 0
     except TaskError as exc:
         log.warning("task %s rejected: %s", spec.job_id, exc)
-        return _fail(emitter, str(exc))
+        return _fail(emitter, str(exc), session=getattr(exc, "session", None))
     except _UnparseableLLMOutput as exc:
-        return _fail(emitter, exc.user_message(), raw_llm_output=exc.content)
+        return _fail(
+            emitter,
+            exc.user_message(),
+            raw_llm_output=exc.content,
+            session=getattr(exc, "session", None),
+        )
     except LLMResponseError as exc:
         log.warning(
             "LLM endpoint returned %d for task %s", exc.status_code, spec.job_id
@@ -436,12 +447,18 @@ def run(spec: RunnerSpec) -> int:
 
 
 def _fail(
-    emitter: CallbackEmitter, message: str, *, raw_llm_output: Optional[str] = None
+    emitter: CallbackEmitter,
+    message: str,
+    *,
+    raw_llm_output: Optional[str] = None,
+    session: Optional[dict[str, Any]] = None,
 ) -> int:
     emitter.emit("step", "error")
     emitter.emit("error", message)
     emitter.emit("done", "")
-    emitter.finish("error", error=message, raw_llm_output=raw_llm_output)
+    emitter.finish(
+        "error", error=message, raw_llm_output=raw_llm_output, session=session
+    )
     return 1
 
 

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -37,6 +37,8 @@ from .prompts import build_task_system_prompt, build_task_user_prompt
 from .reviewer import (
     _extract_json,
     _format_aggregated_metrics,
+    merge_session_records,
+    session_record,
     _make_tool_env,
     _run_agentic_loop,
     _UnparseableLLMOutput,
@@ -95,6 +97,11 @@ class TaskError(Exception):
     def __init__(self, message: str, *, status_code: int = 400):
         super().__init__(message)
         self.status_code = status_code
+        # Agent-loop counters for the work already done when this was raised.
+        # A patch that will not apply is a *terminated session*, and it is one of
+        # the outcomes most worth counting; without this the whole round would
+        # leave no trace but an error string.
+        self.session: dict[str, Any] = {}
 
 
 class NormalizeGateBroken(TaskError):
@@ -167,6 +174,10 @@ class TaskPlan:
     metrics_line: str = ""
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Per-job agent-loop counters (reviewer.session_record): turns, tool calls,
+    # re-opened paths, and which guard ended the loop. Kept past the job row's
+    # 25-job retention so a change to the loop can be shown to have helped.
+    session: dict[str, Any] = field(default_factory=dict)
     model: Optional[str] = None
     # True when the patch was validated in-loop (see :func:`_validate_patch`):
     # the worktree already holds the applied + normalized result, so
@@ -191,6 +202,11 @@ class TaskResult:
     # to the next LLM round. Not persisted in ``to_json`` (tracebacks are large).
     verify_verdict: Optional[str] = None
     verify_tracebacks: dict[str, str] = field(default_factory=dict)
+    # Agent-loop counters accumulated over every round this candidate ran
+    # (reviewer.merge_session_records). Small — counters only, no tracebacks —
+    # so unlike ``verify_tracebacks`` it does travel in ``to_json``, which is
+    # how it reaches serge from a per-task runner pod.
+    session: dict[str, Any] = field(default_factory=dict)
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -203,6 +219,7 @@ class TaskResult:
             "commit_sha": self.commit_sha,
             "changed_files": self.changed_files,
             "verify_verdict": self.verify_verdict,
+            "session": self.session,
         }
 
 
@@ -732,6 +749,7 @@ def prepare_task(
             content=chat.content or "",
             finish_reason=chat.finish_reason,
             metrics_line=metrics_line,
+            session=session_record(metrics),
         ) from exc
 
     title = (result.get("title") or "").strip() or (req.title or "serge: automated fix")
@@ -753,6 +771,7 @@ def prepare_task(
         metrics_line=metrics_line,
         prompt_tokens=metrics.prompt_tokens,
         completion_tokens=metrics.completion_tokens,
+        session=session_record(metrics),
         model=llm.model,
         worktree_prepared=outcome["prepared"],
     )
@@ -1626,6 +1645,9 @@ def prepare_and_publish_candidate(
     rounds = cfg.verify_max_rounds if cfg.verify_on_gpu else 0
     req_i = candidate_req
     result: Optional[TaskResult] = None
+    # Every round runs a fresh agent loop with its own budget; the job-level
+    # bill is their sum, so fold each one in as it completes.
+    session: dict[str, Any] = {}
     for attempt in range(rounds + 1):
         if attempt > 0:
             # Start each retry from a pristine worktree.
@@ -1638,16 +1660,24 @@ def prepare_and_publish_candidate(
             existing_diff=existing_diff,
             chunk_callback=emit,
         )
-        result = publish_task(
-            cfg,
-            gh,
-            req_i,
-            plan,
-            checkout=checkout,
-            clone_cache=clone_cache,
-            job_id=job_id,
-            emit=emit,
-        )
+        session = merge_session_records(session, plan.session)
+        try:
+            result = publish_task(
+                cfg,
+                gh,
+                req_i,
+                plan,
+                checkout=checkout,
+                clone_cache=clone_cache,
+                job_id=job_id,
+                emit=emit,
+            )
+        except TaskError as exc:
+            # The LLM work is done and paid for even though publishing failed;
+            # carry its counters out with the error.
+            exc.session = merge_session_records(exc.session, session)
+            raise
+        result.session = session
         if attempt < rounds and should_retry(result.verify_verdict or ""):
             emit(
                 "log",

--- a/reviewbot/tool_repeat.py
+++ b/reviewbot/tool_repeat.py
@@ -61,6 +61,40 @@ def normalize_arguments(arguments: str) -> str:
         return (arguments or "").strip()
 
 
+# Tools whose ``path`` argument names something the agent has *opened*. A second
+# ``read_file`` of the same file is a re-visit even when the line range differs —
+# that is the shape that dominated the measured prod window (137 of 153 calls in
+# job 9d210794 were repeat visits to an already-opened path, ``modular_blt.py``
+# 53 times). ``grep`` deliberately is not here: the same path with a different
+# pattern is a genuinely new search, not a re-read.
+_PATH_TOOLS = frozenset({"read_file", "list_dir"})
+
+
+def path_argument(name: str, arguments: str) -> str | None:
+    """The path a call opened, or ``None`` when the tool does not open one.
+
+    Normalized only enough to make two spellings of the same file compare equal
+    (``./x.py`` and ``x.py``); no filesystem access, so it stays usable in the
+    metrics path where the checkout may already be gone."""
+    if name not in _PATH_TOOLS:
+        return None
+    try:
+        parsed = json.loads(arguments or "{}")
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    raw = parsed.get("path")
+    if not isinstance(raw, str):
+        # list_dir's path is optional and defaults to the repo root; a missing
+        # path is still a visit to a real location, so name it.
+        return "." if name == "list_dir" else None
+    path = raw.strip().lstrip("/")
+    while path.startswith("./"):
+        path = path[2:]
+    return path.rstrip("/") or "."
+
+
 class ToolRepeatGuard:
     """Count identical tool calls and produce a correction for the repeats.
 
@@ -78,6 +112,10 @@ class ToolRepeatGuard:
         self.trip_after = trip_after
         self.counts: dict[str, int] = {}
         self.repeats = 0
+        # Visits per opened path, counted whether or not the guard is enabled:
+        # this is the session's observability record (see :meth:`stats`), and it
+        # has to be there even for a deployment that turned the nudge off.
+        self.path_visits: dict[str, int] = {}
 
     @property
     def enabled(self) -> bool:
@@ -94,6 +132,9 @@ class ToolRepeatGuard:
         The first occurrence of a call is always free — legitimate investigation
         re-lists directories and re-reads files. Only an *exact* re-run of a call
         already made in this session is treated as a repeat."""
+        path = path_argument(name, arguments)
+        if path is not None:
+            self.path_visits[path] = self.path_visits.get(path, 0) + 1
         if not self.enabled:
             return None
         signature = f"{name}\x00{normalize_arguments(arguments)}"
@@ -118,3 +159,34 @@ class ToolRepeatGuard:
         return f"{self.repeats} repeated tool call(s)" + (
             f" (most repeated: {', '.join(parts)})" if parts else ""
         )
+
+    # ------------------------------------------------------------------
+    # observability
+    # ------------------------------------------------------------------
+    @property
+    def distinct_paths(self) -> int:
+        """How many separate files/directories the session opened."""
+        return len(self.path_visits)
+
+    @property
+    def path_revisits(self) -> int:
+        """Calls spent re-opening a path already opened in this session.
+
+        The headline waste number: with 153 calls over 12 distinct paths, 137 of
+        them were this. Counted as ``visits - 1`` per path, so a file read once
+        contributes nothing.
+        """
+        return sum(count - 1 for count in self.path_visits.values() if count > 1)
+
+    def worst_paths(self, limit: int = 3) -> list[tuple[str, int]]:
+        """The most re-opened paths, highest first — for logs and nudges."""
+        ranked = sorted(self.path_visits.items(), key=lambda kv: (-kv[1], kv[0]))
+        return [(path, count) for path, count in ranked[:limit] if count > 1]
+
+    def stats(self) -> dict[str, int]:
+        """Flat counters for the per-job metrics record."""
+        return {
+            "repeats": self.repeats,
+            "distinct_paths": self.distinct_paths,
+            "path_revisits": self.path_revisits,
+        }

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -883,6 +883,24 @@ def _push_event(job: Job, kind: str, text: str) -> None:
         job.loop.call_soon_threadsafe(job.queue.put_nowait, event)
 
 
+def _session_with_outcome(job: Job) -> dict[str, Any]:
+    """The job's session record, stamped with the status it finished on.
+
+    Every label the metrics endpoint exports has to be immutable for the life of
+    a job, or the same job forks into a second Prometheus series and shows up
+    twice in any table over a window that straddles the change. Status is the one
+    that moves: a review is ``done`` until a human publishes it, and then it is
+    ``published``. Freezing it here — the store's session write is first-wins —
+    keeps the exported label stable, and it is the more honest reading anyway:
+    the session ended when the loop did, not when someone clicked publish."""
+    session = job.session or no_llm_session_record()
+    # Stamped onto the Job, not a copy: _persist_terminal runs again when a human
+    # publishes a draft, and re-stamping there would move the label after all.
+    session.setdefault("outcome", job.status)
+    job.session = session
+    return session
+
+
 def _persist_terminal(job: Job) -> None:
     """Snapshot a finished job into the store so it survives a restart."""
     with job.history_lock:
@@ -895,7 +913,7 @@ def _persist_terminal(job: Job) -> None:
             raw_llm_output=job.raw_llm_output,
             draft=job.draft,
             history=history_copy,
-            session=job.session or no_llm_session_record(),
+            session=_session_with_outcome(job),
         )
         if job.published_draft is not None:
             _store.save_published_review(
@@ -3521,6 +3539,7 @@ def _load_job_from_store(job_id: str) -> Optional[Job]:
     )
     job.task_spec = _safe_json_obj(row.get("task_spec_json"))
     job.task_result = _safe_json_obj(row.get("result_json"))
+    job.session = dict(row.get("session") or {})
     job.history = list(row.get("history") or [])
     return job
 

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -1298,6 +1298,9 @@ def _run_task_worker(job: Job, worker_cfg: Config, req: TaskRequest) -> None:
         emit("error", job.error)
         emit("done", "")
     except _UnparseableLLMOutput as exc:
+        # Three of ten tasks in the measured window died here; these are the
+        # sessions whose counters matter most, so keep what the loop spent.
+        job.session = merge_session_records(job.session, getattr(exc, "session", None))
         job.status = "error"
         job.raw_llm_output = exc.content
         job.error = exc.user_message()
@@ -3271,7 +3274,11 @@ async def ingest_task_event(job_id: str, request: Request) -> JSONResponse:
                     draft.prompt_tokens = int(result.get("prompt_tokens") or 0)
                     draft.completion_tokens = int(result.get("completion_tokens") or 0)
                     draft.truncated_chunks = int(result.get("truncated_chunks") or 0)
-                    draft.session = result.get("session") or {}
+                    # Only when the runner actually sent one: an older runner
+                    # image omits the key, and blanking the draft's own record
+                    # would persist "never ran the loop" for a review that did.
+                    if result.get("session"):
+                        draft.session = result["session"]
                     job.session = draft.session
                 job.draft = draft
         elif isinstance(result, dict):

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -76,10 +76,13 @@ from .reviewer import (
     ReviewEdits,
     ReviewRequest,
     _UnparseableLLMOutput,
+    merge_session_records,
+    no_llm_session_record,
     prepare_review,
     publish_review,
     run_followup,
 )
+from .metrics import render_job_metrics
 from .slack_tool import post_task_finished_notification
 from .store import JobStore, decode_draft
 from .tasks import (
@@ -325,6 +328,11 @@ class Job:
     # For task jobs: the inbound spec and the published outcome.
     task_spec: Optional[dict[str, Any]] = None
     task_result: Optional[dict[str, Any]] = None
+    # Agent-loop counters for the whole job (reviewer.session_record, folded
+    # across candidates/rounds). Persisted at finish into ``session_json`` and
+    # exported by GET /metrics — the only record of a session that survives the
+    # 25-job retention.
+    session: dict[str, Any] = field(default_factory=dict)
     # running | done | error | discarded | published | no_fix
     # Tasks end as "published" (a PR/commit landed) or "no_fix" (completed but
     # serge proposed no patch); reviews use done/published/discarded.
@@ -887,6 +895,7 @@ def _persist_terminal(job: Job) -> None:
             raw_llm_output=job.raw_llm_output,
             draft=job.draft,
             history=history_copy,
+            session=job.session or no_llm_session_record(),
         )
         if job.published_draft is not None:
             _store.save_published_review(
@@ -990,6 +999,7 @@ def _execute_review(
             _push_event(job, "done", "")
             return
         job.draft = draft
+        job.session = draft.session
         if auto_publish:
             _push_event(job, "log", "Publishing review to GitHub…")
             # Store the effective draft publish_review actually posted (e.g.
@@ -1014,6 +1024,7 @@ def _execute_review(
         _push_event(job, "step", "done")
         _push_event(job, "done", "")
     except _UnparseableLLMOutput as exc:
+        job.session = merge_session_records(job.session, getattr(exc, "session", None))
         job.status = "error"
         job.raw_llm_output = exc.content
         job.error = exc.user_message()
@@ -1232,6 +1243,7 @@ def _run_task_worker(job: Job, worker_cfg: Config, req: TaskRequest) -> None:
                     )
                     continue
                 raise
+            job.session = merge_session_records(job.session, attempt_result.session)
             if attempt_result.no_change and index < len(candidate_reqs):
                 last_no_change = attempt_result
                 emit(
@@ -1261,6 +1273,7 @@ def _run_task_worker(job: Job, worker_cfg: Config, req: TaskRequest) -> None:
         emit("done", "")
     except TaskError as exc:
         log.warning("task %s rejected: %s", job.id, exc)
+        job.session = merge_session_records(job.session, getattr(exc, "session", None))
         job.status = "error"
         job.error = str(exc)
         emit("step", "error")
@@ -2145,6 +2158,34 @@ def _build_badge_html() -> str:
 @app.get("/healthz")
 def healthz() -> dict:
     return {"status": "ok"}  # the `serge` build stamp is added by middleware
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    """Prometheus exposition of the finished jobs the store still holds.
+
+    Unauthenticated, like ``/healthz``: it is scraped in-cluster over the pod
+    port, and it carries no review content — job ids, repo/PR numbers, the model
+    name, and counters. Deliberately a rolling window (``WEB_JOB_RETENTION``
+    jobs); Prometheus is the durable side, so read history with a range query,
+    not by curling this. See :mod:`reviewbot.metrics`."""
+    try:
+        sessions = _store.list_sessions(limit=max(cfg.web_job_retention, 1))
+    except Exception:  # noqa: BLE001 — a scrape must never take the app down
+        log.exception("failed to read job sessions for /metrics")
+        sessions = []
+    body = render_job_metrics(
+        sessions,
+        retention=cfg.web_job_retention,
+        version=__version__,
+        commit=git_sha(),
+    )
+    # version=0.0.4 is what Prometheus' text parser expects; without it some
+    # scrapers fall back to sniffing and reject the body.
+    return Response(
+        content=body,
+        media_type="text/plain; version=0.0.4; charset=utf-8",
+    )
 
 
 @app.get("/version")
@@ -3212,13 +3253,20 @@ async def ingest_task_event(job_id: str, request: Request) -> JSONResponse:
                     draft.prompt_tokens = int(result.get("prompt_tokens") or 0)
                     draft.completion_tokens = int(result.get("completion_tokens") or 0)
                     draft.truncated_chunks = int(result.get("truncated_chunks") or 0)
+                    draft.session = result.get("session") or {}
+                    job.session = draft.session
                 job.draft = draft
         elif isinstance(result, dict):
             job.task_result = result
+            job.session = result.get("session") or {}
             try:
                 _store.save_task_result(job.id, _json.dumps(result))
             except Exception:  # noqa: BLE001
                 log.exception("failed to persist task result for %s", job.id)
+        if isinstance(terminal.get("session"), dict) and terminal["session"]:
+            # An errored runner has no ``result`` to hang counters off; it sends
+            # them alongside the error instead.
+            job.session = merge_session_records(job.session, terminal["session"])
         if terminal.get("error"):
             job.error = str(terminal["error"])
         if terminal.get("raw_llm_output"):
@@ -3924,6 +3972,10 @@ def task_status(request: Request, owner: str, repo: str, job_id: str) -> JSONRes
             "model": job.llm_model,
             "prompt_tokens": (row or {}).get("prompt_tokens"),
             "completion_tokens": (row or {}).get("completion_tokens"),
+            # Agent-loop counters for the whole job, so the triage reconciler can
+            # report *why* a group came back no_fix — a guard ending the session
+            # reads very differently from the model deciding it had no fix.
+            "session": (row or {}).get("session") or job.session or {},
         }
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -149,6 +149,18 @@ class RobustnessTests(unittest.TestCase):
         self.assertEqual(len(body.strip().splitlines()), len(body.strip().split("\n")))
         self.assertEqual(len(_samples(body, "serge_job_info")), 1)
 
+    def test_the_frozen_outcome_wins_over_the_live_row_status(self) -> None:
+        """A review is `done` until a human publishes it. If the exported label
+        followed the row, the same job would fork into a second series and show
+        up twice in any table over a window that straddles the publish."""
+        session = dict(_row("a")["session"], outcome="done")
+        body = render_job_metrics([_row("a", status="published", session=session)])
+        self.assertIn('status="done"', _samples(body, "serge_job_info")[0])
+
+    def test_a_session_predating_the_outcome_stamp_falls_back_to_the_row(self) -> None:
+        body = render_job_metrics([_row("a", status="no_fix")])
+        self.assertIn('status="no_fix"', _samples(body, "serge_job_info")[0])
+
     def test_unknown_stop_reason_is_labelled_not_dropped(self) -> None:
         body = render_job_metrics([_row("a", session={"turns": 1})])
         self.assertIn('stop_reason="unknown"', _samples(body, "serge_job_info")[0])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,193 @@
+"""Tests for the Prometheus exposition of finished jobs.
+
+This endpoint is the only thing that carries a session's counters past the
+25-job store retention, so its failure mode matters: a scrape that raises, or a
+body Prometheus refuses to parse, silently loses the history rather than
+reporting an error anyone sees.
+"""
+
+import unittest
+
+from reviewbot.metrics import render_job_metrics
+
+try:
+    from prometheus_client.parser import text_string_to_metric_families
+except ModuleNotFoundError:  # pragma: no cover
+    text_string_to_metric_families = None
+
+
+def _row(job_id: str, **overrides) -> dict:
+    row = {
+        "id": job_id,
+        "target_owner": "huggingface",
+        "target_repo": "transformers",
+        "target_number": 48322,
+        "status": "published",
+        "kind": "task",
+        "llm_model": "kimi-k2",
+        "created_at": 1_756_000_000.0,
+        "updated_at": 1_756_003_600.0,
+        "pr_number": 48322,
+        "verify_verdict": "fixed",
+        "session": {
+            "turns": 46,
+            "tool_calls": 48,
+            "prompt_tokens": 2_111_885,
+            "completion_tokens": 9_000,
+            "seconds": 1234.5,
+            "stop_reason": "input_token_cap",
+            "repeats": 2,
+            "distinct_paths": 12,
+            "path_revisits": 14,
+            "validation_retries": 1,
+            "truncation_retries": 0,
+            "rounds": 1,
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def _samples(body: str, name: str) -> list[str]:
+    return [
+        line
+        for line in body.splitlines()
+        if line.startswith(name + "{") or line == name or line.startswith(name + " ")
+    ]
+
+
+class ExpositionShapeTests(unittest.TestCase):
+    def test_every_metric_declares_help_and_type(self) -> None:
+        body = render_job_metrics([_row("a")], retention=25)
+        named = {
+            line.split()[0]
+            for line in body.splitlines()
+            if line and not line.startswith("#")
+        }
+        metric_names = {name.split("{", 1)[0] for name in named}
+        for metric in metric_names:
+            self.assertIn(f"# HELP {metric} ", body, metric)
+            self.assertIn(f"# TYPE {metric} ", body, metric)
+
+    def test_identity_lives_on_the_info_series_only(self) -> None:
+        """Labels on the value series would fork a job's numbers into a new
+        series every time one of them changed."""
+        body = render_job_metrics([_row("a")])
+        info = _samples(body, "serge_job_info")[0]
+        self.assertIn('stop_reason="input_token_cap"', info)
+        self.assertIn('repo="huggingface/transformers"', info)
+        self.assertIn('pr="48322"', info)
+        self.assertIn('verify_verdict="fixed"', info)
+        self.assertTrue(info.endswith(" 1"))
+        turns = _samples(body, "serge_job_turns")[0]
+        self.assertEqual(turns, 'serge_job_turns{job_id="a"} 46')
+
+    def test_counters_are_exported(self) -> None:
+        body = render_job_metrics([_row("a")])
+        self.assertIn('serge_job_input_tokens{job_id="a"} 2111885', body)
+        self.assertIn('serge_job_path_revisits{job_id="a"} 14', body)
+        self.assertIn('serge_job_distinct_paths{job_id="a"} 12', body)
+        self.assertIn('serge_job_rounds{job_id="a"} 1', body)
+        self.assertIn('serge_job_llm_seconds{job_id="a"} 1234.5', body)
+
+    def test_finished_timestamp_orders_the_window(self) -> None:
+        body = render_job_metrics([_row("a")])
+        self.assertIn(
+            'serge_job_finished_timestamp_seconds{job_id="a"} 1756003600', body
+        )
+
+    def test_retention_is_exported_so_a_gap_is_readable(self) -> None:
+        body = render_job_metrics([], retention=25)
+        self.assertIn("serge_job_retention 25", body)
+
+    def test_build_info(self) -> None:
+        body = render_job_metrics([], version="1.2.3", commit="abc1234")
+        self.assertIn('serge_build_info{version="1.2.3",commit="abc1234"} 1', body)
+
+
+class RobustnessTests(unittest.TestCase):
+    """A scrape reads whatever the store happens to hold, including rows written
+    by an older build."""
+
+    def test_no_jobs_still_renders_a_valid_body(self) -> None:
+        body = render_job_metrics([])
+        self.assertTrue(body.endswith("\n"))
+        self.assertIn("# TYPE serge_job_info gauge", body)
+        self.assertEqual(_samples(body, "serge_job_turns"), [])
+
+    def test_a_session_missing_a_counter_skips_that_sample(self) -> None:
+        body = render_job_metrics([_row("a", session={"turns": 3})])
+        self.assertIn('serge_job_turns{job_id="a"} 3', body)
+        self.assertEqual(_samples(body, "serge_job_path_revisits"), [])
+        # …but the job is still described.
+        self.assertEqual(len(_samples(body, "serge_job_info")), 1)
+
+    def test_a_junk_counter_is_dropped_not_rendered(self) -> None:
+        body = render_job_metrics(
+            [_row("a", session={"turns": "many", "tool_calls": None, "repeats": True})]
+        )
+        self.assertEqual(_samples(body, "serge_job_turns"), [])
+        self.assertEqual(_samples(body, "serge_job_tool_calls"), [])
+        # bool is an int in Python but not a meaningful count here.
+        self.assertEqual(_samples(body, "serge_job_repeat_calls"), [])
+
+    def test_missing_identity_renders_empty_labels_not_none(self) -> None:
+        body = render_job_metrics(
+            [_row("a", llm_model=None, verify_verdict=None, pr_number=None)]
+        )
+        info = _samples(body, "serge_job_info")[0]
+        self.assertIn('model="none"', info)
+        self.assertIn('verify_verdict="none"', info)
+        self.assertIn('pr=""', info)
+        self.assertNotIn("None", info)
+
+    def test_label_values_are_escaped(self) -> None:
+        body = render_job_metrics([_row("a", llm_model='we"ird\\model\nname')])
+        info = _samples(body, "serge_job_info")[0]
+        self.assertIn(r'model="we\"ird\\model\nname"', info)
+        # One line per series, whatever the payload contained.
+        self.assertEqual(len(body.strip().splitlines()), len(body.strip().split("\n")))
+        self.assertEqual(len(_samples(body, "serge_job_info")), 1)
+
+    def test_unknown_stop_reason_is_labelled_not_dropped(self) -> None:
+        body = render_job_metrics([_row("a", session={"turns": 1})])
+        self.assertIn('stop_reason="unknown"', _samples(body, "serge_job_info")[0])
+
+
+class PrometheusParserTests(unittest.TestCase):
+    """Check the body against Prometheus' own parser.
+
+    Everything else here asserts on substrings, which cannot catch a body the
+    scraper rejects outright — and a rejected scrape is invisible from this side.
+    """
+
+    def setUp(self) -> None:
+        if text_string_to_metric_families is None:
+            self.skipTest("prometheus_client not installed")
+
+    def _parse(self, body: str):
+        return list(text_string_to_metric_families(body))
+
+    def test_a_populated_export_parses(self) -> None:
+        rows = [_row(f"job{i}") for i in range(7)]
+        families = self._parse(
+            render_job_metrics(rows, retention=25, version="0.1.0", commit="abc")
+        )
+        by_name = {f.name: f for f in families}
+        self.assertEqual(len(by_name["serge_job_info"].samples), 7)
+        self.assertEqual(len(by_name["serge_job_turns"].samples), 7)
+        for family in families:
+            self.assertEqual(family.type, "gauge", family.name)
+
+    def test_an_empty_export_parses(self) -> None:
+        self._parse(render_job_metrics([], retention=25))
+
+    def test_hostile_label_values_parse_back_unchanged(self) -> None:
+        model = 'we"ird\\model\nname'
+        families = self._parse(render_job_metrics([_row("a", llm_model=model)]))
+        info = {f.name: f for f in families}["serge_job_info"]
+        self.assertEqual(info.samples[0].labels["model"], model)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_review_runner.py
+++ b/tests/test_review_runner.py
@@ -7,7 +7,7 @@ import unittest
 from unittest import mock
 
 from reviewbot import review_runner
-from reviewbot.reviewer import ReviewDraft, ReviewRequest
+from reviewbot.reviewer import ReviewDraft, ReviewRequest, _UnparseableLLMOutput
 from reviewbot.store import decode_draft
 from reviewbot.task_runner import RunnerSpec
 
@@ -53,12 +53,15 @@ class _RecordingEmitter:
     def emit(self, kind, text):
         self.events.append((kind, text))
 
-    def finish(self, status, *, result=None, error=None, raw_llm_output=None):
+    def finish(
+        self, status, *, result=None, error=None, raw_llm_output=None, session=None
+    ):
         self.terminal = {
             "status": status,
             "result": result,
             "error": error,
             "raw_llm_output": raw_llm_output,
+            "session": session,
         }
 
 
@@ -133,11 +136,54 @@ class ReviewRunnerTests(unittest.TestCase):
         self.assertEqual(rebuilt.summary, "looks good")
         self.assertEqual(rebuilt.head_sha, "deadbeef")
 
+    def test_run_ships_the_agent_loop_session(self):
+        """Prod runs reviews in per-review pods, so this callback is the session's
+        only route home. Without it every review persists a zeroed "never ran the
+        loop" record while having run one — worse than missing data."""
+        session = {
+            "turns": 12,
+            "tool_calls": 20,
+            "prompt_tokens": 480_000,
+            "stop_reason": "repeat_guard",
+            "path_revisits": 9,
+            "rounds": 1,
+        }
+        draft = ReviewDraft(
+            owner="acme",
+            repo="widgets",
+            number=7,
+            head_sha="deadbeef",
+            summary="looks good",
+            event="COMMENT",
+            comments=[],
+            prompt_tokens=100,
+            completion_tokens=42,
+            session=session,
+        )
+        code, emitter = self._run(prepare_return=draft)
+        self.assertEqual(code, 0)
+        self.assertEqual(emitter.terminal["result"]["session"], session)
+        # It travels beside the draft, not inside it — decode_draft does not
+        # carry carrier fields, so a caller must read the top-level key.
+        self.assertEqual(decode_draft(emitter.terminal["result"]["draft"]).session, {})
+
     def test_run_no_reviewable_diff(self):
         code, emitter = self._run(prepare_return=None)
         self.assertEqual(code, 0)
         self.assertEqual(emitter.terminal["status"], "done")
         self.assertIsNone(emitter.terminal["result"])
+
+    def test_unparseable_output_still_reports_what_it_spent(self):
+        exc = _UnparseableLLMOutput(
+            content="not json",
+            finish_reason="length",
+            metrics_line="",
+            session={"turns": 31, "stop_reason": "input_token_cap", "rounds": 1},
+        )
+        code, emitter = self._run(prepare_side_effect=exc)
+        self.assertEqual(code, 1)
+        self.assertEqual(emitter.terminal["status"], "error")
+        self.assertEqual(emitter.terminal["session"]["stop_reason"], "input_token_cap")
 
     def test_run_reports_error_on_crash(self):
         code, emitter = self._run(prepare_side_effect=RuntimeError("boom"))

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1184,6 +1184,22 @@ class SessionRecordTests(unittest.TestCase):
             merge_session_records({"turns": 1, "rounds": 2}, already)["rounds"], 5
         )
 
+    def test_a_zero_round_record_is_not_read_as_one(self) -> None:
+        """`rounds: 0` is a real value — a job that never reached the loop — so
+        the arithmetic must not fall back to 1 and invent a loop."""
+        never_ran = no_llm_session_record()
+        self.assertEqual(merge_session_records({}, never_ran)["rounds"], 0)
+        one_loop = {"turns": 5, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        self.assertEqual(merge_session_records(never_ran, one_loop)["rounds"], 1)
+        self.assertEqual(merge_session_records(one_loop, never_ran)["rounds"], 1)
+
+    def test_a_record_without_a_rounds_key_counts_as_one_loop(self) -> None:
+        """Missing is not zero: a session record written before `rounds` existed
+        still describes exactly one loop."""
+        legacy = {"turns": 5, "stop_reason": STOP_ANSWERED}
+        self.assertEqual(merge_session_records({}, legacy)["rounds"], 1)
+        self.assertEqual(merge_session_records(legacy, dict(legacy))["rounds"], 2)
+
     def test_merging_nothing_changes_nothing(self) -> None:
         a = {"turns": 3, "rounds": 1}
         self.assertEqual(merge_session_records(a, None), a)

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -25,6 +25,14 @@ from reviewbot.reviewer import (
     _prose_outside_json,
     _run_agentic_loop,
     _summarize_rejected_comments,
+    STOP_ANSWERED,
+    STOP_BLIND_TURN_CAP,
+    STOP_INPUT_TOKEN_CAP,
+    STOP_NO_LLM_TURNS,
+    STOP_REPEAT_GUARD,
+    merge_session_records,
+    no_llm_session_record,
+    session_record,
 )
 
 
@@ -1009,3 +1017,184 @@ class LeakedTextToolCallLoopTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class StopReasonTests(unittest.TestCase):
+    """Which guard ended the session, recorded per job.
+
+    In the one prod window still readable when this was written, all seven task
+    sessions that ran LLM turns were terminated by a guard and none by the model
+    deciding it was done — a fact that was nowhere in the data, only in the log
+    lines of jobs that have since been pruned."""
+
+    def _tool_turn(self, prompt_tokens: int = 40_000) -> ChatResult:
+        return ChatResult(
+            content="",
+            usage={"prompt_tokens": prompt_tokens, "completion_tokens": 20},
+            tool_calls=[ToolCall(id="t", name="grep", arguments='{"pattern": "Foo"}')],
+        )
+
+    def _answer(self) -> ChatResult:
+        return ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+        )
+
+    def test_a_model_that_finishes_is_recorded_as_answered(self) -> None:
+        cfg = _CfgStub()
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+
+    def test_input_token_cap(self) -> None:
+        cfg = _CfgStub(llm_max_input_tokens=100_000)
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([self._tool_turn(120_000), self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_INPUT_TOKEN_CAP)
+
+    def test_repeat_guard(self) -> None:
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=2)
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([self._tool_turn()] * 3 + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_REPEAT_GUARD)
+
+    def test_blind_turn_cap(self) -> None:
+        cfg = _CfgStub(tool_max_iterations=2, tool_repeat_limit=0)
+        turns = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+                tool_calls=[
+                    ToolCall(
+                        id=f"t{i}", name="grep", arguments='{"pattern": "P%d"}' % i
+                    )
+                ],
+            )
+            for i in range(4)
+        ]
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(turns + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_BLIND_TURN_CAP)
+
+    def test_the_browse_record_rides_out_with_the_metrics(self) -> None:
+        """Whatever exit the loop takes, the counters must be complete."""
+        cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=0)
+        reads = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+                tool_calls=[
+                    ToolCall(
+                        id=f"t{i}",
+                        name="read_file",
+                        arguments='{"path": "a.py", "start_line": %d}' % (i * 50),
+                    )
+                ],
+            )
+            for i in range(3)
+        ]
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(reads + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        # Three reads of one file at different offsets: no exact repeat, but two
+        # of the three calls re-opened a file already in the context.
+        self.assertEqual(metrics.repeats, 0)
+        self.assertEqual(metrics.distinct_paths, 1)
+        self.assertEqual(metrics.path_revisits, 2)
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+
+
+class SessionRecordTests(unittest.TestCase):
+    def test_record_is_flat_and_json_safe(self) -> None:
+        cfg = _CfgStub()
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(  # type: ignore[arg-type]
+                [
+                    ChatResult(
+                        content='{"summary": "ok", "comments": []}',
+                        usage={"prompt_tokens": 7, "completion_tokens": 3},
+                    )
+                ]
+            ),
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        record = session_record(metrics)
+        self.assertEqual(json.loads(json.dumps(record)), record)
+        self.assertEqual(record["turns"], 1)
+        self.assertEqual(record["prompt_tokens"], 7)
+        self.assertEqual(record["rounds"], 1)
+        self.assertEqual(record["stop_reason"], STOP_ANSWERED)
+
+    def test_merging_sums_the_bill_and_counts_the_rounds(self) -> None:
+        a = {
+            "turns": 10,
+            "tool_calls": 5,
+            "prompt_tokens": 900,
+            "rounds": 1,
+            "stop_reason": STOP_ANSWERED,
+            "distinct_paths": 3,
+            "seconds": 1.5,
+        }
+        b = {
+            "turns": 7,
+            "tool_calls": 9,
+            "prompt_tokens": 1_200,
+            "rounds": 1,
+            "stop_reason": STOP_INPUT_TOKEN_CAP,
+            "distinct_paths": 8,
+            "seconds": 2.0,
+        }
+        merged = merge_session_records(a, b)
+        self.assertEqual(merged["turns"], 17)
+        self.assertEqual(merged["prompt_tokens"], 2_100)
+        self.assertEqual(merged["rounds"], 2)
+        self.assertEqual(merged["seconds"], 3.5)
+        # One cut-off round is what starves the patch that gets published, so a
+        # guard anywhere in the job is what the job reports.
+        self.assertEqual(merged["stop_reason"], STOP_INPUT_TOKEN_CAP)
+        # Paths cannot be summed without double-counting a file two rounds both
+        # opened; the larger round is the honest bound.
+        self.assertEqual(merged["distinct_paths"], 8)
+
+    def test_merging_an_accumulation_keeps_its_round_count(self) -> None:
+        already = {"turns": 4, "rounds": 3, "stop_reason": STOP_ANSWERED}
+        self.assertEqual(merge_session_records({}, already)["rounds"], 3)
+        self.assertEqual(
+            merge_session_records({"turns": 1, "rounds": 2}, already)["rounds"], 5
+        )
+
+    def test_merging_nothing_changes_nothing(self) -> None:
+        a = {"turns": 3, "rounds": 1}
+        self.assertEqual(merge_session_records(a, None), a)
+        self.assertEqual(merge_session_records(a, {}), a)
+        self.assertEqual(merge_session_records(None, None), {})
+
+    def test_a_job_that_never_ran_the_loop_still_reports(self) -> None:
+        """Reproduce-first classifying a group ENVIRONMENT is 0 LLM turns, and
+        that has to be countable — otherwise it is indistinguishable from serge
+        never having been asked."""
+        record = no_llm_session_record()
+        self.assertEqual(record["rounds"], 0)
+        self.assertEqual(record["turns"], 0)
+        self.assertEqual(record["stop_reason"], STOP_NO_LLM_TURNS)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -247,3 +247,263 @@ class JobStoreTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SessionRecordPersistenceTests(unittest.TestCase):
+    """The per-job agent-loop counters, and the rolling window over them.
+
+    Point of the whole thing: the job row itself is pruned after
+    ``WEB_JOB_RETENTION`` jobs, so these counters are only useful if something
+    scrapes them out before that. :meth:`JobStore.list_sessions` is what
+    ``GET /metrics`` reads.
+    """
+
+    def _store_with_job(self, tmp: str, job_id: str = "j1", **kw) -> JobStore:
+        store = JobStore(os.path.join(tmp, "jobs.db"))
+        store.insert_job(
+            id=job_id,
+            user="alice",
+            target_owner="huggingface",
+            target_repo="transformers",
+            target_number=48322,
+            trigger_comment="x",
+            llm_provider="hf",
+            llm_api_base="https://router.huggingface.co",
+            llm_model="kimi-k2",
+            created_at=kw.pop("created_at", 1.0),
+            status="running",
+            kind=kw.pop("kind", "task"),
+        )
+        return store
+
+    SESSION = {
+        "turns": 46,
+        "tool_calls": 48,
+        "prompt_tokens": 2_111_885,
+        "stop_reason": "input_token_cap",
+        "path_revisits": 14,
+        "rounds": 1,
+    }
+
+    def test_round_trips_through_the_job_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp)
+            store.save_terminal(
+                "j1",
+                status="published",
+                error=None,
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+                session=self.SESSION,
+            )
+            row = store.load("j1")
+            assert row is not None
+            self.assertEqual(row["session"], self.SESSION)
+
+    def test_the_review_path_takes_it_off_the_draft(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp, kind="review")
+            draft = ReviewDraft(
+                owner="o",
+                repo="r",
+                number=1,
+                head_sha="abc",
+                summary="s",
+                event="COMMENT",
+                session=self.SESSION,
+            )
+            store.save_terminal(
+                "j1",
+                status="done",
+                error=None,
+                raw_llm_output=None,
+                draft=draft,
+                history=[],
+            )
+            row = store.load("j1")
+            assert row is not None
+            self.assertEqual(row["session"]["turns"], 46)
+
+    def test_a_later_write_without_a_session_does_not_erase_one(self) -> None:
+        """Publishing from the UI re-saves the terminal row; the counters were
+        recorded when the loop finished and must survive that."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp)
+            store.save_terminal(
+                "j1",
+                status="done",
+                error=None,
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+                session=self.SESSION,
+            )
+            store.save_terminal(
+                "j1",
+                status="published",
+                error=None,
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+            )
+            row = store.load("j1")
+            assert row is not None
+            self.assertEqual(row["session"], self.SESSION)
+            self.assertEqual(row["status"], "published")
+
+    def test_a_job_with_no_session_reads_as_empty_not_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp)
+            row = store.load("j1")
+            assert row is not None
+            self.assertEqual(row["session"], {})
+
+    def test_list_sessions_skips_running_and_session_less_jobs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp, "done1", created_at=1.0)
+            store.insert_job(
+                id="running1",
+                user="a",
+                target_owner="o",
+                target_repo="r",
+                target_number=2,
+                trigger_comment="x",
+                llm_provider="hf",
+                llm_api_base="b",
+                llm_model="m",
+                created_at=2.0,
+                status="running",
+            )
+            store.insert_job(
+                id="nosession",
+                user="a",
+                target_owner="o",
+                target_repo="r",
+                target_number=3,
+                trigger_comment="x",
+                llm_provider="hf",
+                llm_api_base="b",
+                llm_model="m",
+                created_at=3.0,
+                status="error",
+            )
+            store.save_terminal(
+                "done1",
+                status="published",
+                error=None,
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+                session=self.SESSION,
+            )
+            # A running job that already recorded a partial session must still be
+            # excluded: its counters are still moving.
+            store._conn.execute(
+                "UPDATE jobs SET session_json = ? WHERE id = ?",
+                (json.dumps(self.SESSION), "running1"),
+            )
+            store._conn.commit()
+
+            rows = store.list_sessions()
+            self.assertEqual([r["id"] for r in rows], ["done1"])
+            self.assertEqual(rows[0]["session"]["turns"], 46)
+
+    def test_list_sessions_lifts_the_pr_and_verdict_out_of_the_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp)
+            store.save_task_result(
+                "j1",
+                json.dumps({"pr_number": 48322, "verify_verdict": "fixed"}),
+            )
+            store.save_terminal(
+                "j1",
+                status="published",
+                error=None,
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+                session=self.SESSION,
+            )
+            row = store.list_sessions()[0]
+            self.assertEqual(row["pr_number"], 48322)
+            self.assertEqual(row["verify_verdict"], "fixed")
+
+    def test_a_malformed_session_does_not_break_the_scrape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store_with_job(tmp)
+            store.save_terminal(
+                "j1",
+                status="error",
+                error="boom",
+                raw_llm_output=None,
+                draft=None,
+                history=[],
+                session=self.SESSION,
+            )
+            store._conn.execute(
+                "UPDATE jobs SET session_json = ? WHERE id = ?", ("{not json", "j1")
+            )
+            store._conn.commit()
+            self.assertEqual(store.list_sessions()[0]["session"], {})
+            row = store.load("j1")
+            assert row is not None
+            self.assertEqual(row["session"], {})
+
+    def test_the_window_is_newest_first_and_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(os.path.join(tmp, "jobs.db"))
+            for i in range(5):
+                store.insert_job(
+                    id=f"j{i}",
+                    user="a",
+                    target_owner="o",
+                    target_repo="r",
+                    target_number=i,
+                    trigger_comment="x",
+                    llm_provider="hf",
+                    llm_api_base="b",
+                    llm_model="m",
+                    created_at=float(i),
+                    status="running",
+                )
+                store.save_terminal(
+                    f"j{i}",
+                    status="done",
+                    error=None,
+                    raw_llm_output=None,
+                    draft=None,
+                    history=[],
+                    session={"turns": i},
+                )
+            self.assertEqual(
+                [r["id"] for r in store.list_sessions(limit=3)], ["j4", "j3", "j2"]
+            )
+
+    def test_an_old_database_gains_the_column(self) -> None:
+        """The column is added by _ensure_column, not by recreating the table."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "jobs.db")
+            legacy = sqlite3.connect(path)
+            legacy.execute(
+                """
+                CREATE TABLE jobs (
+                    id TEXT PRIMARY KEY, user TEXT NOT NULL,
+                    target_owner TEXT NOT NULL, target_repo TEXT NOT NULL,
+                    target_number INTEGER NOT NULL, trigger_comment TEXT NOT NULL,
+                    created_at REAL NOT NULL, updated_at REAL NOT NULL,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+            legacy.execute(
+                "INSERT INTO jobs VALUES ('old', 'a', 'o', 'r', 1, 'x', 1.0, 1.0, 'done')"
+            )
+            legacy.commit()
+            legacy.close()
+
+            store = JobStore(path)
+            row = store.load("old")
+            assert row is not None
+            self.assertEqual(row["session"], {})
+            self.assertEqual(store.list_sessions(), [])

--- a/tests/test_tool_repeat.py
+++ b/tests/test_tool_repeat.py
@@ -7,7 +7,7 @@ fix, and produced a patch that failed GPU verification — three rounds running.
 
 import unittest
 
-from reviewbot.tool_repeat import ToolRepeatGuard, normalize_arguments
+from reviewbot.tool_repeat import ToolRepeatGuard, normalize_arguments, path_argument
 
 
 GREP_A = '{"pattern": "GlmOcrProcessor|Glm46VProcessor", "path": "src/transformers/models/glm_ocr", "max_results": 50}'
@@ -142,6 +142,91 @@ class ToolRepeatGuardTests(unittest.TestCase):
                 break
         self.assertTrue(guard.tripped)
         self.assertLessEqual(served, 8)
+
+
+class PathArgumentTests(unittest.TestCase):
+    def test_only_the_opening_tools_name_a_path(self):
+        self.assertEqual(path_argument("read_file", '{"path": "a/b.py"}'), "a/b.py")
+        self.assertEqual(path_argument("list_dir", '{"path": "a"}'), "a")
+        # A grep of the same path with a different pattern is a new search,
+        # not a re-read, so it is not counted as a visit.
+        self.assertIsNone(path_argument("grep", '{"pattern": "x", "path": "a"}'))
+        self.assertIsNone(path_argument("fetch_url", '{"url": "https://x"}'))
+
+    def test_spellings_of_the_same_path_collapse(self):
+        for spelling in ("a/b.py", "./a/b.py", "/a/b.py", "  a/b.py  "):
+            self.assertEqual(
+                path_argument("read_file", '{"path": "%s"}' % spelling.strip()),
+                "a/b.py",
+                spelling,
+            )
+
+    def test_list_dir_without_a_path_is_still_a_visit(self):
+        """Its path is optional and defaults to the repo root."""
+        self.assertEqual(path_argument("list_dir", "{}"), ".")
+        self.assertEqual(path_argument("list_dir", '{"path": "/"}'), ".")
+
+    def test_unusable_arguments_name_no_path(self):
+        self.assertIsNone(path_argument("read_file", "not json"))
+        self.assertIsNone(path_argument("read_file", "[1, 2]"))
+        self.assertIsNone(path_argument("read_file", '{"start_line": 1}'))
+
+
+class PathVisitTests(unittest.TestCase):
+    """The waste the exact-signature counter cannot see.
+
+    Job 9d210794 made 153 tool calls, 137 of them re-openings of a path it had
+    already read — ``modular_blt.py`` 53 times, at different line ranges. Every
+    one of those is a distinct signature, so ``repeats`` stays 0 while the
+    budget drains."""
+
+    def test_rereads_of_one_file_are_revisits_but_not_exact_repeats(self):
+        guard = ToolRepeatGuard(6)
+        for start in (1, 180, 400, 620):
+            guard.observe(
+                "read_file",
+                '{"path": "src/m/modular_blt.py", "start_line": %d}' % start,
+            )
+        self.assertEqual(guard.repeats, 0)
+        self.assertFalse(guard.tripped)
+        self.assertEqual(guard.distinct_paths, 1)
+        self.assertEqual(guard.path_revisits, 3)
+
+    def test_a_file_read_once_is_not_waste(self):
+        guard = ToolRepeatGuard(6)
+        for i in range(10):
+            guard.observe("read_file", '{"path": "f%d.py"}' % i)
+        self.assertEqual(guard.distinct_paths, 10)
+        self.assertEqual(guard.path_revisits, 0)
+
+    def test_counting_survives_a_disabled_guard(self):
+        """The nudge is configurable; the observability record is not."""
+        guard = ToolRepeatGuard(0)
+        for _ in range(5):
+            self.assertIsNone(guard.observe("read_file", '{"path": "a.py"}'))
+        self.assertEqual(guard.repeats, 0)
+        self.assertEqual(guard.path_revisits, 4)
+
+    def test_worst_paths_ranks_the_offenders(self):
+        guard = ToolRepeatGuard(999)
+        for _ in range(53):
+            guard.observe("read_file", '{"path": "modular_blt.py"}')
+        for _ in range(21):
+            guard.observe("read_file", '{"path": "configuration_utils.py"}')
+        guard.observe("read_file", '{"path": "once.py"}')
+        self.assertEqual(
+            guard.worst_paths(),
+            [("modular_blt.py", 53), ("configuration_utils.py", 21)],
+        )
+
+    def test_stats_is_the_flat_record(self):
+        guard = ToolRepeatGuard(6)
+        guard.observe("read_file", '{"path": "a.py"}')
+        guard.observe("read_file", '{"path": "a.py"}')
+        self.assertEqual(
+            guard.stats(),
+            {"repeats": 1, "distinct_paths": 1, "path_revisits": 1},
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_webapp_metrics.py
+++ b/tests/test_webapp_metrics.py
@@ -1,0 +1,154 @@
+"""Tests for ``GET /metrics``.
+
+The endpoint has to be scrapeable without a session (Prometheus holds no
+cookie), must not carry review content, and must answer even when the store is
+empty or a row is unreadable — a scrape that 500s loses the history quietly.
+"""
+
+import importlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+try:
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:  # pragma: no cover
+    TestClient = None
+
+
+SESSION = {
+    "turns": 46,
+    "tool_calls": 48,
+    "prompt_tokens": 2_111_885,
+    "completion_tokens": 9_000,
+    "seconds": 1234.5,
+    "stop_reason": "input_token_cap",
+    "repeats": 2,
+    "distinct_paths": 12,
+    "path_revisits": 14,
+    "validation_retries": 0,
+    "truncation_retries": 0,
+    "rounds": 1,
+}
+
+
+class WebappMetricsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        sys.modules.pop("reviewbot.webapp", None)
+        env = {
+            "GITHUB_APP_ID": "123",
+            "GITHUB_PRIVATE_KEY": "dummy-private-key",
+            "GITHUB_WEBHOOK_SECRET": "webhook-secret",
+            "LLM_API_KEY": "llm-token",
+            "WEB_STORE_PATH": os.path.join(self.tmpdir, "jobs.db"),
+            "WEB_CLONE_CACHE_DIR": os.path.join(self.tmpdir, "clones"),
+            "WEB_JOB_RETENTION": "25",
+            # Real auth, not DEV_NO_AUTH: the point of the first test is that a
+            # scraper with no session still gets the body.
+            "GITHUB_OAUTH_CLIENT_ID": "oauth-client",
+            "GITHUB_OAUTH_CLIENT_SECRET": "oauth-secret",
+            "WEB_SESSION_SECRET": "session-secret",
+            "WEB_ALLOWED_ORG": "huggingface",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.webapp = importlib.import_module("reviewbot.webapp")
+        self.client = TestClient(self.webapp.app)
+
+    def _finished_job(self, job_id: str, *, session=SESSION, **result) -> None:
+        store = self.webapp._store
+        store.insert_job(
+            id=job_id,
+            user="alice",
+            target_owner="huggingface",
+            target_repo="transformers",
+            target_number=48322,
+            trigger_comment="x",
+            llm_provider="hf",
+            llm_api_base="https://router.huggingface.co",
+            llm_model="kimi-k2",
+            created_at=1.0,
+            status="running",
+            kind="task",
+        )
+        if result:
+            store.save_task_result(job_id, json.dumps(result))
+        store.save_terminal(
+            job_id,
+            status="published",
+            error=None,
+            raw_llm_output=None,
+            draft=None,
+            history=[],
+            session=session,
+        )
+
+    def test_scrapeable_without_a_session_cookie(self) -> None:
+        r = self.client.get("/metrics")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.headers["content-type"].startswith("text/plain"))
+        self.assertIn("version=0.0.4", r.headers["content-type"])
+
+    def test_a_json_stamping_middleware_does_not_rewrite_the_body(self) -> None:
+        """The build stamp is merged into JSON bodies; a text exposition must
+        come back byte-for-byte or Prometheus rejects it."""
+        r = self.client.get("/metrics")
+        self.assertNotIn('{"serge"', r.text)
+        for line in r.text.splitlines():
+            self.assertTrue(line.startswith("#") or " " in line, line)
+
+    def test_empty_store_is_a_valid_scrape(self) -> None:
+        r = self.client.get("/metrics")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("serge_job_retention 25", r.text)
+        self.assertNotIn("serge_job_turns{", r.text)
+
+    def test_a_finished_job_is_exported(self) -> None:
+        self._finished_job("job1", pr_number=48322, verify_verdict="fixed")
+        body = self.client.get("/metrics").text
+        self.assertIn('job_id="job1"', body)
+        self.assertIn('stop_reason="input_token_cap"', body)
+        self.assertIn('pr="48322"', body)
+        self.assertIn('serge_job_input_tokens{job_id="job1"} 2111885', body)
+        self.assertIn('serge_job_path_revisits{job_id="job1"} 14', body)
+
+    def test_a_running_job_is_not_exported(self) -> None:
+        self.webapp._store.insert_job(
+            id="live",
+            user="alice",
+            target_owner="huggingface",
+            target_repo="transformers",
+            target_number=1,
+            trigger_comment="x",
+            llm_provider="hf",
+            llm_api_base="b",
+            llm_model="m",
+            created_at=1.0,
+            status="running",
+        )
+        self.assertNotIn('job_id="live"', self.client.get("/metrics").text)
+
+    def test_no_review_content_reaches_the_exposition(self) -> None:
+        self._finished_job("job1")
+        body = self.client.get("/metrics").text
+        for leaked in ("trigger_comment", "@askserge", "alice"):
+            self.assertNotIn(leaked, body)
+
+    def test_a_broken_store_answers_instead_of_failing_the_scrape(self) -> None:
+        with patch.object(
+            self.webapp._store, "list_sessions", side_effect=RuntimeError("db gone")
+        ):
+            r = self.client.get("/metrics")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("serge_job_retention 25", r.text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -573,6 +573,25 @@ class WebappTasksTests(unittest.TestCase):
         self.assertEqual(job.session["stop_reason"], "repeat_guard")
         self.assertEqual(job.session["turns"], 27)
 
+    def test_the_persisted_session_freezes_the_outcome(self):
+        """The exported status label must not move after the session ended."""
+        webapp = self._import_webapp()
+        result = webapp.TaskResult(
+            mode="new_pr", pr_number=7, no_change=False, session={"turns": 3}
+        )
+        job = self._run_task_worker_with(webapp, result, persist=True)
+        row = webapp._store.load(job.id)
+        assert row is not None
+        self.assertEqual(row["session"]["outcome"], "published")
+        # _persist_terminal runs again when a human publishes a draft; the
+        # outcome recorded at the end of the session must not follow.
+        job.status = "discarded"
+        webapp._persist_terminal(job)
+        row = webapp._store.load(job.id)
+        assert row is not None
+        self.assertEqual(row["status"], "discarded")
+        self.assertEqual(row["session"]["outcome"], "published")
+
     def test_a_job_that_never_ran_the_loop_persists_a_zeroed_session(self):
         """Reproduce-first classifying a group ENVIRONMENT costs 0 LLM turns.
         Recording nothing would make it indistinguishable from a job that was

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -573,6 +573,25 @@ class WebappTasksTests(unittest.TestCase):
         self.assertEqual(job.session["stop_reason"], "repeat_guard")
         self.assertEqual(job.session["turns"], 27)
 
+    def test_unparseable_task_output_keeps_the_session(self):
+        """Three of ten tasks in the measured window ended here — the sessions
+        whose counters matter most."""
+        webapp = self._import_webapp()
+        exc = webapp._UnparseableLLMOutput(
+            content="not json",
+            finish_reason=None,
+            metrics_line="",
+            session={"turns": 76, "stop_reason": "input_token_cap", "rounds": 1},
+        )
+
+        def _raise(*a, **k):
+            raise exc
+
+        job = self._run_task_worker_with(webapp, None, side_effect=_raise)
+        self.assertEqual(job.status, "error")
+        self.assertEqual(job.session["stop_reason"], "input_token_cap")
+        self.assertEqual(job.session["turns"], 76)
+
     def test_the_persisted_session_freezes_the_outcome(self):
         """The exported status label must not move after the session ended."""
         webapp = self._import_webapp()
@@ -1105,6 +1124,74 @@ class TaskLauncherTests(unittest.TestCase):
         self.assertEqual(job.draft.summary, "looks fine")
         self.assertEqual(job.draft.prompt_tokens, 100)
         self.assertEqual(job.draft.completion_tokens, 25)
+
+    def test_review_callback_lands_the_session_on_the_job(self):
+        """The pod ships the session beside the draft (decode_draft does not carry
+        carrier fields). Persisting a review without it would record `no_llm_turns`
+        for a job that ran the loop — prod runs reviews in pods, so this is the
+        only route."""
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        job = self._review_job(webapp)
+        draft = webapp.decode_draft(
+            '{"owner":"acme","repo":"widgets","number":7,"head_sha":"abc",'
+            '"summary":"looks fine","event":"COMMENT","comments":[]}'
+        )
+        from reviewbot.store import encode_draft
+
+        session = {"turns": 12, "stop_reason": "repeat_guard", "rounds": 1}
+        with (
+            patch.object(webapp, "_persist_terminal"),
+            patch.object(webapp, "_notify_task_finished"),
+        ):
+            r = TestClient(webapp.app).post(
+                f"/internal/tasks/{job.id}/events",
+                json={
+                    "terminal": {
+                        "status": "done",
+                        "result": {
+                            "draft": encode_draft(draft),
+                            "prompt_tokens": 100,
+                            "completion_tokens": 25,
+                            "session": session,
+                        },
+                    }
+                },
+                headers={"Authorization": "Bearer cbtok"},
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(job.session, session)
+        self.assertEqual(job.draft.session, session)
+
+    def test_an_errored_runner_reports_its_session_beside_the_error(self):
+        """A failed pod has no `result` to hang counters off."""
+        if TestClient is None:
+            self.skipTest("fastapi not installed")
+        webapp = self._import_webapp()
+        job = self._review_job(webapp)
+        with (
+            patch.object(webapp, "_persist_terminal"),
+            patch.object(webapp, "_notify_task_finished"),
+        ):
+            r = TestClient(webapp.app).post(
+                f"/internal/tasks/{job.id}/events",
+                json={
+                    "terminal": {
+                        "status": "error",
+                        "error": "the model returned an unparseable review",
+                        "session": {
+                            "turns": 31,
+                            "stop_reason": "input_token_cap",
+                            "rounds": 1,
+                        },
+                    }
+                },
+                headers={"Authorization": "Bearer cbtok"},
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(job.session["stop_reason"], "input_token_cap")
+        self.assertEqual(job.session["turns"], 31)
 
     def _webhook_review_job(self, webapp):
         job = self._review_job(webapp)

--- a/tests/test_webapp_tasks.py
+++ b/tests/test_webapp_tasks.py
@@ -4,6 +4,7 @@ verification and the task worker are stubbed so no network/LLM is touched —
 we assert the route's accept/reject behavior and that an accepted task is
 queued."""
 
+import contextlib
 import importlib
 import os
 import shutil
@@ -450,7 +451,9 @@ class WebappTasksTests(unittest.TestCase):
         self.assertEqual(notify.call_args.kwargs["channel"], "#dynamic-ci")
         self.assertEqual(notify.call_args.kwargs["pr_number"], 99)
 
-    def _run_task_worker_with(self, webapp, task_result):
+    def _run_task_worker_with(
+        self, webapp, task_result, *, side_effect=None, persist=False
+    ):
         """Drive _run_task_worker with the heavy deps stubbed so the only thing
         under test is how a TaskResult maps to the terminal job.status."""
         worker_cfg = webapp.dataclasses.replace(
@@ -480,6 +483,32 @@ class WebappTasksTests(unittest.TestCase):
         )
         # The per-candidate prepare+publish (incl. any GPU verify retry loop) is
         # stubbed to return the given result, so we only assert status mapping.
+        candidate = (
+            {"side_effect": side_effect}
+            if side_effect is not None
+            else {"return_value": task_result}
+        )
+        persist_ctx = (
+            contextlib.nullcontext()
+            if persist
+            else patch.object(webapp, "_persist_terminal")
+        )
+        if persist:
+            webapp._store.insert_job(
+                id=job.id,
+                user=job.user,
+                target_owner=job.target_owner,
+                target_repo=job.target_repo,
+                target_number=job.target_number,
+                trigger_comment=job.trigger_comment,
+                llm_provider=job.llm_provider,
+                llm_api_base=job.llm_api_base,
+                llm_model=job.llm_model,
+                created_at=job.created_at,
+                status="running",
+                source="task",
+                kind="task",
+            )
         with (
             patch.object(webapp, "installation_id_for_repo", return_value=1),
             patch.object(webapp, "installation_token", return_value="tok"),
@@ -490,10 +519,8 @@ class WebappTasksTests(unittest.TestCase):
                 return_value=types.SimpleNamespace(path="/tmp/co"),
             ),
             patch.object(webapp._clone_cache, "release"),
-            patch.object(webapp, "_persist_terminal"),
-            patch.object(
-                webapp, "prepare_and_publish_candidate", return_value=task_result
-            ),
+            persist_ctx,
+            patch.object(webapp, "prepare_and_publish_candidate", **candidate),
         ):
             webapp._run_task_worker(job, worker_cfg, req)
         return job
@@ -509,6 +536,55 @@ class WebappTasksTests(unittest.TestCase):
         result = webapp.TaskResult(mode="new_pr", no_change=True)
         job = self._run_task_worker_with(webapp, result)
         self.assertEqual(job.status, "no_fix")
+
+    def test_the_candidate_session_lands_on_the_job(self):
+        """A no_fix outcome reads completely differently depending on whether
+        the model concluded there was no fix or a guard cut it off mid-hunt, so
+        the counters have to reach the job, not just the run log."""
+        webapp = self._import_webapp()
+        session = {
+            "turns": 46,
+            "tool_calls": 48,
+            "prompt_tokens": 2_111_885,
+            "stop_reason": "input_token_cap",
+            "path_revisits": 137,
+            "rounds": 1,
+        }
+        result = webapp.TaskResult(mode="new_pr", no_change=True, session=session)
+        job = self._run_task_worker_with(webapp, result)
+        self.assertEqual(job.session["stop_reason"], "input_token_cap")
+        self.assertEqual(job.session["path_revisits"], 137)
+        # It also travels in the result, which is how a runner pod reports it.
+        self.assertEqual(job.task_result["session"], session)
+
+    def test_a_failed_candidate_still_reports_what_it_spent(self):
+        """ "Patch did not apply" is a terminated session too — its budget is
+        already gone, so losing its counters loses the expensive cases."""
+        webapp = self._import_webapp()
+        error = webapp.TaskError("patch did not apply", status_code=422)
+        error.session = {"turns": 27, "stop_reason": "repeat_guard", "rounds": 1}
+        webapp_module = webapp
+
+        def _raise(*args, **kwargs):
+            raise error
+
+        job = self._run_task_worker_with(webapp_module, None, side_effect=_raise)
+        self.assertEqual(job.status, "error")
+        self.assertEqual(job.session["stop_reason"], "repeat_guard")
+        self.assertEqual(job.session["turns"], 27)
+
+    def test_a_job_that_never_ran_the_loop_persists_a_zeroed_session(self):
+        """Reproduce-first classifying a group ENVIRONMENT costs 0 LLM turns.
+        Recording nothing would make it indistinguishable from a job that was
+        never dispatched."""
+        webapp = self._import_webapp()
+        result = webapp.TaskResult(mode="new_pr", no_change=True)
+        job = self._run_task_worker_with(webapp, result, persist=True)
+        row = webapp._store.load(job.id)
+        self.assertIsNotNone(row)
+        assert row is not None
+        self.assertEqual(row["session"]["stop_reason"], "no_llm_turns")
+        self.assertEqual(row["session"]["rounds"], 0)
 
 
 class TaskLauncherTests(unittest.TestCase):


### PR DESCRIPTION
## Why

`WEB_JOB_RETENTION` is 25 jobs — about two days of traffic. Everything about how a task session actually went lived only in that job row and in log lines attached to it, so **no change to the agent loop could be shown to have helped**: the evidence for it was deleted before it shipped.

The finding that motivated this is one nobody could have queried for. In the last prod window still readable, ten `task` jobs ran; three were classified ENVIRONMENT for 0 LLM turns, and **all seven that ran LLM turns were terminated by a guard — none by the model deciding it was done.** The only PR that window produced was written by a model that had just been told its budget was gone and it must answer with no tools.

Design notes: `docs/plans/serge-itf-quick-wins-2026-08-26.md` item 8 in `transformers-ci-playbooks`.

## What a session now records

`turns`, `tool_calls`, input/output tokens, LLM seconds, validation and truncation retries, `rounds`, and **`stop_reason`**:

| `stop_reason` | meaning |
| --- | --- |
| `answered` | the model decided it was done — **the only value that means this** |
| `input_token_cap` | `LLM_MAX_INPUT_TOKENS` reached; the answer came from a tool-less final turn |
| `repeat_guard` | `TOOL_REPEAT_LIMIT` tripped |
| `blind_turn_cap` / `strict_tool_cap` / `absolute_ceiling` | a `TOOL_MAX_ITERATIONS` bound |
| `chunk_input_token_cap` | a chunked review skipped chunks it could not afford |
| `no_llm_turns` | the job finished or failed without ever running the loop |

`no_llm_turns` is deliberate: reproduce-first calling a group ENVIRONMENT costs 0 turns, and recording nothing there would make it indistinguishable from a job that was never dispatched.

Multi-round jobs fold into one record — one loop per candidate group, plus one per GPU verify retry — with a `rounds` count. The counters also ride out of a `TaskError` on publish: *"patch did not apply"* is a terminated session whose budget is already spent, and those are the expensive ones to lose.

## Two browse numbers, not one

`ToolRepeatGuard` keys on `name + exact arguments`, so fifty-three reads of *different line ranges* of one file are fifty-three distinct signatures and it counts **zero** repeats. That is the shape that dominates in practice — in one measured job, 137 of 153 tool calls re-opened a path already read, `modular_blt.py` 53 times.

So the guard now also counts visits per opened path (`read_file` and `list_dir`; a `grep` of the same path with a new pattern is a real search, not a re-read) and reports `distinct_paths` and `path_revisits` alongside `repeats`. Behaviour is unchanged — this commit only counts. The nudge that uses it is item 2 of the plan, separately.

## How the session gets home

Prod runs both reviews and tasks in per-job pods (`reviewPods: true`), so the in-process path is not the one that matters. Each execution route carries the record explicitly:

| path | success | failure |
| --- | --- | --- |
| in-process review / task | `draft.session` / `TaskResult.session` | `exc.session` off `_UnparseableLLMOutput` and `TaskError` |
| runner pod | beside the draft in the terminal `result` — the draft payload carries no carrier fields, same reason `prompt_tokens` travels beside it | a top-level `session` on the terminal callback, which has no `result` to hang it off |

Getting this wrong is not a gap in the data, it is a wrong value: a job with no record persists `no_llm_session_record()`, whose `stop_reason` is `no_llm_turns` — the value that specifically means reproduce-first skipped the group without ever calling the LLM. The serving side therefore refuses to blank a record it already has when a runner omits the key, so an older runner image degrades to *missing* rather than *false*.

## `GET /metrics`

Prometheus text exposition, unauthenticated like `/healthz` — scraped in-cluster over the pod port, carrying no review content. Deliberately a **rolling window** over the retained jobs: Prometheus is the durable side, so a pruned job's series goes stale while its samples stay queryable. Identity lives on a `serge_job_info` series and the values are keyed by `job_id` alone, and every label on it is immutable for the life of a job — `status` is the outcome frozen when the loop ended, not the row's live status, so a review a human later publishes does not fork into a second series.

The same record is returned on `GET /tasks/{owner}/{repo}/{id}/status`, so a dispatcher can report *why* a group came back `no_fix` — a guard cutting the hunt off reads very differently from the model concluding there was no fix.

## Testing

749 pass, ruff clean. New coverage for each loop exit, the merge arithmetic (including `rounds: 0` — a real measurement — not collapsing into the "not recorded" default), store round-tripping (including an old DB gaining the column and a malformed record not breaking a scrape), the endpoint, and each of the four routes in the table above. The exposition is checked against **Prometheus' own parser** — substring assertions cannot catch a body the scraper rejects outright, and a rejected scrape is invisible from this side. `prometheus_client` added to the CI install for that one test.

## Review round

Three findings from the agent review, all real and **none covered by a test** — the suite passed before and after each fix. Every fix now ships with a check I verified fails without it, by reverting the fix and re-running. Details in the [reply](https://github.com/huggingface/serge/pull/99#issuecomment-5453075283); the substantive one was that `review_runner` never sent the session at all, which on `reviewPods: true` would have recorded `no_llm_turns` for every review that ran a full loop.

## Shipping

Land this before the scrape that reads it, huggingface/transformers-ci#97 — that target 404s until this image is live, and nothing alerts on it meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

