### PR TITLE
Count the file it keeps re-opening, not just the call it repeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The tool-repeat guard is now **path-aware**. It keyed on the exact arguments,
+  so fifty-three reads of one file at a different line range each time were
+  fifty-three distinct signatures and it counted zero repeats — while that is
+  the shape that dominates in practice (prod task `9d210794`: 137 of 153 calls
+  re-opened a path it had already opened). A second counter tracks visits per
+  opened path, with its own allowance (`TOOL_PATH_REVISIT_LIMIT`, default 3) and
+  its own cut-off (`TOOL_PATH_TRIP_AFTER`, default 40). The correction names the
+  file and the ranges already served — *"you have already read `modular_blt.py`
+  6 times in this session (lines 1-200, 180-420, 400-650)"* — rather than only
+  saying stop, because the first is something a model can act on. Still not a
+  cache: every call executes for real, since a re-read after a patch must return
+  the new content. A session cut off this way reports `stop_reason
+  =path_revisit_guard`, distinct from `repeat_guard`.
+
 - Per-job agent-loop metrics, exported for Prometheus at `GET /metrics`
   (unauthenticated, like `/healthz`; scraped in-cluster over the pod port).
   Every finished job now records how many turns and tool calls it ran, what it

--- a/aws/reviewbot-web.env.example
+++ b/aws/reviewbot-web.env.example
@@ -94,6 +94,14 @@ LOG_LEVEL=INFO
 # reasoning or content). Productive turns are free. Default 30; set
 # higher for very tool-heavy reviews, or to 0 to disable the cap.
 # TOOL_MAX_ITERATIONS=30
+# Byte-identical tool calls tolerated before the loop is cut off.
+# TOOL_REPEAT_LIMIT=6
+# Visits to one path before the model is told what it already has. The
+# exact-argument counter above cannot see a re-read at a new line range,
+# which is the shape that dominates in practice.
+# TOOL_PATH_REVISIT_LIMIT=3
+# Total path re-opens before the loop is cut off. 0 nudges without cutting off.
+# TOOL_PATH_TRIP_AFTER=40
 # Path to the SQLite file used to persist review jobs (metadata, draft,
 # event history). Default is relative to the service WorkingDirectory
 # (/opt/app/jobs.db on the deploy host); switch to /var/lib/reviewbot/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,9 @@ package is missing or a compression call fails, so a review never breaks on it.
 | `HELPER_TOOLS_PATH` | `helper_tools_path` | `.ai/review-tools.json` | Optional helper tool config. |
 | `REPO_CHECKOUT_PATH` | `repo_checkout_path` | Action: `github.workspace`; env: empty | Local checkout root for read-only tools. Empty disables tools. |
 | `TOOL_MAX_ITERATIONS` | `tool_max_iterations` | env default `30`, Action default `8` | Maximum tool-calling rounds. Set `0` to disable the cap. |
+| `TOOL_REPEAT_LIMIT` | `tool_repeat_limit` | `6` | Byte-identical tool calls tolerated before the loop is cut off. Each repeat is told it is repeating. `0` disables. |
+| `TOOL_PATH_REVISIT_LIMIT` | `tool_path_revisit_limit` | `3` | Visits to one file/directory before every further visit is told what it already has. Catches the re-read-at-a-different-line-range shape `TOOL_REPEAT_LIMIT` cannot see. `0` disables the nudge. |
+| `TOOL_PATH_TRIP_AFTER` | `tool_path_trip_after` | `40` | Total re-opens across all paths before the loop is cut off. Set well above a healthy session. `0` keeps the nudges but never cuts off. |
 
 ## GitHub App
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -110,13 +110,16 @@ retries, and two numbers about how the budget was spent browsing:
 | `serge_job_repeat_calls` | Tool calls that re-ran an *earlier call verbatim* — what `TOOL_REPEAT_LIMIT` counts. |
 | `serge_job_path_revisits` | Calls that re-opened a *path already opened*, counted per path as visits−1. A second `read_file` of the same file at a different line range is a revisit but not a verbatim repeat, and that is the shape that dominates in practice. |
 
+Both have a nudge attached (`TOOL_REPEAT_LIMIT` / `TOOL_PATH_REVISIT_LIMIT`) and a separate cut-off budget (`TOOL_REPEAT_LIMIT` / `TOOL_PATH_TRIP_AFTER`), because they are different failures: one model is stuck on a single call, the other is browsing in circles.
+
 The label that matters most is `stop_reason` on `serge_job_info`:
 
 | `stop_reason` | The session ended because… |
 | ------------- | -------------------------- |
 | `answered` | the model decided it was done — the only value that means this |
 | `input_token_cap` | `LLM_MAX_INPUT_TOKENS` was reached; the answer came from a tool-less final turn |
-| `repeat_guard` | `TOOL_REPEAT_LIMIT` tripped |
+| `repeat_guard` | `TOOL_REPEAT_LIMIT` tripped — the model kept re-issuing one call verbatim |
+| `path_revisit_guard` | `TOOL_PATH_TRIP_AFTER` tripped — the model kept re-opening files it had already opened |
 | `blind_turn_cap` / `strict_tool_cap` / `absolute_ceiling` | a `TOOL_MAX_ITERATIONS` bound was reached |
 | `chunk_input_token_cap` | a chunked review skipped chunks it could not afford |
 | `no_llm_turns` | the job finished (or failed) without ever running the loop — e.g. reproduce-first classified the group ENVIRONMENT |

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -94,6 +94,19 @@ class Config:
     # it is repeating; past this many the loop stops rather than spending the
     # rest of the input-token budget re-running the same search. 0 disables.
     tool_repeat_limit: int = 6
+    # The same problem measured a second way. The counter above keys on the
+    # exact arguments, so re-reading one file at a different line range each
+    # time is invisible to it — and that is the shape that dominates (prod task
+    # 9d210794: 137 of 153 calls re-opened an already-opened path). Past this
+    # many visits to one path, every further visit is told what it already has.
+    # Higher than tool_repeat_limit on purpose: re-opening a file at a genuinely
+    # new range is normal investigation. 0 disables the nudge.
+    tool_path_revisit_limit: int = 3
+    # Total re-opens across all paths before the loop is cut off and the budget
+    # spent on an answer. Set well above any healthy session (the worst measured
+    # spent 137 calls this way; the one that produced a PR about 10). 0 keeps
+    # the nudges but never cuts the loop off.
+    tool_path_trip_after: int = 40
     # Commit only the files the patch is responsible for, dropping files the
     # normalizer regenerated because the *base* was stale (see commit_scope).
     # Validation still runs repo-wide; this only bounds the commit.
@@ -493,6 +506,8 @@ class Config:
             tool_max_iterations=_int_env("TOOL_MAX_ITERATIONS", 30),
             llm_max_input_tokens=_int_env("LLM_MAX_INPUT_TOKENS", 2_000_000),
             tool_repeat_limit=_int_env("TOOL_REPEAT_LIMIT", 6),
+            tool_path_revisit_limit=_int_env("TOOL_PATH_REVISIT_LIMIT", 3),
+            tool_path_trip_after=_int_env("TOOL_PATH_TRIP_AFTER", 40),
             task_scope_commit_to_patch=_bool_env("TASK_SCOPE_COMMIT_TO_PATCH", True),
             task_commit_always_include=[
                 p.strip()

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -491,6 +491,10 @@ class _AggregateMetrics:
 STOP_ANSWERED = "answered"
 STOP_INPUT_TOKEN_CAP = "input_token_cap"
 STOP_REPEAT_GUARD = "repeat_guard"
+# The path counter tripping, not the exact-argument one. Reported separately
+# because they mean different things: `repeat_guard` is a model stuck re-issuing
+# one call, `path_revisit_guard` is a model browsing the same files in circles.
+STOP_PATH_REVISIT_GUARD = "path_revisit_guard"
 STOP_BLIND_TURN_CAP = "blind_turn_cap"
 STOP_STRICT_TOOL_CAP = "strict_tool_cap"
 STOP_ABSOLUTE_CEILING = "absolute_ceiling"
@@ -1005,7 +1009,11 @@ def _run_agentic_loop(
     # Stops a model that has started re-issuing the *same* tool call from eating
     # the whole input-token budget on it. Each repeat is told it is repeating;
     # past the limit we break out and spend what's left on an answer.
-    repeat_guard = ToolRepeatGuard(getattr(cfg, "tool_repeat_limit", 0) or 0)
+    repeat_guard = ToolRepeatGuard(
+        getattr(cfg, "tool_repeat_limit", 0) or 0,
+        path_revisit_limit=getattr(cfg, "tool_path_revisit_limit", 0) or 0,
+        path_trip_after=getattr(cfg, "tool_path_trip_after", 0) or 0,
+    )
     iteration = 0
     blind_tool_turns = 0
     validation_retries = 0
@@ -1199,10 +1207,11 @@ def _run_agentic_loop(
             if repeat_note is not None:
                 result = f"{result}{repeat_note}"
                 log.info(
-                    "Repeated tool call %s (%s); %s",
+                    "Corrected tool call %s (%s); %s | %s",
                     tc.name,
                     _summarize_args_str(tc.arguments),
                     repeat_guard.summary(),
+                    repeat_guard.path_summary(),
                 )
             # Kimi-K2 (and some other engines) require ``name`` on tool
             # replies; OpenAI's spec ignores it. Always sending it is
@@ -1219,18 +1228,21 @@ def _run_agentic_loop(
 
         if repeat_guard.tripped:
             log.warning(
-                "Tool-repeat guard tripped (%s, limit=%d); asking for a final "
+                "Tool-repeat guard tripped (%s); asking for a final "
                 "answer instead of spending the rest of the budget looping",
-                repeat_guard.summary(),
-                repeat_guard.trip_after,
+                repeat_guard.trip_summary(),
             )
             if emit is not None:
                 emit(
                     "log",
-                    f"Stuck in a tool-call loop ({repeat_guard.summary()}); "
+                    f"Stuck in a tool-call loop ({repeat_guard.trip_summary()}); "
                     "asking for a final answer without tools",
                 )
-            metrics.stop_reason = STOP_REPEAT_GUARD
+            metrics.stop_reason = (
+                STOP_REPEAT_GUARD
+                if repeat_guard._repeats_tripped
+                else STOP_PATH_REVISIT_GUARD
+            )
             break
 
     # Iteration budget hit — force a final answer with tools disabled.

--- a/reviewbot/tool_repeat.py
+++ b/reviewbot/tool_repeat.py
@@ -17,9 +17,20 @@ the cure is not to memoize the tool — it is to tell the model it is looping an
 if it keeps going, to stop the loop early and spend the remaining budget on an
 answer instead of on the 50th identical grep.
 
-Deliberately **not** a cache. A repeated ``read_file`` after an ``apply_patch``
-must return the *new* content, so every call still executes for real; the guard
-only appends a correction to the result and counts how often it has had to.
+There is a second shape the exact-match counter cannot see, and it is the one
+that dominates. Measured on prod task 9d210794 (blt): 153 tool calls, of which
+**137 were repeat visits to a path it had already opened** — ``modular_blt.py``
+53 times, at a different line range each time. Every one of those is a distinct
+signature, so the counter above stays at zero while the budget drains. So the
+guard counts a second thing: visits per opened *path*, with its own thresholds,
+and a nudge that names the file and the ranges already served rather than just
+saying stop. A model that is told "you already have lines 1-200, 180-420 and
+400-650 of this file" can act on that; "you are repeating" it cannot.
+
+Deliberately **not** a cache, in either direction. A repeated ``read_file``
+after an ``apply_patch`` must return the *new* content, so every call still
+executes for real; the guard only appends a correction to the result and counts
+how often it has had to.
 """
 
 from __future__ import annotations
@@ -42,6 +53,43 @@ _TRIPPED_NOTE = (
     "\n\n[serge] This is repeat #{repeats}. You are in a loop. Give your final "
     "answer from what you already know — no further tool calls will be answered."
 )
+
+
+# Appended when a call re-opens a path already opened in this session. Unlike
+# the exact-repeat nudge this one is *actionable*: it names the file and what
+# was already served, so the model can decide it has the bytes rather than
+# guess. Ranges are listed because "you read this file 12 times" invites a 13th
+# read of a part it has not seen — "you have lines 1-200, 180-420" does not.
+_PATH_NUDGE = (
+    "\n\n[serge] You have already {verb} `{path}` {count} times in this session "
+    "({ranges}). {advice} If you need a part you have not seen yet, ask for those "
+    "line numbers specifically; otherwise work from what you already have."
+)
+
+_PATH_TRIPPED_NOTE = (
+    "\n\n[serge] {revisits} of your tool calls have now re-opened a path you had "
+    "already opened. You are not learning anything new by browsing. Give your "
+    "final answer from what you have — no further tool calls will be answered."
+)
+
+# How many ranges to name before eliding. Enough to show the overlap, short
+# enough that the nudge stays cheap on every repeat.
+_MAX_LISTED_RANGES = 4
+
+
+def _range_label(parsed: dict) -> str:
+    """Human-readable span for one ``read_file`` call, e.g. ``lines 400-650``."""
+    start = parsed.get("start_line")
+    end = parsed.get("end_line")
+    start = start if isinstance(start, int) else None
+    end = end if isinstance(end, int) else None
+    if start is None and end is None:
+        return "the whole file"
+    if start is not None and end is not None:
+        return f"lines {start}-{end}"
+    if start is not None:
+        return f"from line {start}"
+    return f"up to line {end}"
 
 
 def normalize_arguments(arguments: str) -> str:
@@ -70,12 +118,13 @@ def normalize_arguments(arguments: str) -> str:
 _PATH_TOOLS = frozenset({"read_file", "list_dir"})
 
 
-def path_argument(name: str, arguments: str) -> str | None:
-    """The path a call opened, or ``None`` when the tool does not open one.
+def path_visit(name: str, arguments: str) -> tuple[str, str] | None:
+    """The ``(path, range_label)`` a call opened, or ``None`` for a tool that
+    opens nothing.
 
-    Normalized only enough to make two spellings of the same file compare equal
-    (``./x.py`` and ``x.py``); no filesystem access, so it stays usable in the
-    metrics path where the checkout may already be gone."""
+    The path is normalized only enough to make two spellings of the same file
+    compare equal (``./x.py`` and ``x.py``); no filesystem access, so this stays
+    usable in the metrics path where the checkout may already be gone."""
     if name not in _PATH_TOOLS:
         return None
     try:
@@ -88,11 +137,22 @@ def path_argument(name: str, arguments: str) -> str | None:
     if not isinstance(raw, str):
         # list_dir's path is optional and defaults to the repo root; a missing
         # path is still a visit to a real location, so name it.
-        return "." if name == "list_dir" else None
+        if name != "list_dir":
+            return None
+        return ".", "the directory"
     path = raw.strip().lstrip("/")
     while path.startswith("./"):
         path = path[2:]
-    return path.rstrip("/") or "."
+    path = path.rstrip("/") or "."
+    label = "the directory" if name == "list_dir" else _range_label(parsed)
+    return path, label
+
+
+def path_argument(name: str, arguments: str) -> str | None:
+    """Just the path :func:`path_visit` would report. Kept for callers that do
+    not care which part of the file was asked for."""
+    visit = path_visit(name, arguments)
+    return None if visit is None else visit[0]
 
 
 class ToolRepeatGuard:
@@ -108,14 +168,32 @@ class ToolRepeatGuard:
     enough to stop that would misfire on legitimate re-reads.
     """
 
-    def __init__(self, trip_after: int = 6):
+    def __init__(
+        self,
+        trip_after: int = 6,
+        *,
+        path_revisit_limit: int = 3,
+        path_trip_after: int = 40,
+    ):
         self.trip_after = trip_after
+        # Visits to one path tolerated before every further visit is nudged.
+        # Higher than the exact-repeat allowance on purpose: re-opening a file
+        # at a genuinely new range is normal investigation, and the healthy
+        # sessions in the measured window did it a handful of times each.
+        self.path_revisit_limit = path_revisit_limit
+        # Total re-opens across all paths before the loop is cut off. Set well
+        # above any healthy session (the worst measured one spent 137 calls
+        # this way, the one that produced a PR about 10) so this only catches
+        # the pathological shape. 0 disables the cut-off, leaving the nudges.
+        self.path_trip_after = path_trip_after
         self.counts: dict[str, int] = {}
         self.repeats = 0
         # Visits per opened path, counted whether or not the guard is enabled:
         # this is the session's observability record (see :meth:`stats`), and it
         # has to be there even for a deployment that turned the nudge off.
         self.path_visits: dict[str, int] = {}
+        # Range labels already served per path, in order, for the nudge text.
+        self.path_ranges: dict[str, list[str]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -123,7 +201,21 @@ class ToolRepeatGuard:
 
     @property
     def tripped(self) -> bool:
+        """True when the loop should stop and spend what is left on an answer.
+
+        Either counter can trip it: byte-identical repeats, or sheer volume of
+        re-opening paths already read. They are separate budgets because they
+        are separate failure modes — the first is a model stuck on one call, the
+        second is a model browsing in circles without noticing."""
+        return self._repeats_tripped or self._paths_tripped
+
+    @property
+    def _repeats_tripped(self) -> bool:
         return self.enabled and self.repeats >= self.trip_after
+
+    @property
+    def _paths_tripped(self) -> bool:
+        return self.path_trip_after > 0 and self.path_revisits >= self.path_trip_after
 
     def observe(self, name: str, arguments: str) -> str | None:
         """Record one tool call. Returns text to append to its result when the
@@ -131,22 +223,83 @@ class ToolRepeatGuard:
 
         The first occurrence of a call is always free — legitimate investigation
         re-lists directories and re-reads files. Only an *exact* re-run of a call
-        already made in this session is treated as a repeat."""
-        path = path_argument(name, arguments)
-        if path is not None:
-            self.path_visits[path] = self.path_visits.get(path, 0) + 1
+        already made in this session is treated as a repeat.
+
+        A call that re-opens a path already opened gets the path nudge instead —
+        it is the more useful correction, and the two would otherwise stack on
+        the same result."""
+        path_note = self._observe_path(name, arguments)
         if not self.enabled:
-            return None
+            return path_note
         signature = f"{name}\x00{normalize_arguments(arguments)}"
         count = self.counts.get(signature, 0) + 1
         self.counts[signature] = count
         if count == 1:
-            return None
+            return path_note
         self.repeats += 1
         note = _NUDGE.format(name=name, count=count)
-        if self.tripped:
+        if self._repeats_tripped:
             note += _TRIPPED_NOTE.format(repeats=self.repeats)
         return note
+
+    def _observe_path(self, name: str, arguments: str) -> str | None:
+        """Record one path visit; return the nudge when it is a re-open past the
+        allowance. Counting happens whether or not the exact-repeat guard is
+        enabled — the session's browse record must not depend on that setting."""
+        visit = path_visit(name, arguments)
+        if visit is None:
+            return None
+        path, label = visit
+        count = self.path_visits.get(path, 0) + 1
+        self.path_visits[path] = count
+        self.path_ranges.setdefault(path, []).append(label)
+        if self.path_revisit_limit <= 0 or count <= self.path_revisit_limit:
+            return None
+        note = _PATH_NUDGE.format(
+            verb="listed" if name == "list_dir" else "read",
+            path=path,
+            count=count,
+            ranges=self._describe_ranges(path),
+            advice=(
+                "Listing a directory you have not changed cannot tell you anything new."
+                if name == "list_dir"
+                else "Re-reading a file you have not modified cannot tell you "
+                "anything new."
+            ),
+        )
+        if self._paths_tripped:
+            note += _PATH_TRIPPED_NOTE.format(revisits=self.path_revisits)
+        return note
+
+    def _describe_ranges(self, path: str) -> str:
+        """The spans already served for ``path``, deduplicated and elided."""
+        seen: list[str] = []
+        for label in self.path_ranges.get(path, [])[:-1]:  # exclude this call
+            if label not in seen:
+                seen.append(label)
+        if not seen:
+            return "the same range each time"
+        shown = ", ".join(seen[:_MAX_LISTED_RANGES])
+        return shown + (", …" if len(seen) > _MAX_LISTED_RANGES else "")
+
+    def path_summary(self) -> str:
+        """One-line description of the re-opened paths, for the run log."""
+        worst = ", ".join(f"{path}×{n}" for path, n in self.worst_paths())
+        return f"{self.path_revisits} re-open(s) of an already-opened path" + (
+            f" (most re-opened: {worst})" if worst else ""
+        )
+
+    def trip_summary(self) -> str:
+        """Why the loop is being cut off, naming the counter that did it.
+
+        The two are separate budgets, so reporting the wrong one is actively
+        confusing: a path trip described as "0 repeated tool call(s)" reads like
+        a bug in the guard rather than a model browsing in circles."""
+        if self._repeats_tripped and self._paths_tripped:
+            return f"{self.summary()}; {self.path_summary()}"
+        if self._paths_tripped:
+            return self.path_summary()
+        return self.summary()
 
     def summary(self) -> str:
         """One-line description of the worst offenders, for the run log."""

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -29,6 +29,7 @@ from reviewbot.reviewer import (
     STOP_BLIND_TURN_CAP,
     STOP_INPUT_TOKEN_CAP,
     STOP_NO_LLM_TURNS,
+    STOP_PATH_REVISIT_GUARD,
     STOP_REPEAT_GUARD,
     merge_session_records,
     no_llm_session_record,
@@ -518,12 +519,16 @@ class _CfgStub:
         llm_max_input_tokens: int = 0,
         llm_reasoning_effort: str | None = None,
         tool_repeat_limit: int = 0,
+        tool_path_revisit_limit: int = 0,
+        tool_path_trip_after: int = 0,
     ) -> None:
         self.llm_max_tokens = llm_max_tokens
         self.tool_max_iterations = tool_max_iterations
         self.llm_max_input_tokens = llm_max_input_tokens
         self.llm_reasoning_effort = llm_reasoning_effort
         self.tool_repeat_limit = tool_repeat_limit
+        self.tool_path_revisit_limit = tool_path_revisit_limit
+        self.tool_path_trip_after = tool_path_trip_after
 
 
 class _FakeLLM:
@@ -1214,3 +1219,166 @@ class SessionRecordTests(unittest.TestCase):
         self.assertEqual(record["rounds"], 0)
         self.assertEqual(record["turns"], 0)
         self.assertEqual(record["stop_reason"], STOP_NO_LLM_TURNS)
+
+
+class PathRevisitLoopTests(unittest.TestCase):
+    """The path counter has to end the loop, not just annotate results.
+
+    Task 9d210794 spent 137 of its 153 calls re-opening files it had already
+    opened, at a different line range each time, and the exact-argument guard
+    counted zero repeats the whole way down."""
+
+    def _reading_llm(self, reads: int) -> _FakeLLM:
+        turns = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 40_000, "completion_tokens": 20},
+                tool_calls=[
+                    ToolCall(
+                        id=f"t{i}",
+                        name="read_file",
+                        arguments='{"path": "modular_blt.py", "start_line": %d}'
+                        % (i * 10),
+                    )
+                ],
+            )
+            for i in range(reads)
+        ]
+        final = ChatResult(
+            content='{"summary": "stuck", "comments": []}',
+            usage={"prompt_tokens": 40_000, "completion_tokens": 20},
+        )
+        return _FakeLLM(turns + [final])
+
+    def test_re_reads_cut_the_loop_off_and_say_which_guard_did_it(self) -> None:
+        cfg = _CfgStub(
+            tool_max_iterations=0,
+            tool_repeat_limit=6,
+            tool_path_revisit_limit=2,
+            tool_path_trip_after=4,
+        )
+        llm = self._reading_llm(5)
+        chat, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "fix this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_PATH_REVISIT_GUARD)
+        # Not the exact-argument guard: every read used a different range.
+        self.assertEqual(metrics.repeats, 0)
+        self.assertGreater(metrics.path_revisits, 0)
+        self.assertEqual(chat.content, '{"summary": "stuck", "comments": []}')
+        self.assertLess(len(llm.calls), 12)
+        self.assertNotIn("tools", llm.calls[-1])
+
+    def test_the_model_is_told_what_it_already_has(self) -> None:
+        cfg = _CfgStub(
+            tool_max_iterations=0,
+            tool_repeat_limit=6,
+            tool_path_revisit_limit=2,
+            tool_path_trip_after=0,
+        )
+        llm = self._reading_llm(6)
+        _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "fix this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        tool_messages = [
+            m for m in llm.calls[-1]["messages"] if m.get("role") == "tool"
+        ]
+        self.assertNotIn("[serge]", tool_messages[0]["content"])
+        nudged = tool_messages[-1]["content"]
+        self.assertIn("modular_blt.py", nudged)
+        self.assertIn("from line 0", nudged)
+
+    def test_the_emitted_reason_names_the_counter_that_tripped(self) -> None:
+        """A path trip reported as "0 repeated tool call(s)" reads like a bug in
+        the guard rather than a model browsing in circles."""
+        events: list[tuple[str, str]] = []
+        cfg = _CfgStub(
+            tool_max_iterations=0,
+            tool_repeat_limit=6,
+            tool_path_revisit_limit=2,
+            tool_path_trip_after=4,
+        )
+        _run_agentic_loop(
+            self._reading_llm(5),  # type: ignore[arg-type]
+            [{"role": "user", "content": "fix this"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+            emit=lambda kind, text: events.append((kind, text)),
+        )
+        logs = [t for k, t in events if k == "log"]
+        stuck = [line for line in logs if "Stuck in a tool-call loop" in line]
+        self.assertTrue(stuck)
+        self.assertIn("re-open(s) of an already-opened path", stuck[0])
+        self.assertIn("modular_blt.py", stuck[0])
+        self.assertNotIn("repeated tool call(s)", stuck[0])
+
+    def test_an_exact_repeat_still_reports_the_repeat_guard(self) -> None:
+        """The two stop reasons must stay distinguishable — they call for
+        different fixes."""
+        cfg = _CfgStub(
+            tool_max_iterations=0,
+            tool_repeat_limit=2,
+            tool_path_revisit_limit=99,
+            tool_path_trip_after=99,
+        )
+        repeat = ChatResult(
+            content="",
+            usage={"prompt_tokens": 40_000, "completion_tokens": 20},
+            tool_calls=[ToolCall(id="t", name="grep", arguments='{"pattern": "Foo"}')],
+        )
+        final = ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+        )
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([repeat] * 4 + [final]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_REPEAT_GUARD)
+
+    def test_a_broad_investigation_is_left_alone(self) -> None:
+        """Many files opened once each must not trip anything."""
+        cfg = _CfgStub(
+            tool_max_iterations=0,
+            tool_repeat_limit=6,
+            tool_path_revisit_limit=3,
+            tool_path_trip_after=40,
+        )
+        turns = [
+            ChatResult(
+                content="thinking",
+                usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+                tool_calls=[
+                    ToolCall(
+                        id=f"t{i}", name="read_file", arguments='{"path": "m%d.py"}' % i
+                    )
+                ],
+            )
+            for i in range(25)
+        ]
+        final = ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+        )
+        llm = _FakeLLM(turns + [final])
+        _, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+        self.assertEqual(metrics.path_revisits, 0)
+        self.assertEqual(metrics.distinct_paths, 25)
+        for call in llm.calls:
+            for m in call["messages"]:
+                if m.get("role") == "tool":
+                    self.assertNotIn("[serge]", m["content"])

--- a/tests/test_tool_repeat.py
+++ b/tests/test_tool_repeat.py
@@ -7,7 +7,12 @@ fix, and produced a patch that failed GPU verification — three rounds running.
 
 import unittest
 
-from reviewbot.tool_repeat import ToolRepeatGuard, normalize_arguments, path_argument
+from reviewbot.tool_repeat import (
+    ToolRepeatGuard,
+    normalize_arguments,
+    path_argument,
+    path_visit,
+)
 
 
 GREP_A = '{"pattern": "GlmOcrProcessor|Glm46VProcessor", "path": "src/transformers/models/glm_ocr", "max_results": 50}'
@@ -199,13 +204,29 @@ class PathVisitTests(unittest.TestCase):
         self.assertEqual(guard.distinct_paths, 10)
         self.assertEqual(guard.path_revisits, 0)
 
-    def test_counting_survives_a_disabled_guard(self):
-        """The nudge is configurable; the observability record is not."""
-        guard = ToolRepeatGuard(0)
+    def test_counting_survives_both_guards_being_disabled(self):
+        """The nudges are configurable; the observability record is not."""
+        guard = ToolRepeatGuard(0, path_revisit_limit=0, path_trip_after=0)
         for _ in range(5):
             self.assertIsNone(guard.observe("read_file", '{"path": "a.py"}'))
         self.assertEqual(guard.repeats, 0)
         self.assertEqual(guard.path_revisits, 4)
+        self.assertFalse(guard.tripped)
+
+    def test_the_two_allowances_are_independent(self):
+        """Turning off the exact-repeat guard must not turn off the path nudge:
+        they catch different failures and have separate budgets."""
+        guard = ToolRepeatGuard(0, path_revisit_limit=2)
+        self.assertFalse(guard.enabled)  # exact-repeat guard off
+        for _ in range(2):
+            self.assertIsNone(guard.observe("read_file", '{"path": "a.py"}'))
+        self.assertIsNotNone(guard.observe("read_file", '{"path": "a.py"}'))
+        # …and vice versa: the path nudge off leaves exact repeats caught.
+        guard = ToolRepeatGuard(2, path_revisit_limit=0)
+        guard.observe("read_file", '{"path": "a.py"}')
+        self.assertIn(
+            "already made this exact", guard.observe("read_file", '{"path": "a.py"}')
+        )
 
     def test_worst_paths_ranks_the_offenders(self):
         guard = ToolRepeatGuard(999)
@@ -226,6 +247,161 @@ class PathVisitTests(unittest.TestCase):
         self.assertEqual(
             guard.stats(),
             {"repeats": 1, "distinct_paths": 1, "path_revisits": 1},
+        )
+
+
+class PathNudgeTests(unittest.TestCase):
+    """The correction for re-opening a path, which the exact-match nudge misses."""
+
+    FILE = "src/transformers/models/blt/modular_blt.py"
+
+    def _read(self, guard, start=None, end=None, path=None):
+        args = {"path": path or self.FILE}
+        if start is not None:
+            args["start_line"] = start
+        if end is not None:
+            args["end_line"] = end
+        import json as _json
+
+        return guard.observe("read_file", _json.dumps(args))
+
+    def test_the_allowance_is_spent_before_nudging(self):
+        guard = ToolRepeatGuard(6, path_revisit_limit=3)
+        for i in range(3):
+            self.assertIsNone(self._read(guard, i * 100, i * 100 + 99))
+        self.assertIsNotNone(self._read(guard, 400, 500))
+
+    def test_the_nudge_names_the_file_and_what_was_already_served(self):
+        """ "You are repeating" is not actionable; "you already have lines
+        1-200, 180-420" is."""
+        guard = ToolRepeatGuard(6, path_revisit_limit=2)
+        self._read(guard, 1, 200)
+        self._read(guard, 180, 420)
+        note = self._read(guard, 400, 650)
+        self.assertIn(f"`{self.FILE}`", note)
+        self.assertIn("3 times", note)
+        self.assertIn("lines 1-200", note)
+        self.assertIn("lines 180-420", note)
+        # Not the range being served right now — that one is new to the model.
+        self.assertNotIn("lines 400-650", note)
+        self.assertIn("cannot tell you anything new", note)
+
+    def test_repeated_identical_ranges_are_described_once(self):
+        guard = ToolRepeatGuard(0, path_revisit_limit=1)
+        for _ in range(4):
+            note = self._read(guard, 1, 200)
+        self.assertEqual(note.count("lines 1-200"), 1)
+
+    def test_a_long_history_is_elided(self):
+        guard = ToolRepeatGuard(0, path_revisit_limit=1)
+        for i in range(9):
+            note = self._read(guard, i * 100, i * 100 + 50)
+        self.assertIn("…", note)
+        self.assertLessEqual(note.count("lines "), 5)
+
+    def test_a_whole_file_read_says_so(self):
+        guard = ToolRepeatGuard(0, path_revisit_limit=1)
+        self._read(guard)
+        self.assertIn("the whole file", self._read(guard))
+
+    def test_list_dir_is_phrased_as_listing(self):
+        guard = ToolRepeatGuard(0, path_revisit_limit=1)
+        guard.observe("list_dir", '{"path": "src/transformers"}')
+        note = guard.observe("list_dir", '{"path": "src/transformers"}')
+        self.assertIn("listed", note)
+        self.assertNotIn("Re-reading", note)
+        self.assertIn("Listing a directory", note)
+
+    def test_different_files_never_nudge(self):
+        """A genuine investigation opens many files once each."""
+        guard = ToolRepeatGuard(6, path_revisit_limit=3)
+        for i in range(40):
+            self.assertIsNone(self._read(guard, path=f"m{i}.py"))
+        self.assertFalse(guard.tripped)
+
+    def test_grep_is_not_a_revisit(self):
+        """Same path, different pattern is a new search, not a re-read."""
+        guard = ToolRepeatGuard(0, path_revisit_limit=1)
+        for pat in ("Alpha", "Beta", "Gamma", "Delta"):
+            note = guard.observe("grep", '{"pattern": "%s", "path": "src"}' % pat)
+            self.assertIsNone(note)
+        self.assertEqual(guard.path_revisits, 0)
+
+
+class PathTripTests(unittest.TestCase):
+    """The cut-off, which is a separate budget from the exact-repeat one."""
+
+    def test_the_prod_shape_is_cut_off(self):
+        """Task 9d210794: 153 calls, 137 of them re-opening an already-opened
+        path, `modular_blt.py` 53 times — and the exact-match counter saw none
+        of it because every read used a different line range."""
+        guard = ToolRepeatGuard(6, path_revisit_limit=3, path_trip_after=40)
+        served = 0
+        for i in range(153):
+            guard.observe(
+                "read_file",
+                '{"path": "modular_blt.py", "start_line": %d, "end_line": %d}'
+                % (i * 10, i * 10 + 200),
+            )
+            served += 1
+            if guard.tripped:
+                break
+        self.assertTrue(guard.tripped)
+        self.assertLess(served, 60)
+        # The exact-argument counter never fired — this is the whole point.
+        self.assertEqual(guard.repeats, 0)
+
+    def test_the_trip_note_tells_the_model_to_stop(self):
+        guard = ToolRepeatGuard(0, path_revisit_limit=1, path_trip_after=3)
+        for i in range(5):
+            note = guard.observe("read_file", '{"path": "a.py", "start_line": %d}' % i)
+        self.assertTrue(guard.tripped)
+        self.assertIn("no further tool calls will be answered", note)
+
+    def test_a_zero_trip_nudges_forever_without_cutting_off(self):
+        """The escape hatch: keep the correction, never end the session on it."""
+        guard = ToolRepeatGuard(0, path_revisit_limit=2, path_trip_after=0)
+        for i in range(100):
+            note = guard.observe("read_file", '{"path": "a.py", "start_line": %d}' % i)
+        self.assertIsNotNone(note)
+        self.assertFalse(guard.tripped)
+        self.assertEqual(guard.path_revisits, 99)
+
+    def test_the_two_trips_are_separate_budgets(self):
+        """A session can exhaust one without touching the other."""
+        guard = ToolRepeatGuard(3, path_revisit_limit=99, path_trip_after=99)
+        for _ in range(4):
+            guard.observe("grep", '{"pattern": "x"}')
+        self.assertTrue(guard.tripped)  # exact repeats only
+        self.assertEqual(guard.path_revisits, 0)
+
+
+class PathVisitRangeTests(unittest.TestCase):
+    def test_reports_path_and_range(self):
+        self.assertEqual(
+            path_visit("read_file", '{"path": "a.py", "start_line": 5, "end_line": 9}'),
+            ("a.py", "lines 5-9"),
+        )
+        self.assertEqual(
+            path_visit("read_file", '{"path": "a.py"}'), ("a.py", "the whole file")
+        )
+        self.assertEqual(
+            path_visit("read_file", '{"path": "a.py", "start_line": 5}'),
+            ("a.py", "from line 5"),
+        )
+        self.assertEqual(
+            path_visit("read_file", '{"path": "a.py", "end_line": 9}'),
+            ("a.py", "up to line 9"),
+        )
+        self.assertEqual(
+            path_visit("list_dir", '{"path": "src"}'), ("src", "the directory")
+        )
+        self.assertIsNone(path_visit("grep", '{"pattern": "x", "path": "src"}'))
+
+    def test_a_non_integer_range_does_not_break_the_label(self):
+        self.assertEqual(
+            path_visit("read_file", '{"path": "a.py", "start_line": "five"}'),
+            ("a.py", "the whole file"),
         )
 
 


### PR DESCRIPTION
Item 2 of `docs/plans/serge-itf-quick-wins-2026-08-26.md`. Builds on the counters shipped in #99.

## The blind spot

`ToolRepeatGuard` keys on `name + exact arguments`, and its docstring says so plainly: *"Only an exact re-run of a call already made in this session is treated as a repeat."* That catches the case it was built for — prod task `433e8274` issuing the same grep 21 and 44 times — and is blind to the one that actually dominates.

Prod task `9d210794`: **153 tool calls, 137 of them re-opening a path it had already opened**, `modular_blt.py` 53 times at a different line range each time. Fifty-three distinct signatures, so the counter sat at **zero** for the whole 2.1M-token session, which then died on the input-token cap.

The measured cost is per *turn*, not per call — every repeat resends the whole conversation, ~40k input tokens — so this is the biggest single token line item in the flow.

## What changes

A second counter keyed on the opened path, with its own two thresholds:

| knob | default | what it does |
| --- | --- | --- |
| `TOOL_PATH_REVISIT_LIMIT` | `3` | visits to one path before every further visit is corrected |
| `TOOL_PATH_TRIP_AFTER` | `40` | total re-opens across all paths before the loop is cut off |

Separate budgets from `TOOL_REPEAT_LIMIT` because they are separate failures — one model is stuck on a single call, the other is browsing in circles — and a separate `stop_reason` (`path_revisit_guard`) so the dashboard can tell them apart.

Both defaults come from the measured window rather than taste: the session that actually produced a PR re-opened its main file about ten times, so an allowance of 3 nudges early while leaving the loop running; the pathological session spent 137 calls this way, nowhere near which a healthy one goes.

`grep` is deliberately **not** counted as a path visit — the same path with a different pattern is a genuinely new search, not a re-read.

## The correction is the point, not the counting

```
[serge] You have already read `src/transformers/models/blt/modular_blt.py` 6 times
in this session (lines 1-200, lines 180-420, lines 400-650, lines 620-900).
Re-reading a file you have not modified cannot tell you anything new. If you need
a part you have not seen yet, ask for those line numbers specifically; otherwise
work from what you already have.
```

A model told *"you are repeating"* can only stop or continue. A model told **which ranges it already holds** can decide it has the bytes. Ranges are deduplicated, elided past four, and the range being served right now is excluded — that one is genuinely new to it.

Still **not a cache**, in either direction: every call executes for real, because a `read_file` after an `apply_patch` must return the new content. The guard only appends.

## Also fixed

The trip log printed the exact-repeat summary unconditionally, so a path trip would have reported `0 repeated tool call(s)` — which reads like a bug in the guard rather than a model browsing in circles. It now names whichever counter tripped, and both when both did. This one only exists *because* of this change, so it ships with it.

## Testing

769 pass, ruff clean. I verified each new test fails without its change by reverting the change and re-running — including the prod shape (153 re-reads at rolling offsets) being cut off in under 60 calls with `repeats == 0` throughout, and a broad investigation of 25 files opened once each being left completely untouched.

## On measuring it

#99's metrics went live in prod today, so `serge_job_path_revisits` is only now starting to accumulate a baseline — and the window this change is argued from no longer exists. **I'd suggest holding the merge for a few days** so there is a real before/after rather than a comparison against a deleted window. The change stands on its own, but its effect would otherwise be as unfalsifiable as everything item 8 was meant to fix.

Companion dashboard change (the new `stop_reason` needs a value mapping or it renders raw): huggingface/transformers-ci#98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
