### PR TITLE
Salvage a final answer that is only leaked tool-call markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A final answer that is **nothing but leaked tool-call markup** is now
+  re-asked instead of parsed. `_needs_final_salvage` only recognised a
+  *truncated* or *empty* reply, so markup-only content — non-empty, so it
+  looked parseable — went straight to `_extract_json` and raised
+  `LLM returned unparseable output` with **zero** recovery attempts. The
+  review path had a backstop after parsing; the task path had none, which is
+  what 3 of 10 task jobs in the 2026-08-24→26 window died of. The three
+  unusable shapes are now one classifier (`_final_answer_defect`), so the
+  loop, the log line and the recovery prompt agree on what was wrong, and the
+  markup case gets a prompt that names the mistake.
+- `_UnparseableLLMOutput` now carries `salvage_attempts`, so the error
+  distinguishes "salvage never recognised this shape" (0) from "salvage ran
+  and the model still could not produce JSON" (>0). Those are different bugs
+  and they used to share one error string.
+
 - The new-review form's per-provider model dropdown is visible again: it now
   lists a provider's models on page load (via `GET /llm-options/models`) instead
   of only after a PR reference resolved to a matching config, and Anthropic's

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -908,19 +908,68 @@ _EMPTY_ANSWER_RECOVERY_MESSAGE = (
     "with ONLY the final JSON object the task requires: no analysis, no "
     "explanation, no <think> block, no markdown fences."
 )
+# A reply that is non-empty but is *only* chat-template markup. Says what was
+# wrong explicitly, because unlike the other two shapes this one is a mistake
+# the model can avoid rather than a budget it ran out of.
+_MARKUP_ANSWER_RECOVERY_MESSAGE = (
+    "Your previous reply contained only tool-call markup — no JSON object came "
+    "through. Do not write tool calls as text; you have no tools left on this "
+    "turn. Reply now with ONLY the final JSON object the task requires: no "
+    "analysis, no explanation, no <think> block, no markdown fences."
+)
+
+_RECOVERY_MESSAGES = {
+    "empty": _EMPTY_ANSWER_RECOVERY_MESSAGE,
+    "truncated": _TRUNCATION_RECOVERY_MESSAGE,
+    "markup": _MARKUP_ANSWER_RECOVERY_MESSAGE,
+}
+# How each defect is named in the operator-facing log line.
+_DEFECT_LABELS = {
+    "empty": "empty",
+    "truncated": "truncated",
+    "markup": "nothing but tool-call markup",
+}
+
+
+def _final_answer_defect(chat: ChatResult) -> Optional[str]:
+    """Which unusable shape the final answer has, or ``None`` when it is worth
+    parsing. One classifier because all three callers need the same verdict:
+    the loop (salvage or not), the log line (what was wrong) and the recovery
+    prompt (what to tell the model).
+
+    - ``"empty"`` — blank content, commonly ``finish_reason=None`` when the
+      provider truncates the stream on a very large context.
+    - ``"truncated"`` — hit the output-token limit (``finish_reason="length"``).
+    - ``"markup"`` — non-empty but says nothing: the model wrote its tool calls
+      out as chat-template special tokens instead of calling them (serge#81).
+
+    ``"markup"`` is the one that used to escape. Its content is non-empty, so
+    the older emptiness test said "parse it"; on the task path ``_extract_json``
+    then raised ``_UnparseableLLMOutput`` with **zero** recovery attempts. The
+    review path had a backstop for it after parsing, the task path had none —
+    which is why 3 of 10 task jobs in the 2026-08-24→26 window died
+    "unparseable". Checked last because it is the only test that has to walk the
+    content.
+    """
+    if not (chat.content or "").strip():
+        return "empty"
+    if chat.finish_reason == "length":
+        return "truncated"
+    if _is_model_markup_only(chat.content or ""):
+        return "markup"
+    return None
 
 
 def _needs_final_salvage(chat: ChatResult) -> bool:
     """True when a tool-free final answer should be re-asked rather than
-    parsed: it either hit the output-token limit (``finish_reason="length"``)
-    or came back with blank content (commonly ``finish_reason=None`` when the
-    provider truncates the stream on a very large context)."""
-    return chat.finish_reason == "length" or not (chat.content or "").strip()
+    parsed."""
+    return _final_answer_defect(chat) is not None
 
 
 def _final_recovery_message(chat: ChatResult) -> str:
-    blank = not (chat.content or "").strip()
-    return _EMPTY_ANSWER_RECOVERY_MESSAGE if blank else _TRUNCATION_RECOVERY_MESSAGE
+    return _RECOVERY_MESSAGES.get(
+        _final_answer_defect(chat) or "", _TRUNCATION_RECOVERY_MESSAGE
+    )
 
 
 def _emit_final_salvage(
@@ -928,7 +977,7 @@ def _emit_final_salvage(
 ) -> None:
     if emit is None:
         return
-    what = "empty" if not (chat.content or "").strip() else "truncated"
+    what = _DEFECT_LABELS.get(_final_answer_defect(chat) or "", "unparseable")
     emit(
         "log",
         f"Final answer was {what} (finish_reason={chat.finish_reason}); re-asking "
@@ -1550,6 +1599,7 @@ class _UnparseableLLMOutput(Exception):
         finish_reason: Optional[str],
         metrics_line: str,
         session: Optional[dict[str, Any]] = None,
+        salvage_attempts: int = 0,
     ):
         super().__init__("unparseable LLM output")
         self.content = content
@@ -1559,19 +1609,34 @@ class _UnparseableLLMOutput(Exception):
         # answer is what a starved final turn produces, and the job row records
         # only the error string.
         self.session = session or {}
+        # How many tool-free re-asks the loop already spent trying to recover
+        # this answer. 0 and >0 are different bugs wearing the same error
+        # string: 0 means the salvage never recognised the shape (what the
+        # task path did with leaked markup), >0 means it recognised it and the
+        # model still could not produce JSON. Without this the two are
+        # indistinguishable from the job row, which is how the task path's
+        # missing markup case stayed hidden.
+        self.salvage_attempts = salvage_attempts
+
+    def _salvage_note(self) -> str:
+        if self.salvage_attempts:
+            return f", {self.salvage_attempts} salvage re-ask(s) did not recover it"
+        return ", no salvage was attempted for this shape"
 
     def user_message(self) -> str:
         if self.finish_reason == "length":
             return (
                 "LLM response was truncated before it produced valid review JSON "
-                f"(finish_reason=length, {self.metrics_line}). Increase "
+                f"(finish_reason=length, {self.metrics_line}"
+                f"{self._salvage_note()}). Increase "
                 "LLM_MAX_TOKENS for this provider, or narrow the review scope / "
                 "reduce TOOL_MAX_ITERATIONS so the final answer has enough output "
                 "budget."
             )
         return (
             "LLM returned unparseable output "
-            f"(finish_reason={self.finish_reason}, {self.metrics_line})"
+            f"(finish_reason={self.finish_reason}, {self.metrics_line}"
+            f"{self._salvage_note()})"
         )
 
 
@@ -1783,6 +1848,7 @@ def prepare_review(
                 finish_reason=chat.finish_reason,
                 metrics_line=metrics_line,
                 session=session_record(total_metrics),
+                salvage_attempts=total_metrics.truncation_retries,
             ) from exc
 
         summary = (result.get("summary") or "").strip()

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -750,6 +750,7 @@ def prepare_task(
             finish_reason=chat.finish_reason,
             metrics_line=metrics_line,
             session=session_record(metrics),
+            salvage_attempts=metrics.truncation_retries,
         ) from exc
 
     title = (result.get("title") or "").strip() or (req.title or "serge: automated fix")

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -11,6 +11,7 @@ from reviewbot.reviewer import (
     _LOG_MSG_MAX_CHARS,
     _MAX_TRUNCATION_RETRIES,
     _UnparseableLLMOutput,
+    _final_answer_defect,
     _assistant_tool_call_dict,
     _build_annotated_diff_chunks,
     _content_preview,
@@ -1382,3 +1383,128 @@ class PathRevisitLoopTests(unittest.TestCase):
             for m in call["messages"]:
                 if m.get("role") == "tool":
                     self.assertNotIn("[serge]", m["content"])
+
+
+class MarkupOnlyFinalAnswerSalvageTests(unittest.TestCase):
+    """A final answer that is nothing but leaked tool-call markup must be
+    re-asked, not parsed.
+
+    This is the task-path hole: the content is non-empty, so the emptiness
+    test said "parse it", and `_extract_json` then raised
+    `_UnparseableLLMOutput` with zero recovery attempts. The review path had a
+    backstop after parsing; the task path had none.
+    """
+
+    LEAKED = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>"
+        "functions.read_file:6<|tool_call_argument_begin|>\n\n"
+        "<|tool_call_end|><|tool_calls_section_end|>"
+    )
+
+    def test_markup_only_answer_needs_salvage(self) -> None:
+        # Fails before the fix: non-empty content, finish_reason="stop".
+        self.assertTrue(
+            _needs_final_salvage(ChatResult(content=self.LEAKED, finish_reason="stop"))
+        )
+        self.assertEqual(
+            _final_answer_defect(ChatResult(content=self.LEAKED, finish_reason="stop")),
+            "markup",
+        )
+
+    def test_real_answer_is_still_parsed(self) -> None:
+        # The guard must not reach past its shape: a normal answer, and a
+        # review that legitimately quotes a special token, both still parse.
+        self.assertIsNone(
+            _final_answer_defect(
+                ChatResult(content='{"summary": "ok"}', finish_reason="stop")
+            )
+        )
+        self.assertIsNone(
+            _final_answer_defect(
+                ChatResult(
+                    content="The test asserts `<|endoftext|>` is appended.",
+                    finish_reason="stop",
+                )
+            )
+        )
+
+    def test_defect_classification_keeps_prior_precedence(self) -> None:
+        # Empty is reported ahead of length so the recovery prompt keeps
+        # saying "empty" for a blank truncated reply, as it did before.
+        self.assertEqual(
+            _final_answer_defect(ChatResult(content="", finish_reason="length")),
+            "empty",
+        )
+        self.assertEqual(
+            _final_answer_defect(
+                ChatResult(content='{"partial', finish_reason="length")
+            ),
+            "truncated",
+        )
+
+    def test_markup_recovery_message_names_the_mistake(self) -> None:
+        msg = _final_recovery_message(
+            ChatResult(content=self.LEAKED, finish_reason="stop")
+        )
+        self.assertIn("tool-call markup", msg)
+        self.assertNotEqual(
+            msg, _final_recovery_message(ChatResult(content="", finish_reason=None))
+        )
+
+    def test_loop_re_asks_and_recovers_a_markup_only_answer(self) -> None:
+        """End to end through the loop: the markup answer is re-asked
+        tool-free and the recovered JSON is what the caller gets."""
+        results = [
+            ChatResult(content=self.LEAKED, finish_reason="stop"),
+            ChatResult(content='{"summary": "recovered", "comments": []}'),
+        ]
+        llm = _FakeLLM(results)
+        chat, metrics = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "review this"}],
+            cfg=_CfgStub(),  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        # Before the fix the loop returned the markup on the first turn.
+        self.assertIn("recovered", chat.content or "")
+        self.assertEqual(metrics.truncation_retries, 1)
+        self.assertEqual(len(llm.calls), 2)
+
+
+class UnparseableSalvageAttemptsTests(unittest.TestCase):
+    """`salvage_attempts` separates two bugs that shared one error string."""
+
+    def test_zero_attempts_says_no_salvage_ran(self) -> None:
+        exc = _UnparseableLLMOutput(
+            content="junk",
+            finish_reason="stop",
+            metrics_line="turns=3",
+            salvage_attempts=0,
+        )
+        self.assertIn("no salvage was attempted", exc.user_message())
+
+    def test_exhausted_attempts_are_reported(self) -> None:
+        exc = _UnparseableLLMOutput(
+            content="junk",
+            finish_reason="stop",
+            metrics_line="turns=3",
+            salvage_attempts=_MAX_TRUNCATION_RETRIES,
+        )
+        msg = exc.user_message()
+        self.assertIn(f"{_MAX_TRUNCATION_RETRIES} salvage re-ask", msg)
+        self.assertNotIn("no salvage was attempted", msg)
+
+    def test_length_truncation_message_also_reports_salvage(self) -> None:
+        exc = _UnparseableLLMOutput(
+            content="junk",
+            finish_reason="length",
+            metrics_line="turns=3",
+            salvage_attempts=1,
+        )
+        self.assertIn("1 salvage re-ask", exc.user_message())
+
+    def test_defaults_to_no_salvage(self) -> None:
+        exc = _UnparseableLLMOutput(
+            content="junk", finish_reason="stop", metrics_line="turns=3"
+        )
+        self.assertEqual(exc.salvage_attempts, 0)


### PR DESCRIPTION
## What

The salvage step recognised two unusable final answers — **truncated**
(`finish_reason="length"`) and **empty** — and a third shape slipped between
them: content that is non-empty but is nothing except chat-template tool-call
markup, which Kimi emits when it writes its tool calls out as text instead of
calling them (#81).

Because that content is non-empty, `_needs_final_salvage` said "parse it". On
the **task** path `_extract_json` then raised `_UnparseableLLMOutput` with
**zero** recovery attempts — the review path has a backstop after parsing
(`_is_model_markup_only` at two call sites), the task path never calls it.

That is what **3 of 10 task jobs** in the 2026-08-24→26 window died of, and it
gives the ITF plan's question ("is the salvage exhausting, or not reached?") a
third answer: **never entered**.

## How

- The three unusable shapes are now one classifier, `_final_answer_defect`, so
  the loop (salvage or not), the operator log line (what was wrong) and the
  recovery prompt (what to tell the model) cannot disagree.
- `empty` is still reported ahead of `length`, so a blank truncated reply keeps
  the "your previous reply was empty" prompt it had before — that ordering was
  load-bearing in the old code.
- The markup case gets a prompt that names the mistake rather than the generic
  truncation text.
- `_UnparseableLLMOutput` carries `salvage_attempts`, separating two bugs that
  shared one error string: `0` = salvage never recognised the shape, `>0` =
  it ran and the model still could not produce JSON. Not knowing which is how
  this hole stayed hidden.

The two downstream review-path backstops are untouched: loop salvage runs
earlier, so if it recovers real JSON they never fire, and if it exhausts they
still behave exactly as before.

## Verified against the pre-fix code

Stashing the fix makes the test module fail to *import*, which proves nothing —
so the assertions were run directly against the old code:

```
OLD _needs_final_salvage(markup) = False
OLD loop returned markup? True | recovered? False
OLD truncation_retries = 0 | complete() calls = 1
OLD _UnparseableLLMOutput rejects salvage_attempts
```

One call, raw markup returned, zero salvage attempts — the production shape
exactly.

## Tests

778 pass (102 in `test_reviewer.py`, 9 new), `make format` clean.
Every new test was checked to fail without its change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)