### PR TITLE
Log what the resent prompt prefix is made of

### DIFF
--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -653,6 +653,36 @@ def _read_repo_conventions(cfg: Config, checkout: Checkout) -> str:
     return cfg.default_review_rules
 
 
+def prompt_prefix_summary(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    conventions: str = "",
+    normalize_guidance: str | None = "",
+    context: str = "",
+    instruction: str = "",
+    existing_diff: str | None = "",
+) -> str:
+    """One line naming the size of every part of the resent prompt prefix.
+
+    Pure so the wording is testable without a checkout, an LLM or a GPU. Chars
+    rather than tokens deliberately: the exact token count already arrives in
+    the per-turn ``metrics`` events, and a char count needs no tokenizer for a
+    model whose tokenizer we do not ship.
+    """
+    total = len(system_prompt) + len(user_prompt)
+    return (
+        f"Prompt prefix {total:,} chars, resent every turn: "
+        f"system {len(system_prompt):,} "
+        f"[conventions {len(conventions or ''):,}, "
+        f"normalize-guidance {len(normalize_guidance or ''):,}] · "
+        f"user {len(user_prompt):,} "
+        f"[context {len(context or ''):,}, "
+        f"instruction {len(instruction or ''):,}, "
+        f"existing-diff {len(existing_diff or ''):,}]"
+    )
+
+
 def prepare_task(
     cfg: Config,
     req: TaskRequest,
@@ -691,8 +721,9 @@ def prepare_task(
         stream=cfg.llm_stream,
         compressor=MessageCompressor.from_env(),
     )
+    conventions = _read_repo_conventions(cfg, checkout)
     system_prompt = build_task_system_prompt(
-        _read_repo_conventions(cfg, checkout),
+        conventions,
         cfg.task_normalize_guidance,
         tools_enabled=tool_env is not None,
     )
@@ -702,6 +733,30 @@ def prepare_task(
         instruction=req.instruction,
         context=req.context,
         existing_diff=existing_diff,
+    )
+
+    # This prefix is resent on EVERY turn, so its size -- not the number of tool
+    # calls -- sets how many turns the input-token cap buys. Measured on a real
+    # 51-turn task (mm_grounding_dino, 2026-08-31): turn 1 cost 25,335 input
+    # tokens and the conversation itself then grew only ~510 tokens a turn, so
+    # ~63% of the whole 2M budget went on re-sending this prefix. The known
+    # components (system template, conventions, tool schemas, dispatched ITF
+    # context) account for only ~3.2k of those 25.3k, and the residue is
+    # believed to be the GPU reproduce/verify feedback that `_with_feedback`
+    # appends to `req.context`. "Believed" is the problem: it was reached by
+    # subtraction because the request body is never logged. Log the breakdown
+    # once per task so the dominant component is a fact in the job row.
+    _emit(
+        "log",
+        prompt_prefix_summary(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            conventions=conventions,
+            normalize_guidance=cfg.task_normalize_guidance,
+            context=req.context,
+            instruction=req.instruction,
+            existing_diff=existing_diff,
+        ),
     )
 
     # Wire the normalize verification gate into the loop when configured. The

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,6 +13,7 @@ from reviewbot.clone_cache import Checkout, CloneCache
 from reviewbot.config import Config
 from reviewbot.github_client import SERGE_GIT_EMAIL
 from reviewbot.tasks import (
+    prompt_prefix_summary,
     MAX_REVIEWERS,
     NormalizeGateBroken,
     TaskError,
@@ -1310,3 +1311,46 @@ class ReadRepoConventionsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PromptPrefixSummaryTests(unittest.TestCase):
+    """The prefix is resent on every turn, so its breakdown is what explains
+    where an input-token budget went. Measured on a real 51-turn task: turn 1
+    cost 25,335 tokens and the conversation then grew only ~510 a turn, so ~63%
+    of the 2M cap was this prefix -- and which component dominates was reached
+    by subtraction, which is what this line replaces."""
+
+    def test_names_every_component(self) -> None:
+        line = prompt_prefix_summary(
+            system_prompt="s" * 4000,
+            user_prompt="u" * 90000,
+            conventions="c" * 3597,
+            normalize_guidance="n" * 120,
+            context="x" * 88000,
+            instruction="i" * 1000,
+            existing_diff="",
+        )
+        self.assertIn("Prompt prefix 94,000 chars", line)
+        self.assertIn("system 4,000", line)
+        self.assertIn("conventions 3,597", line)
+        self.assertIn("normalize-guidance 120", line)
+        self.assertIn("user 90,000", line)
+        self.assertIn("context 88,000", line)
+        self.assertIn("instruction 1,000", line)
+        self.assertIn("existing-diff 0", line)
+
+    def test_none_components_are_zero_not_a_crash(self) -> None:
+        # normalize_guidance and existing_diff are Optional in the real call.
+        line = prompt_prefix_summary(
+            system_prompt="s",
+            user_prompt="u",
+            normalize_guidance=None,
+            existing_diff=None,
+        )
+        self.assertIn("normalize-guidance 0", line)
+        self.assertIn("existing-diff 0", line)
+        self.assertIn("Prompt prefix 2 chars", line)
+
+    def test_total_is_system_plus_user(self) -> None:
+        line = prompt_prefix_summary(system_prompt="a" * 10, user_prompt="b" * 5)
+        self.assertIn("Prompt prefix 15 chars", line)


### PR DESCRIPTION
Diagnostic only — one extra log event per task, no behaviour change.

## Why

The prompt prefix is resent on **every turn**, so its size — not the number of
tool calls — sets how many turns the input-token cap buys.

Measured on a real 51-turn task (`mm_grounding_dino`, 2026-08-31), by
differencing the cumulative `in` in the per-turn `metrics` events:

```
turn  1   this turn 25,335
turn 20   this turn 36,112
turn 40   this turn 49,298
turn 51   this turn 50,703  → hit the 2M cap
```

Turn 1 already costs 25,335 tokens and the conversation then grows only
**~510 tokens a turn**, so roughly **63% of the entire 2M budget** goes on
re-sending the prefix rather than on new information. That reframes the whole
token-efficiency effort: items 2/5/6 reduced how *often* the agent browses,
which attacks the other ~35%.

## The gap this closes

The components we can measure account for only ~3.2k of those 25.3k:

| component | tokens |
| --- | --- |
| task system prompt template | ~883 |
| `.ai/AGENTS.md` (`review_rules`) | ~899 |
| tool schemas (4 tools) | ~719 |
| dispatched ITF failure-group context | ~700 |

The remaining ~22k is **believed** to be the GPU reproduce/verify feedback that
`_with_feedback` appends to `req.context` (`tasks.py`), which then rides in the
user prompt on all 51 turns — plausible, since those tracebacks carry
`--showlocals` tensor dumps. But "believed" is the problem: it was reached by
**subtraction**, because the request body is never logged. A 40%-of-budget claim
should not rest on that.

So this logs the breakdown once per task:

```
Prompt prefix 94,000 chars, resent every turn: system 4,000
[conventions 3,597, normalize-guidance 120] · user 90,000
[context 88,000, instruction 1,000, existing-diff 0]
```

Chars rather than tokens deliberately: the exact token count already arrives in
the per-turn `metrics` events, and a char count needs no tokenizer for a model
whose tokenizer we do not ship.

## Tests

781 pass, 3 new. `prompt_prefix_summary` is pure, so the wording is tested
without a checkout, an LLM or a GPU — including the `None` cases
(`normalize_guidance`, `existing_diff` are both Optional at the real call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)