### PR TITLE
Stop truncating away the GPU reproduce evidence

### DIFF
--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -207,7 +207,12 @@ class Config:
     # and the asserted actual output, which sit at the HEAD of the longrepr and a
     # smaller tail-cut would drop (the owlvit/instructblip cases).
     # Tunable via REPRODUCE_TB_CHARS.
-    reproduce_tb_chars: int = 40000
+    # Per-traceback cap for the reproduce block. MUST stay below
+    # prompts.CONTEXT_TAIL_RESERVE_CHARS: this used to be 40000, exactly equal to
+    # MAX_CONTEXT_CHARS, so the block was allowed to claim the entire context
+    # budget on its own and was then appended after the report and truncated
+    # away. Aligned with _format_reproduce_feedback's own default.
+    reproduce_tb_chars: int = 12000
     # Optional task-only completion-token cap. When unset, tasks use the
     # normal llm_max_tokens value.
     task_llm_max_tokens: Optional[int] = None
@@ -469,7 +474,7 @@ class Config:
             classify_bail_on_environment=_bool_env(
                 "CLASSIFY_BAIL_ON_ENVIRONMENT", True
             ),
-            reproduce_tb_chars=_int_env("REPRODUCE_TB_CHARS", 40000),
+            reproduce_tb_chars=_int_env("REPRODUCE_TB_CHARS", 12000),
             # Streaming on by default — the web UI's live token counter
             # and reasoning display rely on incremental SSE chunks. Set
             # LLM_STREAM=0 to fall back to the buffered REST path.

--- a/reviewbot/prompts.py
+++ b/reviewbot/prompts.py
@@ -234,6 +234,39 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit] + f"\n[... truncated, {len(text) - limit} chars omitted ...]"
 
 
+def _truncate_middle(text: str, limit: int, tail: int) -> str:
+    """Keep the first ``limit - tail`` chars AND the last ``tail`` chars,
+    dropping the middle.
+
+    Plain head truncation cannot be used on a task context, because both ends
+    carry something load-bearing:
+
+    * the **head** opens with the ``<!-- serge-task:... -->`` marker and the
+      fingerprint line, which the instruction requires be copied into the PR
+      body — lose it and the PR no longer links back to its triage row;
+    * the **tail** is where ``_with_verify_feedback`` appends the GPU
+      reproduce/verify block, which announces itself as *authoritative* and
+      carries the triage steer (test issue vs library bug).
+
+    Head truncation kept the first and silently discarded the second. Measured
+    on 2026-08-31: three live task contexts of 42,815 / 62,939 / 124,011 chars
+    against a 40,000 limit dropped 2,815 / 22,939 / 84,011 chars from the tail,
+    so two of the three lost the whole reproduce block — roughly 50 GPU-minutes
+    of evidence each — and worked from the report's head instead.
+    """
+    if len(text) <= limit:
+        return text
+    tail = max(0, min(tail, limit))
+    head_len = limit - tail
+    omitted = len(text) - limit
+    head = text[:head_len]
+    kept_tail = text[len(text) - tail :] if tail else ""
+    return (
+        f"{head}\n[... {omitted} chars omitted from the middle; the end of the "
+        f"context follows ...]\n{kept_tail}"
+    )
+
+
 # Sequences a malicious PR body / diff line could use to spoof the
 # boundary markers around untrusted blocks (see USER_PROMPT_TEMPLATE).
 # We don't try to be exhaustive — collapsing the marker prefix is enough
@@ -478,6 +511,11 @@ def build_user_prompt(
 
 MAX_INSTRUCTION_CHARS = 8000
 MAX_CONTEXT_CHARS = 40000
+# How much of the END of a task context is protected from truncation. The
+# appended GPU reproduce/verify block lives there and is the authoritative
+# evidence for the fix, so it must outrank the middle of the report. Sized above
+# `Config.reproduce_tb_chars` (12000) so a full block fits inside the reserve.
+CONTEXT_TAIL_RESERVE_CHARS = 16000
 
 
 TASK_SYSTEM_PROMPT_TEMPLATE = """You are an expert software engineer making a
@@ -611,7 +649,11 @@ def build_task_user_prompt(
         instruction=_scrub_delimiters(
             _truncate(instruction or "(none)", MAX_INSTRUCTION_CHARS)
         ),
-        context=_scrub_delimiters(_truncate(context or "(none)", MAX_CONTEXT_CHARS)),
+        context=_scrub_delimiters(
+            _truncate_middle(
+                context or "(none)", MAX_CONTEXT_CHARS, CONTEXT_TAIL_RESERVE_CHARS
+            )
+        ),
         existing_block=existing_block,
         today_iso=today.isoformat(),
     )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,6 +1,10 @@
 import unittest
 
 from reviewbot.prompts import (
+    CONTEXT_TAIL_RESERVE_CHARS,
+    MAX_CONTEXT_CHARS,
+    _truncate_middle,
+    build_task_user_prompt,
     build_followup_system_prompt,
     build_followup_user_prompt,
     build_system_prompt,
@@ -90,3 +94,92 @@ class FollowupPromptTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ContextTruncationTests(unittest.TestCase):
+    """A task context is load-bearing at BOTH ends, so it truncates in the
+    middle.
+
+    Head: the `<!-- serge-task:... -->` marker and fingerprint the instruction
+    requires in the PR body. Tail: the GPU reproduce/verify block appended by
+    `_with_verify_feedback`, which announces itself as authoritative and carries
+    the triage steer. Head truncation kept the first and silently dropped the
+    second."""
+
+    MARKER = "<!-- serge-task:integration-failure-triage:sha256:abc123 -->"
+    REPRODUCE = "## The targeted test(s) were REPRODUCED on GPU (authoritative)"
+
+    def _context(self, filler_chars: int) -> str:
+        return (
+            f"{self.MARKER}\nSerge task fingerprint: `abc123`.\n\n"
+            + ("REPORT " * (filler_chars // 7))[:filler_chars]
+            + f"\n\n{self.REPRODUCE}\n\nE AssertionError: Tensor-likes are not close!"
+        )
+
+    def _prompt(self, context: str) -> str:
+        return build_task_user_prompt(
+            repo_full_name="huggingface/transformers",
+            base_ref="main",
+            instruction="fix it",
+            context=context,
+            existing_diff="",
+        )
+
+    def test_reproduce_block_survives_a_context_over_the_limit(self) -> None:
+        # The live 124,011-char case: head truncation dropped 84,011 chars from
+        # the tail and the model never saw the reproduce block.
+        prompt = self._prompt(self._context(121_000))
+        self.assertIn(self.REPRODUCE, prompt)
+        self.assertIn("Tensor-likes are not close", prompt)
+
+    def test_marker_also_survives(self) -> None:
+        prompt = self._prompt(self._context(121_000))
+        self.assertIn(self.MARKER, prompt)
+        self.assertIn("Serge task fingerprint", prompt)
+
+    def test_live_sizes_all_keep_both_ends(self) -> None:
+        # The three real contexts measured on 2026-08-31.
+        for size in (42_815, 62_939, 124_011):
+            with self.subTest(context_chars=size):
+                prompt = self._prompt(self._context(size))
+                self.assertIn(self.MARKER, prompt)
+                self.assertIn(self.REPRODUCE, prompt)
+
+    def test_short_context_is_untouched(self) -> None:
+        ctx = self._context(100)
+        prompt = self._prompt(ctx)
+        self.assertNotIn("omitted from the middle", prompt)
+        self.assertIn(self.REPRODUCE, prompt)
+
+    def test_says_the_middle_was_dropped(self) -> None:
+        prompt = self._prompt(self._context(121_000))
+        self.assertIn("omitted from the middle", prompt)
+
+
+class TruncateMiddleTests(unittest.TestCase):
+    def test_keeps_head_and_tail_and_reports_the_gap(self) -> None:
+        text = "H" * 100 + "M" * 800 + "T" * 100
+        out = _truncate_middle(text, limit=200, tail=100)
+        self.assertTrue(out.startswith("H" * 100))
+        self.assertTrue(out.endswith("T" * 100))
+        self.assertIn("800 chars omitted from the middle", out)
+
+    def test_under_limit_is_returned_verbatim(self) -> None:
+        self.assertEqual(_truncate_middle("short", 100, 50), "short")
+
+    def test_tail_larger_than_limit_is_clamped(self) -> None:
+        # Degenerate config must not produce a negative head slice.
+        out = _truncate_middle("x" * 500, limit=100, tail=999)
+        self.assertIn("omitted from the middle", out)
+        self.assertTrue(out.endswith("x" * 100))
+
+    def test_zero_tail_behaves_like_head_truncation(self) -> None:
+        out = _truncate_middle("A" * 50 + "B" * 50, limit=50, tail=0)
+        self.assertTrue(out.startswith("A" * 50))
+        self.assertNotIn("B", out)
+
+    def test_reserve_fits_a_full_reproduce_block(self) -> None:
+        # The whole point of the constant: a maximal reproduce block
+        # (Config.reproduce_tb_chars = 12000) must fit inside the reserve.
+        self.assertGreater(CONTEXT_TAIL_RESERVE_CHARS, 12_000)
+        self.assertLess(CONTEXT_TAIL_RESERVE_CHARS, MAX_CONTEXT_CHARS)


### PR DESCRIPTION
## The bug

`MAX_CONTEXT_CHARS` head-truncates a task context at 40,000 chars, and
`_with_verify_feedback` **appends** the GPU reproduce/verify block to the end of
that context. So the block was always the first thing discarded.

And `Config.reproduce_tb_chars` was **40000 — exactly equal to
`MAX_CONTEXT_CHARS`** — so the block was permitted to claim the entire context
budget on its own, then appended past the cap. The two limits were in direct
conflict, in code rather than config.

## Measured on live traffic

Three real task contexts from the 2026-08-31 run, against the 40,000 limit:

| job | context | dropped from tail |
| --- | --- | --- |
| `42ed30c8` | 42,815 | 2,815 |
| `50c08d51` | 62,939 | 22,939 |
| `f50c5e85` | 124,011 | **84,011** |

Two of the three lost the **whole** reproduce block — roughly 50 GPU-minutes of
evidence each — and `f50c5e85` lost ~44k of the report as well.

Confirmed on the real code path rather than by reading: with the genuine
`_format_reproduce_feedback` output appended, the block's
`REPRODUCED on GPU (authoritative)` marker is present at 38,666 chars of context
and **absent** at 60,667 and 121,665.

## Why it matters beyond tokens

That block announces itself as authoritative — *"serge ran these `@slow` tests on
a GPU runner at the base commit before asking you to fix them… base your fix on
them"* — and carries the triage steer (`test_issue` vs `product_issue`) that
decides whether the model edits expected values or model code. Losing it
silently, while the model is still told "do not run the tests yourself", is a
plausible contributor to the `no_fix` rate.

## The fix

A task context is load-bearing at **both** ends, so it now truncates in the
middle:

- **head** — the `<!-- serge-task:... -->` marker and fingerprint line, which the
  instruction requires be copied into the PR body; lose it and the PR stops
  linking back to its triage row. (This is why simply prepending the block would
  have been wrong.)
- **tail** — the appended reproduce/verify block.

`_truncate_middle(text, limit, tail)` keeps `limit - tail` from the head and
`tail` from the end, and states how much of the middle it dropped.
`CONTEXT_TAIL_RESERVE_CHARS = 16000`, deliberately above `reproduce_tb_chars` so
a full block fits inside the reserve; `reproduce_tb_chars` drops
**40000 → 12000**, matching `_format_reproduce_feedback`'s own default.

**Tradeoff:** less traceback text per test. `_tail_tb` keeps each traceback's
*tail*, where the assertion lives, so the decisive part survives. Raising the
reserve is the knob if you want to trade differently.

## Tests

791 pass, 11 new. Verified against the pre-fix code — all three live context
sizes kept the fingerprint marker and dropped the reproduce block, which is the
exact asymmetry this changes. Covers the three live sizes as subtests, the
marker-survival invariant, the short-context no-op, and the degenerate
`tail > limit` case (which must not produce a negative head slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)