### PR TITLE
Clip a reproduce traceback from the middle, and budget the block as a whole

### DIFF
--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -197,22 +197,24 @@ class Config:
     # CLASSIFY_BAIL_ON_ENVIRONMENT=0 to investigate them anyway (the old
     # behaviour) if the label ever starts misfiring.
     classify_bail_on_environment: bool = True
-    # Per-traceback char budget when serge seeds the reproduced/verify failures
-    # into the fix prompt. The GPU run emits full assertion diffs (pytest -vv);
-    # the old 2000-char tail chopped the very generated strings the LLM needs to
-    # rewrite stale expected values. Raised to 40000 to pair with the verdict
-    # tool's traceback distiller (serge_verify_verdict.distill_failure): the
-    # distiller caps KB-scale intermediate tensors so a distilled traceback is
-    # ~20-30KB, and this budget keeps the whole of it — including the assert diff
-    # and the asserted actual output, which sit at the HEAD of the longrepr and a
-    # smaller tail-cut would drop (the owlvit/instructblip cases).
-    # Tunable via REPRODUCE_TB_CHARS.
-    # Per-traceback cap for the reproduce block. MUST stay below
-    # prompts.CONTEXT_TAIL_RESERVE_CHARS: this used to be 40000, exactly equal to
-    # MAX_CONTEXT_CHARS, so the block was allowed to claim the entire context
-    # budget on its own and was then appended after the report and truncated
-    # away. Aligned with _format_reproduce_feedback's own default.
-    reproduce_tb_chars: int = 12000
+    # Char budget for the reproduce/verify block **as a whole** when serge seeds
+    # the GPU failures into the fix prompt — NOT a per-traceback cap. The
+    # formatters show up to 5 tracebacks and divide this budget across the ones
+    # actually present (tasks._tb_budget), because what has to fit somewhere is
+    # the block, not one traceback:
+    #
+    #   * as a per-traceback cap of 40000 it produced a 121,417-char block
+    #     (job f50c5e85) against a 40,000-char context — the block was appended
+    #     past MAX_CONTEXT_CHARS and head-truncation deleted it outright (#103);
+    #   * dropping the same knob to 12000 kept the block (25,197 chars on job
+    #     d2d9c129) but cut each traceback to its last 12,000 chars, which for a
+    #     25,586-char longrepr is the --showlocals tensor dump and none of the
+    #     assertion diff. That job returned no_fix saying so.
+    #
+    # Sized to fit prompts.CONTEXT_TAIL_RESERVE_CHARS, so a full block survives
+    # context truncation. Tunable via REPRODUCE_BLOCK_CHARS (REPRODUCE_TB_CHARS
+    # is still read as a legacy alias).
+    reproduce_block_chars: int = 32000
     # Optional task-only completion-token cap. When unset, tasks use the
     # normal llm_max_tokens value.
     task_llm_max_tokens: Optional[int] = None
@@ -474,7 +476,9 @@ class Config:
             classify_bail_on_environment=_bool_env(
                 "CLASSIFY_BAIL_ON_ENVIRONMENT", True
             ),
-            reproduce_tb_chars=_int_env("REPRODUCE_TB_CHARS", 12000),
+            reproduce_block_chars=_int_env(
+                "REPRODUCE_BLOCK_CHARS", _int_env("REPRODUCE_TB_CHARS", 32000)
+            ),
             # Streaming on by default — the web UI's live token counter
             # and reasoning display rely on incremental SSE chunks. Set
             # LLM_STREAM=0 to fall back to the buffered REST path.

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -81,7 +81,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "verify_max_rounds",
     "classify_max_tokens",
     "classify_bail_on_environment",
-    "reproduce_tb_chars",
+    "reproduce_block_chars",
 )
 
 

--- a/reviewbot/prompts.py
+++ b/reviewbot/prompts.py
@@ -514,8 +514,10 @@ MAX_CONTEXT_CHARS = 40000
 # How much of the END of a task context is protected from truncation. The
 # appended GPU reproduce/verify block lives there and is the authoritative
 # evidence for the fix, so it must outrank the middle of the report. Sized above
-# `Config.reproduce_tb_chars` (12000) so a full block fits inside the reserve.
-CONTEXT_TAIL_RESERVE_CHARS = 16000
+# `Config.reproduce_block_chars` (32000) — which budgets the whole block, not one
+# traceback — so a full block fits inside the reserve however many tests failed.
+# The earlier 16000 only held for a single traceback; the formatters take five.
+CONTEXT_TAIL_RESERVE_CHARS = 34000
 
 
 TASK_SYSTEM_PROMPT_TEMPLATE = """You are an expert software engineer making a

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -1402,21 +1402,70 @@ def publish_task(
     )
 
 
-def _tail_tb(tb: Optional[str], max_chars: int) -> str:
-    """Keep the tail of a traceback (the assertion diff + captured output sit at
-    the end) up to ``max_chars``, marking the cut so the LLM knows it's partial."""
+# The smallest per-traceback slice worth sending. Below this a traceback is
+# noise in both directions, so we would rather show fewer tests in full.
+MIN_TB_CHARS = 6000
+# How much of the HEAD of each traceback is protected from the middle cut.
+# Sized from real reproduce artifacts (see ``_clip_tb``): the assertion summary
+# pytest prepends, the failing source line and the ``E`` block together run to
+# ~2.4k, so 4k keeps them whole with margin.
+TB_HEAD_KEEP_CHARS = 4000
+
+
+def _clip_tb(tb: Optional[str], max_chars: int) -> str:
+    """Clip a traceback to ``max_chars`` from the MIDDLE, keeping both ends.
+
+    A traceback carries the load-bearing ``E`` block at *either* end depending
+    on how pytest laid it out, so no single-ended cut can serve both shapes.
+    Measured on the 2026-08-31 reproduce artifacts:
+
+    * ``mm_grounding_dino`` — pytest prepends the assertion summary, so the
+      ``E`` block sits at offset 1,515 of 25,586 and 2,116 of 45,905: at the
+      **head**;
+    * ``cwm`` (36,497) and ``kimi_k25`` (117,073 / 118,454) — the test source
+      contains a huge inline ``Expectations({...})`` literal, pushing the ``E``
+      block to 404 and ~9,640 chars from the **end**.
+
+    The old tail-only cut kept the last ``max_chars`` and therefore deleted the
+    entire assertion diff, the ``expected_*`` literal and the actual-vs-expected
+    comparison for the first shape — everything the model needs to rewrite a
+    stale expectation, leaving only the ``--showlocals`` tensor dump. Job
+    ``d2d9c129`` returned ``no_fix`` saying exactly that, and was right to:
+    "the actual decoder logits ... is in the elided portion of the traceback,
+    so I cannot record a plausible, verified expectation."
+    """
     text = tb or ""
     if len(text) <= max_chars:
         return text
-    return "…(traceback truncated to last %d chars)…\n%s" % (
-        max_chars,
-        text[-max_chars:],
+    head_len = min(TB_HEAD_KEEP_CHARS, max_chars // 3)
+    tail_len = max_chars - head_len
+    omitted = len(text) - max_chars
+    return (
+        "%s\n…(%d chars omitted from the middle of the traceback; the end follows)…\n%s"
+        % (
+            text[:head_len],
+            omitted,
+            text[len(text) - tail_len :],
+        )
     )
 
 
-def _format_verify_feedback(result: TaskResult, max_chars: int = 12000) -> str:
+def _tb_budget(count: int, block_chars: int) -> int:
+    """Per-traceback slice of the whole-block budget.
+
+    ``block_chars`` bounds the reproduce/verify block as a whole, because that
+    is what has to fit inside ``prompts.CONTEXT_TAIL_RESERVE_CHARS``. The old
+    per-traceback cap could not: the formatters take up to 5 tracebacks, so a
+    12,000 cap allowed a 60,000-char block against a 16,000 reserve, and a
+    40,000 cap produced the 121,417-char block observed on job ``f50c5e85``.
+    """
+    return max(MIN_TB_CHARS, block_chars // max(1, count))
+
+
+def _format_verify_feedback(result: TaskResult, max_chars: int = 32000) -> str:
     """Markdown feedback for the next LLM round: the failures the previous
-    candidate's GPU verify still produced."""
+    candidate's GPU verify still produced. ``max_chars`` budgets the block as a
+    whole and is divided across the tracebacks it shows."""
     lines = [
         "## Your previous patch did NOT fix the tests (GPU verification)",
         "",
@@ -1426,10 +1475,12 @@ def _format_verify_feedback(result: TaskResult, max_chars: int = 12000) -> str:
         "repeat the same change; use the tracebacks to find the real cause.",
         "",
     ]
-    for nodeid, tb in list(result.verify_tracebacks.items())[:5]:
+    shown = list(result.verify_tracebacks.items())[:5]
+    per_tb = _tb_budget(len(shown), max_chars)
+    for nodeid, tb in shown:
         lines.append(f"### {nodeid}")
         lines.append("```")
-        lines.append(_tail_tb(tb, max_chars))
+        lines.append(_clip_tb(tb, per_tb))
         lines.append("```")
         lines.append("")
     return "\n".join(lines).rstrip()
@@ -1493,7 +1544,7 @@ def _environment_bail_message(
 def _format_reproduce_feedback(
     outcome: VerifyOutcome,
     classification: ClassifyResult,
-    max_chars: int = 12000,
+    max_chars: int = 32000,
 ) -> str:
     """Authoritative reproduction context seeded into the LLM prompt. Supersedes
     any inbound 'do not run the test suite' note: serge already ran the tests on
@@ -1537,8 +1588,10 @@ def _format_reproduce_feedback(
             "a change if you can point at concrete code that is actually at fault.",
             "",
         ]
-    for nodeid, tb in list(outcome.tracebacks.items())[:5]:
-        lines += [f"### {nodeid}", "```", _tail_tb(tb, max_chars), "```", ""]
+    shown = list(outcome.tracebacks.items())[:5]
+    per_tb = _tb_budget(len(shown), max_chars)
+    for nodeid, tb in shown:
+        lines += [f"### {nodeid}", "```", _clip_tb(tb, per_tb), "```", ""]
     return "\n".join(lines).rstrip()
 
 
@@ -1661,7 +1714,7 @@ def _maybe_reproduce_first(
     seeded = _with_verify_feedback(
         req,
         _format_reproduce_feedback(
-            outcome, classification, max_chars=cfg.reproduce_tb_chars
+            outcome, classification, max_chars=cfg.reproduce_block_chars
         ),
     )
     seeded = dataclasses.replace(seeded, reproduce_run_url=outcome.run_url)
@@ -1742,7 +1795,7 @@ def prepare_and_publish_candidate(
             )
             req_i = _with_verify_feedback(
                 candidate_req,
-                _format_verify_feedback(result, max_chars=cfg.reproduce_tb_chars),
+                _format_verify_feedback(result, max_chars=cfg.reproduce_block_chars),
             )
             continue
         return result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -179,7 +179,18 @@ class TruncateMiddleTests(unittest.TestCase):
         self.assertNotIn("B", out)
 
     def test_reserve_fits_a_full_reproduce_block(self) -> None:
-        # The whole point of the constant: a maximal reproduce block
-        # (Config.reproduce_tb_chars = 12000) must fit inside the reserve.
-        self.assertGreater(CONTEXT_TAIL_RESERVE_CHARS, 12_000)
+        # The whole point of the constant: a maximal reproduce block must fit
+        # inside the reserve. Assert it against the config field rather than a
+        # copied literal — the two drifted apart once already (the reserve was
+        # sized for one traceback while the formatters take five).
+        import dataclasses
+
+        from reviewbot.config import Config
+
+        block = next(
+            f.default
+            for f in dataclasses.fields(Config)
+            if f.name == "reproduce_block_chars"
+        )
+        self.assertGreaterEqual(CONTEXT_TAIL_RESERVE_CHARS, block)
         self.assertLess(CONTEXT_TAIL_RESERVE_CHARS, MAX_CONTEXT_CHARS)

--- a/tests/test_reproduce_first.py
+++ b/tests/test_reproduce_first.py
@@ -1,6 +1,7 @@
 import types
+import unittest
 
-from reviewbot import tasks
+from reviewbot import prompts, tasks
 from reviewbot.classify import (
     ENVIRONMENT_ISSUE,
     PRODUCT_ISSUE,
@@ -33,7 +34,7 @@ def _cfg(reproduce_first=True, bail_on_env=True):
         verify_poll_timeout=100,
         verify_poll_interval=0,
         classify_max_tokens=4096,
-        reproduce_tb_chars=12000,
+        reproduce_block_chars=32000,
     )
 
 
@@ -308,3 +309,76 @@ def test_decorate_body_no_gpu_section_without_footer():
     plan = tasks.TaskPlan(title="t", body="b", patch="p")
     req = types.SimpleNamespace(context="")
     assert "Verified on GPU" not in tasks._decorate_body(cfg, plan, req)
+
+
+class TracebackClipTests(unittest.TestCase):
+    """Regression cover for the two truncation bugs the 2026-08-31 reproduce
+    artifacts exposed. Both fixtures mirror a real longrepr layout: the
+    load-bearing ``E`` block sits at the HEAD in one shape and at the END in the
+    other, so a single-ended cut always deletes it for one of them."""
+
+    # mm_grounding_dino: pytest prepends the assertion summary, so everything
+    # the model needs is in the first ~2.4k and the rest is --showlocals noise.
+    HEAD_SHAPE = (
+        "AssertionError: Tensor-likes are not close!\n"
+        "Mismatched elements: 9 / 9 (100.0%)\n"
+        "        expected_logits = torch.tensor([[-5.1160, -0.2143]])\n"
+        ">       torch.testing.assert_close(outputs.logits[0, :3, :3], expected_logits)\n"
+        "E       AssertionError: Tensor-likes are not close!\n"
+    ) + "pixel_values = tensor([[0.2795, 0.3138]])\n" * 4000
+
+    # cwm / kimi_k25: a huge inline Expectations({...}) literal in the test
+    # source pushes the E block to within ~10k of the end.
+    TAIL_SHAPE = (
+        (
+            "self = <tests.models.kimi_k25.test_modeling_kimi_k25.KimiK25IntegrationTest>\n"
+            "    expectations = Expectations({('cuda', None): [\n"
+        )
+        + "        [0.123, 0.456, 0.789],\n" * 4000
+        + ("E       RuntimeError: index out of range in self\n")
+    )
+
+    def test_head_shape_keeps_the_assertion_diff(self) -> None:
+        out = tasks._clip_tb(self.HEAD_SHAPE, 12000)
+        self.assertLess(len(self.HEAD_SHAPE), 200_000)
+        self.assertIn("Tensor-likes are not close", out)
+        self.assertIn("expected_logits = torch.tensor", out)
+        self.assertIn("E       AssertionError", out)
+
+    def test_tail_shape_keeps_the_error_line(self) -> None:
+        out = tasks._clip_tb(self.TAIL_SHAPE, 12000)
+        self.assertIn("E       RuntimeError: index out of range in self", out)
+
+    def test_a_tail_only_cut_would_have_lost_the_head_shape(self) -> None:
+        """The bug this replaces: the old cut kept only ``text[-max_chars:]``."""
+        self.assertNotIn("expected_logits = torch.tensor", self.HEAD_SHAPE[-12000:])
+
+    def test_short_tracebacks_are_returned_whole(self) -> None:
+        self.assertEqual(tasks._clip_tb("short", 12000), "short")
+        self.assertEqual(tasks._clip_tb(None, 12000), "")
+
+    def test_clip_respects_the_budget(self) -> None:
+        out = tasks._clip_tb("x" * 50_000, 12000)
+        # The marker adds a bounded constant; the kept text is within budget.
+        self.assertLessEqual(len(out), 12000 + 200)
+
+    def test_budget_is_divided_across_the_tracebacks_present(self) -> None:
+        self.assertEqual(tasks._tb_budget(1, 32000), 32000)
+        self.assertEqual(tasks._tb_budget(2, 32000), 16000)
+        # Never below the floor, however many tests failed.
+        self.assertEqual(tasks._tb_budget(20, 32000), tasks.MIN_TB_CHARS)
+        self.assertEqual(tasks._tb_budget(0, 32000), 32000)
+
+    def test_reproduce_block_stays_within_the_context_reserve(self) -> None:
+        """A 5-traceback block used to be able to reach 5x the per-tb cap; the
+        block budget is what has to fit inside CONTEXT_TAIL_RESERVE_CHARS."""
+        outcome = VerifyOutcome(
+            verdict=REPRODUCED,
+            run_url="u",
+            detail="d",
+            tracebacks={f"t{i}": "y" * 200_000 for i in range(5)},
+        )
+        block = tasks._format_reproduce_feedback(
+            outcome, ClassifyResult(TEST_ISSUE, "r"), max_chars=32000
+        )
+        self.assertLessEqual(len(block), prompts.CONTEXT_TAIL_RESERVE_CHARS)

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -449,21 +449,21 @@ class RunnerConfigPassthroughTest(unittest.TestCase):
         )
         self.assertEqual(launcher.runner_config(fake)["classify_max_tokens"], 4096)
 
-    def test_reproduce_tb_chars_is_threaded_to_the_runner(self):
+    def test_reproduce_block_chars_is_threaded_to_the_runner(self):
         # The reproduce/verify traceback seed is built in the runner pod, so its
         # char budget must reach it (same failure class as classify_max_tokens).
         import types
 
         from reviewbot import launcher
 
-        self.assertIn("reproduce_tb_chars", launcher.RUNNER_CONFIG_FIELDS)
+        self.assertIn("reproduce_block_chars", launcher.RUNNER_CONFIG_FIELDS)
         fake = types.SimpleNamespace(
             **{
-                field: (12000 if field == "reproduce_tb_chars" else None)
+                field: (32000 if field == "reproduce_block_chars" else None)
                 for field in launcher.RUNNER_CONFIG_FIELDS
             }
         )
-        self.assertEqual(launcher.runner_config(fake)["reproduce_tb_chars"], 12000)
+        self.assertEqual(launcher.runner_config(fake)["reproduce_block_chars"], 32000)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -9,7 +9,7 @@ def _cfg(on_gpu: bool, rounds: int = 2, reproduce_first: bool = False):
         verify_max_rounds=rounds,
         verify_reproduce_first=reproduce_first,
         classify_max_tokens=4096,
-        reproduce_tb_chars=12000,
+        reproduce_block_chars=32000,
     )
 
 


### PR DESCRIPTION
Follow-up to #103, from the first nightly batch that ran on it.

#103 stopped the GPU reproduce block being deleted by context truncation — that part works, and the contexts in this batch were 6,625 / 15,303 / 27,874 / 28,607 chars, none truncated. But it also halved `reproduce_tb_chars` 40000 → 12000 without touching `_tail_tb`, which keeps `text[-max_chars:]`.

Job `d2d9c129` returned `no_fix` and said why:

> The reproduced GPU tracebacks are truncated to the last 12 000 characters and only show the model's `pred_boxes`, encoder outputs, and hidden states. The actual decoder `logits[0, :3, :3]` tensor — the value that must replace the stale expected logits — is in the elided portion of the traceback, so I cannot record a plausible, verified expectation.

It was right, and it was right to refuse rather than invent values.

## The measurement

Pulled the three `serge-verify-result` artifacts from that batch. The load-bearing `E` block sits at **either** end, depending on how pytest laid the longrepr out:

| traceback | length | `E` block at | tail-12k keeps it? |
| --- | --- | --- | --- |
| `mm_grounding_dino::test_inference_object_detection_head` | 25,586 | 1,515 | ❌ |
| `mm_grounding_dino::…_equivalence_cpu_gpu` | 45,905 | 2,116 | ❌ |
| `cwm::test_cwm_integration` | 36,497 | 36,093 | ✅ |
| `kimi_k25::test_model_logits` | 117,073 | 107,433 | ✅ |
| `kimi_k25::test_model_logits_batched` | 118,454 | 111,212 | ✅ |

Where pytest prepends the assertion summary, everything the model needs — `Tensor-likes are not close`, `Mismatched elements`, the `expected_logits` literal, the failing assert — is in the first ~2.4k and the remaining 90% is the `--showlocals` tensor dump. Where the test source carries a huge inline `Expectations({...})` literal, the `E` block is pushed to within ~10k of the end.

So **no single-ended cut can serve both shapes, at any size.**

## The changes

1. **`_tail_tb` → `_clip_tb`**, cutting the middle and keeping both ends — the same lesson #103 applied one level up to the context. Against the real artifacts it keeps the `E` block for **5 of 5** (was 3 of 5).

2. **`reproduce_tb_chars` → `reproduce_block_chars`, budgeting the block as a whole.** The old knob was a *per-traceback* cap, but what has to fit inside `CONTEXT_TAIL_RESERVE_CHARS` is the block, and both formatters take up to 5 tracebacks. At 40000 that allowed the 121,417-char block observed on job `f50c5e85`; at 12000 it still allowed 60,000 against a 16,000 reserve. Now 32000, divided across the tracebacks actually present, with a 6000 floor. `REPRODUCE_TB_CHARS` is still read as a legacy alias; prod sets neither.

3. **`CONTEXT_TAIL_RESERVE_CHARS` 16000 → 34000**, and `test_reserve_fits_a_full_reproduce_block` now asserts it against the config field rather than a copied literal — those two drifted apart once already (the reserve was sized for one traceback while the formatters take five).

## Verification

Against the three prod artifacts, not only fixtures:

- every rendered block lands at 32,719–33,032 chars, inside the 34,000 reserve;
- `d2d9c129`'s context would now be 3,410 + 33,032 = **36,444** chars — under `MAX_CONTEXT_CHARS`, so untruncated end to end;
- each of `Tensor-likes are not close`, `Mismatched elements`, `Greatest absolute difference` and the `expected_logits = torch.tensor` literal is present after clipping and absent from the old tail-12k slice.

798 tests pass, 9 new. The new tests use fixtures mirroring both real longrepr layouts, and one asserts the old tail-only cut would have lost the head shape, so the regression cannot come back silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)