### PR TITLE
Record the verify verdict when the gate PASSES, not only when it fails

### DIFF
--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -1143,8 +1143,14 @@ def _commit_changes(
         # back to its previous head so the follow-up commit is undone.
         gh.update_ref(owner, repo, f"heads/{head_branch}", commit_sha)
         emit_fn("log", f"Pushed commit {commit_sha[:8]} to {head_branch}")
+        # Recorded on BOTH branches below. A verdict that only survives failure
+        # is not a metric: every published job stored `verify_verdict=None`
+        # while the ones that produced no PR carried it, so the field read as
+        # "the gate never ran" exactly where it had run and passed.
+        verdict: Optional[str] = None
         if verify is not None:
             outcome = verify(parent_sha, commit_sha)
+            verdict = outcome.verdict
             if not outcome.is_fixed:
                 try:
                     gh.update_ref(
@@ -1174,6 +1180,7 @@ def _commit_changes(
             changed_files=changed_files,
             message=f"Pushed follow-up commit to PR #{req.pr_number}.",
             url=f"https://github.com/{owner}/{repo}/pull/{req.pr_number}",
+            verify_verdict=verdict,
         )
 
     # new_pr
@@ -1196,8 +1203,10 @@ def _commit_changes(
     # verdict, tear the branch down and return without a PR.
     verify_run_url: Optional[str] = None
     verify_runs: Optional[int] = None
+    verdict = None
     if verify is not None:
         outcome = verify(parent_sha, commit_sha)
+        verdict = outcome.verdict
         if not outcome.is_fixed:
             try:
                 gh.delete_ref(owner, repo, f"heads/{branch}")
@@ -1274,6 +1283,7 @@ def _commit_changes(
         changed_files=changed_files,
         message=f"Opened PR #{pr.get('number')}.",
         url=pr.get("html_url"),
+        verify_verdict=verdict,
     )
 
 

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -153,3 +153,145 @@ def test_with_verify_feedback_appends_context():
     out = tasks._with_verify_feedback(req, "FEEDBACK")
     assert out.context == "base ctx\n\nFEEDBACK"
     assert req.context == "base ctx"  # original untouched
+
+
+# ── The verdict must survive a PASSING gate, not only a failing one ──────────
+# Every published job in prod stored `verify_verdict=None` while the ones that
+# produced no PR carried it, so the field read as "the gate never ran" exactly
+# where it had run and passed. Both `_commit_changes` success paths dropped it.
+
+
+def _full_cfg():
+    """The real Config: `_commit_changes` renders a PR body, which the
+    SimpleNamespace `_cfg` above (built for the rounds loop) cannot satisfy."""
+    from tests.test_tasks import _make_cfg
+
+    return _make_cfg()
+
+
+class _VerdictGH:
+    """Minimal Git Data API fake for the two `_commit_changes` publish paths."""
+
+    def __init__(self):
+        self.created_pr = None
+        self.deleted = []
+        self.updated_refs = []
+
+    def get_ref_sha(self, owner, repo, ref):
+        return "parentsha"
+
+    def get_commit_tree_sha(self, owner, repo, commit_sha):
+        return "basetree"
+
+    def create_blob(self, owner, repo, content):
+        return "blob1"
+
+    def create_tree(self, owner, repo, base_tree, entries):
+        return "newtree"
+
+    def create_commit(self, owner, repo, *, message, tree_sha, parents):
+        return "newcommit"
+
+    def create_ref(self, owner, repo, ref, sha):
+        return {"ref": ref}
+
+    def update_ref(self, owner, repo, ref, sha, *, force=False):
+        self.updated_refs.append((ref, sha, force))
+        return {}
+
+    def delete_ref(self, owner, repo, ref):
+        self.deleted.append(ref)
+
+    def create_pull_request(self, owner, repo, *, title, head, base, body, draft=False):
+        self.created_pr = {"head": head}
+        return {"number": 99, "html_url": "u", "node_id": "n"}
+
+    def mark_pull_request_ready(self, node_id):
+        pass
+
+    def request_reviewers(self, owner, repo, number, reviewers):
+        return list(reviewers)
+
+
+def _commit(mode, verdict, monkeypatch):
+    from reviewbot.clone_cache import FileChange
+
+    monkeypatch.setattr(
+        tasks, "post_task_pr_created_notification", lambda **_k: None, raising=False
+    )
+    gh = _VerdictGH()
+    req = tasks.TaskRequest(
+        owner="acme",
+        repo="widget",
+        base_ref="main",
+        instruction="fix",
+        context="",
+        mode=mode,
+        pr_number=7 if mode == "existing_pr" else None,
+        head_branch="serge/fix-old" if mode == "existing_pr" else None,
+    )
+    result = tasks._commit_changes(
+        _full_cfg(),
+        gh,
+        req,
+        changes=[FileChange(path="a.txt", status="M", content=b"x", mode="100644")],
+        plan=tasks.TaskPlan(title="t", body="b", patch="p"),
+        job_id="job12345",
+        emit_fn=lambda *_a: None,
+        verify=lambda parent, candidate: verify.VerifyOutcome(verdict=verdict),
+    )
+    return result, gh
+
+
+def test_new_pr_records_the_verdict_that_let_it_publish(monkeypatch):
+    result, gh = _commit("new_pr", verify.FIXED, monkeypatch)
+    assert gh.created_pr is not None, "a fixed verdict must still open the PR"
+    assert result.pr_number == 99
+    assert result.verify_verdict == "fixed"
+    assert result.to_json()["verify_verdict"] == "fixed"
+
+
+def test_existing_pr_follow_up_records_the_verdict(monkeypatch):
+    result, gh = _commit("existing_pr", verify.FIXED, monkeypatch)
+    assert result.pr_number == 7
+    assert result.verify_verdict == "fixed"
+
+
+def test_a_failing_gate_still_records_its_verdict(monkeypatch):
+    result, gh = _commit("new_pr", verify.NOT_FIXED, monkeypatch)
+    assert gh.created_pr is None
+    assert result.no_change
+    assert result.verify_verdict == "not_fixed"
+
+
+def test_no_gate_leaves_the_verdict_unset(monkeypatch):
+    """`None` must keep meaning "the gate did not run" — that is the only way
+    to tell a skipped gate from a passing one."""
+    from reviewbot.clone_cache import FileChange
+
+    monkeypatch.setattr(
+        tasks, "post_task_pr_created_notification", lambda **_k: None, raising=False
+    )
+    gh = _VerdictGH()
+    req = tasks.TaskRequest(
+        owner="a", repo="b", base_ref="main", instruction="i", context="", mode="new_pr"
+    )
+    result = tasks._commit_changes(
+        _full_cfg(),
+        gh,
+        req,
+        changes=[FileChange(path="a.txt", status="M", content=b"x", mode="100644")],
+        plan=tasks.TaskPlan(title="t", body="b", patch="p"),
+        job_id="job12345",
+        emit_fn=lambda *_a: None,
+        verify=None,
+    )
+    assert result.verify_verdict is None
+
+
+def test_recording_fixed_does_not_trigger_a_retry_round():
+    """The rounds loop keys on `result.verify_verdict`, so populating it on the
+    success path could have made every published job retry. It cannot: `fixed`
+    is not in `_RETRYABLE`."""
+    assert not verify.should_retry(verify.FIXED)
+    assert not verify.should_retry(verify.ALREADY_PASSING)


### PR DESCRIPTION
`verify_verdict` was set on both `_commit_changes` **failure** returns and on **neither** success return, so it survived exactly where no PR came out of it.

In prod every published job stored `verify_verdict=None` — `1ecc4fe0`, `42ed30c8`, `f50c5e85` — while the jobs that produced no PR carried theirs:

```
1ecc4fe0  published #48429   verify=None
9a898563  no_fix             verify=already_passing
9f20cf8b  no_fix             verify=not_fixed
```

So the field read as *"the GPU gate never ran"* precisely where it had run and passed. That matters beyond tidiness: it is the metric the [ITF quick-wins plan](https://github.com/huggingface/transformers-ci-playbooks/blob/main/docs/plans/serge-itf-quick-wins-2026-08-26.md) nominated as **the** outcome measure for judging #103/#104, and it was missing on the path that produces the output we actually care about.

## The change

Both success paths now carry the verdict that let them publish — the `new_pr` return after `create_pull_request`, and the `existing_pr` follow-up return.

`None` keeps its meaning: **the gate did not run**. That is the only way to tell a skipped gate from a passing one, and there is a test pinning it.

## One coupling worth naming

Populating this field on success could have been a live bug rather than a fix. `_run_task_rounds` decides whether to re-prompt from:

```python
if attempt < rounds and should_retry(result.verify_verdict or ""):
```

Before this change that expression could never see a `fixed` verdict, because the success path never set one. It is safe only because `_RETRYABLE` is `{not_fixed, broke_others}` and excludes `fixed` and `already_passing` — otherwise every published job would now retry. That is pinned by a test rather than left as a reader's exercise.

## Tests

803 pass, 5 new, exercising `_commit_changes` directly through both publish paths with a fake gate. Both success-path changes were mutation-checked: dropping either one turns a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)