### PR TITLE
Reproduce a follow-up at its PR head, and stop re-asking a defect that repeats

### DIFF
--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -972,6 +972,46 @@ def _final_recovery_message(chat: ChatResult) -> str:
     )
 
 
+def _salvage_decision(
+    defect: Optional[str], last_defect: Optional[str], attempts: int
+) -> str:
+    """Whether to re-ask for a defective final answer: ``"reask"``,
+    ``"repeated"`` (the recovery already failed on this same shape) or
+    ``"stop"``.
+
+    One function because both salvage sites — the normal no-tool-calls turn and
+    the forced final turn after a guard trip — need the identical rule, and the
+    forced one is where the expensive case actually happens.
+
+    Re-asking is worth one attempt: `9f20cf8b` returned an empty forced-final
+    answer and recovery 1/2 produced the JSON. It is *not* worth a second
+    attempt at the same shape: `36798024` and `d0dca820` each spent both
+    re-asks going empty -> empty -> empty, ~39.5k input tokens apiece for
+    ~75-100 output tokens of nothing, and neither recovered. A recovery that
+    returns the same defect has demonstrably not worked, so the signal to stop
+    is repetition, not an attempt count.
+    """
+    if defect is None:
+        return "stop"
+    if defect == last_defect:
+        return "repeated"
+    if attempts >= _MAX_TRUNCATION_RETRIES:
+        return "stop"
+    return "reask"
+
+
+def _emit_salvage_giveup(
+    emit: Optional[Callable[[str, str], None]], defect: str, attempts: int
+) -> None:
+    if emit is None:
+        return
+    emit(
+        "log",
+        f"Final answer was {_DEFECT_LABELS.get(defect, defect)} again after "
+        f"{attempts} re-ask(s); the recovery is not working, not re-asking.",
+    )
+
+
 def _emit_final_salvage(
     emit: Optional[Callable[[str, str], None]], chat: ChatResult, attempt: int
 ) -> None:
@@ -1067,6 +1107,9 @@ def _run_agentic_loop(
     blind_tool_turns = 0
     validation_retries = 0
     truncation_retries = 0
+    # The defect the last re-ask was issued for. A re-ask that produces the same
+    # shape again has demonstrably not worked; see the loop below.
+    last_defect: Optional[str] = None
 
     def _finalize(chat: ChatResult) -> tuple[ChatResult, "_AggregateMetrics"]:
         """Attach the session's browse/retry record to the metrics on the way
@@ -1177,11 +1220,13 @@ def _run_agentic_loop(
             # the provider truncates a huge-context stream). Re-ask for the JSON
             # only, tool-less and low-reasoning, instead of returning content
             # that just fails the parse.
-            if (
-                _needs_final_salvage(chat)
-                and truncation_retries < _MAX_TRUNCATION_RETRIES
-            ):
+            defect = _final_answer_defect(chat)
+            decision = _salvage_decision(defect, last_defect, truncation_retries)
+            if decision == "repeated":
+                _emit_salvage_giveup(emit, defect or "", truncation_retries)
+            elif decision == "reask":
                 truncation_retries += 1
+                last_defect = defect
                 _emit_final_salvage(emit, chat, truncation_retries)
                 messages.append({"role": "assistant", "content": chat.content or None})
                 messages.append(
@@ -1348,8 +1393,15 @@ def _run_agentic_loop(
         # to die on: an empty completion (finish_reason=None) went straight to
         # the parser and surfaced as "LLM returned unparseable output". Re-ask
         # for the JSON only instead (bounded by _MAX_TRUNCATION_RETRIES).
-        if _needs_final_salvage(chat) and truncation_retries < _MAX_TRUNCATION_RETRIES:
+        defect = _final_answer_defect(chat)
+        decision = _salvage_decision(defect, last_defect, truncation_retries)
+        if decision == "repeated":
+            # This is the site the expensive case actually hits: both measured
+            # jobs were already guard-terminated before this turn.
+            _emit_salvage_giveup(emit, defect or "", truncation_retries)
+        elif decision == "reask":
             truncation_retries += 1
+            last_defect = defect
             _emit_final_salvage(emit, chat, truncation_retries)
             messages.append({"role": "assistant", "content": chat.content or None})
             messages.append({"role": "user", "content": _final_recovery_message(chat)})

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -1658,10 +1658,30 @@ def _maybe_reproduce_first(
     if not node_ids:
         return None, req  # nothing to reproduce → investigate as before
 
+    # Which commit to reproduce AT. For a new PR that is the base branch, but
+    # for a follow-up on serge's own existing PR the work already lives on that
+    # PR's head — reproducing at `main` asks "is this still broken on main?",
+    # which stays true until the fix PR merges, and answers `reproduced` on a
+    # branch that already fixes it.
+    #
+    # That is the stale-group burn, measured: the nightly re-dispatched PR
+    # #48414's group on two consecutive nights (`f31aa5d8`, then `9a898563`),
+    # each ran a full session — 43 and 60 turns, ~2.5M input tokens between them
+    # — and each ended `verify_verdict=already_passing`, because the end gate
+    # *does* use the PR head as its baseline. The two gates disagreed about what
+    # "the baseline" is, and the expensive one was wrong.
+    reproduce_ref = (
+        f"heads/{req.head_branch}"
+        if req.mode == "existing_pr" and req.head_branch
+        else f"heads/{req.base_ref}"
+    )
     try:
-        base_sha = gh.get_ref_sha(req.owner, req.repo, f"heads/{req.base_ref}")
+        base_sha = gh.get_ref_sha(req.owner, req.repo, reproduce_ref)
     except Exception as exc:  # noqa: BLE001 — can't resolve base → fail open
-        emit("log", f"GPU reproduce: could not resolve base ref ({exc}); proceeding.")
+        emit(
+            "log",
+            f"GPU reproduce: could not resolve {reproduce_ref} ({exc}); proceeding.",
+        )
         return None, req
 
     outcome = run_gpu_reproduce(
@@ -1681,7 +1701,15 @@ def _maybe_reproduce_first(
     )
 
     if outcome.verdict == NOT_REPRODUCED:
-        emit("log", "GPU reproduce: not reproducible — skipping group.")
+        if req.mode == "existing_pr" and req.head_branch:
+            emit(
+                "log",
+                f"GPU reproduce: the targeted test(s) already PASS on "
+                f"{req.head_branch} — the open PR already fixes this group. "
+                "Nothing to add; skipping without spending an LLM session.",
+            )
+        else:
+            emit("log", "GPU reproduce: not reproducible — skipping group.")
         return (
             TaskResult(
                 mode=req.mode,

--- a/tests/test_reproduce_first.py
+++ b/tests/test_reproduce_first.py
@@ -382,3 +382,88 @@ class TracebackClipTests(unittest.TestCase):
             outcome, ClassifyResult(TEST_ISSUE, "r"), max_chars=32000
         )
         self.assertLessEqual(len(block), prompts.CONTEXT_TAIL_RESERVE_CHARS)
+
+
+class ReproduceRefForFollowUpTests(unittest.TestCase):
+    """Which commit reproduce-first runs AT.
+
+    The stale-group burn: the nightly re-dispatched PR #48414's group on two
+    consecutive nights (`f31aa5d8`, then `9a898563`), each ran a full session
+    — 43 and 60 turns, ~2.5M input tokens between them — and each ended
+    `verify_verdict=already_passing`. Reproduce-first asked "is this still
+    broken on main?", which stays true until the fix PR merges, while the end
+    verify gate used the PR head. The two gates disagreed about the baseline
+    and the expensive one was wrong.
+    """
+
+    def _gh(self, refs):
+        asked = []
+
+        class _GH:
+            def get_ref_sha(self, owner, repo, ref):
+                asked.append(ref)
+                return refs[ref]
+
+        return _GH(), asked
+
+    def _req(self, **kw):
+        base = dict(
+            owner="huggingface",
+            repo="transformers",
+            base_ref="main",
+            instruction="fix",
+            context=CTX,
+            mode="new_pr",
+        )
+        base.update(kw)
+        return tasks.TaskRequest(**base)
+
+    def _run(self, req, verdict):
+        gh, asked = self._gh(
+            {"heads/main": "mainsha", "heads/serge/fix/itf-abc": "prheadsha"}
+        )
+        seen = {}
+
+        def fake_reproduce(_gh, **kw):
+            seen.update(kw)
+            return VerifyOutcome(
+                verdict=verdict, run_url="u", detail="d", tracebacks={"t": "tb"}
+            )
+
+        orig = tasks.run_gpu_reproduce
+        tasks.run_gpu_reproduce = fake_reproduce
+        try:
+            bail, out = tasks._maybe_reproduce_first(
+                _cfg(), gh, req, "job1", lambda *_a: None
+            )
+        finally:
+            tasks.run_gpu_reproduce = orig
+        return bail, out, asked, seen
+
+    def test_a_follow_up_reproduces_at_the_pr_head(self) -> None:
+        req = self._req(
+            mode="existing_pr", pr_number=48414, head_branch="serge/fix/itf-abc"
+        )
+        _bail, _out, asked, seen = self._run(req, REPRODUCED)
+        self.assertEqual(asked, ["heads/serge/fix/itf-abc"])
+        self.assertEqual(seen["base_sha"], "prheadsha")
+
+    def test_a_new_pr_still_reproduces_at_the_base_branch(self) -> None:
+        _bail, _out, asked, seen = self._run(self._req(), REPRODUCED)
+        self.assertEqual(asked, ["heads/main"])
+        self.assertEqual(seen["base_sha"], "mainsha")
+
+    def test_a_follow_up_whose_pr_already_passes_costs_no_llm(self) -> None:
+        req = self._req(
+            mode="existing_pr", pr_number=48414, head_branch="serge/fix/itf-abc"
+        )
+        bail, _out, _asked, _seen = self._run(req, NOT_REPRODUCED)
+        self.assertIsNotNone(bail)
+        self.assertTrue(bail.no_change)
+        self.assertEqual(bail.pr_number, 48414)
+        self.assertEqual(bail.verify_verdict, NOT_REPRODUCED)
+
+    def test_an_existing_pr_with_no_head_branch_falls_back_to_base(self) -> None:
+        req = self._req(mode="existing_pr", pr_number=1)
+        _bail, _out, asked, _seen = self._run(req, REPRODUCED)
+        self.assertEqual(asked, ["heads/main"])

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -19,6 +19,7 @@ from reviewbot.reviewer import (
     _final_recovery_message,
     _is_model_markup_only,
     _needs_final_salvage,
+    _salvage_decision,
     _extract_json,
     _REVIEW_JSON_KEYS,
     _merge_chunk_event,
@@ -923,10 +924,13 @@ class TruncationRecoveryTests(unittest.TestCase):
             )
         )
 
-    def test_truncation_recovery_is_bounded(self) -> None:
+    def test_recovery_stops_when_the_same_defect_comes_back(self) -> None:
         cfg = _CfgStub()
-        # Always truncated: recovery must give up after _MAX_TRUNCATION_RETRIES
-        # and return the last answer rather than loop forever.
+        # An unchanging defect means the recovery prompt is not working, so the
+        # second re-ask cannot help and costs another whole conversation.
+        # Measured on the task path: `36798024` and `d0dca820` each spent both
+        # re-asks going empty -> empty -> empty for ~39.5k input tokens apiece
+        # and neither recovered.
         always_trunc = ChatResult(
             content='{"patch": "nope',
             usage={"prompt_tokens": 10, "completion_tokens": 16384},
@@ -939,9 +943,65 @@ class TruncationRecoveryTests(unittest.TestCase):
             cfg=cfg,  # type: ignore[arg-type]
             tool_env=None,
         )
-        # Initial answer + _MAX_TRUNCATION_RETRIES recovery attempts.
-        self.assertEqual(len(llm.calls), 1 + _MAX_TRUNCATION_RETRIES)
+        # Initial answer + exactly ONE re-ask, not _MAX_TRUNCATION_RETRIES.
+        self.assertEqual(len(llm.calls), 2)
         self.assertEqual(chat.finish_reason, "length")
+
+    def test_a_different_defect_still_earns_another_attempt(self) -> None:
+        """Stopping is keyed on repetition, not an attempt count: a reply that
+        comes back in a *different* unusable shape means the model did respond
+        to the correction, so the remaining budget is still worth spending."""
+        cfg = _CfgStub()
+        truncated = ChatResult(
+            content='{"patch": "nope',
+            usage={"prompt_tokens": 10, "completion_tokens": 16384},
+            finish_reason="length",
+        )
+        empty = ChatResult(content="", usage={"prompt_tokens": 10}, finish_reason=None)
+        good = ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 10},
+            finish_reason="stop",
+        )
+        llm = _FakeLLM([truncated, empty, good])
+        chat, _ = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "go"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        self.assertEqual(len(llm.calls), 3)
+        self.assertEqual(chat.finish_reason, "stop")
+
+    def test_one_re_ask_that_works_is_still_made(self) -> None:
+        """`9f20cf8b` returned an empty forced-final answer and recovery 1/2
+        produced the JSON — the first attempt must not be cut."""
+        cfg = _CfgStub()
+        empty = ChatResult(content="", usage={"prompt_tokens": 10}, finish_reason=None)
+        good = ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 10},
+            finish_reason="stop",
+        )
+        llm = _FakeLLM([empty, good])
+        chat, _ = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "go"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        self.assertEqual(len(llm.calls), 2)
+        self.assertEqual(chat.content, '{"summary": "ok", "comments": []}')
+
+    def test_salvage_decision_rule(self) -> None:
+        self.assertEqual(_salvage_decision("empty", None, 0), "reask")
+        self.assertEqual(_salvage_decision("empty", "empty", 1), "repeated")
+        self.assertEqual(_salvage_decision("truncated", "empty", 1), "reask")
+        self.assertEqual(_salvage_decision(None, None, 0), "stop")
+        # Still bounded when the shape keeps changing.
+        self.assertEqual(
+            _salvage_decision("markup", "empty", _MAX_TRUNCATION_RETRIES), "stop"
+        )
 
 
 class LeakedTextToolCallLoopTests(unittest.TestCase):


### PR DESCRIPTION
Two independent wastes on the task path, both measured.

## 1. Stale groups — the expensive one

`_maybe_reproduce_first` always resolved the **base branch**:

```python
base_sha = gh.get_ref_sha(req.owner, req.repo, f"heads/{req.base_ref}")
```

So a follow-up on serge's *own* open PR asked *"is this still broken on `main`?"* — which stays true until the fix PR merges. It answered `reproduced` on a branch that already fixes the group, and let a full LLM session run.

Meanwhile the **end** verify gate uses the PR head as its baseline and correctly returned `already_passing`. The two gates disagreed about what "the baseline" is, and the expensive one was wrong.

Measured: the nightly re-dispatched PR #48414's group on two consecutive nights.

| job | night | turns | input tokens | verdict |
| --- | --- | --- | --- | --- |
| `f31aa5d8` | 08-30 | 43 | 1,079,373 | `already_passing` |
| `9a898563` | 08-31 | 60 | 1,488,547 | `already_passing` |

~2.5M input tokens to rediscover twice that an existing PR already works.

A follow-up now reproduces at `head_branch`, so a PR that already fixes its group bails with **zero LLM turns** and says why. `new_pr` is unchanged, and an `existing_pr` with no `head_branch` still falls back to base.

## 2. Futile re-asks

Both salvage sites re-asked up to `_MAX_TRUNCATION_RETRIES` regardless of whether the re-ask changed anything. `36798024` and `d0dca820` each spent both attempts going `empty → empty → empty`, ~39.5k input tokens apiece for ~75–100 output tokens of nothing.

**The stop signal is repetition, not an attempt count.** A recovery that returns the *same* defect has demonstrably not worked; a *different* shape means the model did respond to the correction and the remaining budget is worth spending.

The first re-ask is always made. `9f20cf8b` hit exactly this shape and recovery 1/2 produced the JSON — capping attempts at 1 would have lost a real save. That job is why this is keyed on repetition rather than the simpler cap the plan originally proposed.

`_salvage_decision` is shared by both salvage sites so they cannot drift. The forced-final site is where the expensive case actually happens: both measured jobs were already guard-terminated before that turn.

## Tests

810 pass, 8 new. Both changes mutation-checked.

`test_truncation_recovery_is_bounded` encoded the old policy and correctly went red — it is rewritten to the new contract rather than deleted, and joined by cover for the different-defect case and the one-re-ask-that-works case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)