### PR TITLE
Keep the branch when the verify gate never ran, and bound the poll by the budget

### DIFF
--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -77,6 +77,9 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "verify_run_collateral",
     "verify_machine_type",
     "verify_poll_timeout",
+    # The runner needs its OWN deadline to bound the verify poll by the budget it
+    # has left; without it the poll outlives the process that is waiting on it.
+    "task_runner_timeout",
     "verify_poll_interval",
     "verify_max_rounds",
     "classify_max_tokens",

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -504,17 +504,30 @@ STOP_CHUNK_BUDGET = "chunk_input_token_cap"
 # the 10 tasks in the measured window — and it has to be countable, otherwise
 # "serge did nothing for 0 turns" and "serge never ran" look identical.
 STOP_NO_LLM_TURNS = "no_llm_turns"
+# The runner died before reporting anything, so what it spent is unknown. This
+# must NOT be recorded as `no_llm_turns`: that value means "the job legitimately
+# never reached the loop" and is a cheap outcome, and conflating the two makes an
+# expensive job look free. Job `b228e033` was killed by TASK_RUNNER_TIMEOUT while
+# polling for a GPU runner, after 28 LLM turns and 879,010 input tokens, and was
+# recorded as `no_llm_turns` with turns=0 — 1 of the 7 `no_llm_turns` rows in the
+# store was this, i.e. 14% of the "free bail" population was not free at all.
+STOP_RUNNER_LOST = "runner_lost"
 
 
-def no_llm_session_record() -> dict[str, Any]:
-    """A zeroed session for a job that never reached the agent loop."""
+def no_llm_session_record(stop_reason: str = STOP_NO_LLM_TURNS) -> dict[str, Any]:
+    """A zeroed session for a job that never reported one.
+
+    ``stop_reason`` distinguishes *why* the counters are zero: the default means
+    the job really did skip the agent loop, while :data:`STOP_RUNNER_LOST` means
+    the counters are unknown rather than zero.
+    """
     return {
         "turns": 0,
         "tool_calls": 0,
         "prompt_tokens": 0,
         "completion_tokens": 0,
         "seconds": 0.0,
-        "stop_reason": STOP_NO_LLM_TURNS,
+        "stop_reason": stop_reason,
         "repeats": 0,
         "distinct_paths": 0,
         "path_revisits": 0,

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import subprocess
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
@@ -50,6 +51,7 @@ from .verify import (
     REPRODUCED,
     VerifyOutcome,
     extract_verify_targets,
+    gate_did_not_run,
     run_gpu_reproduce,
     run_gpu_verify,
     should_retry,
@@ -986,6 +988,19 @@ def _decorate_body(
     return body
 
 
+def _verify_unjudged_message(outcome: VerifyOutcome, branch: str) -> str:
+    """What to report when the gate never ran. Names the branch, because that
+    branch is the only surviving artifact of the work and nothing else points
+    at it."""
+    where = f" ({outcome.run_url})" if outcome.run_url else ""
+    return (
+        f"A candidate patch was committed to `{branch}` but GPU verification "
+        f"could not run (`{outcome.verdict}`){where}, so it is UNVERIFIED and no "
+        "PR was opened. The branch is kept: re-run verification against it, or "
+        "delete it if the group has moved on."
+    )
+
+
 def _verify_failure_message(outcome: VerifyOutcome) -> str:
     """Human/next-run explanation when GPU verify does not confirm the fix."""
     reasons = {
@@ -1013,6 +1028,37 @@ def _verify_failure_message(outcome: VerifyOutcome) -> str:
     for nodeid, tb in list(outcome.tracebacks.items())[:5]:
         lines.append(f"\n### {nodeid}\n```\n{(tb or '')[-1500:]}\n```")
     return "\n".join(lines)
+
+
+# When the runner process started, so the verify poll can be bounded by the
+# budget the runner has LEFT rather than an absolute hour. `TASK_RUNNER_TIMEOUT`
+# is enforced from outside — webapp waits on the subprocess and kills it — so a
+# poll that outlives the runner is not a slow poll, it is a lost job: no code in
+# this process gets to run, and the branch is left with no PR and no verdict.
+#
+# Observed 2026-08-31 on job `b228e033`: LLM work finished 78 minutes into a
+# 120-minute budget, verify was dispatched, and the poll believed it had its
+# full 60 minutes when 42 remained. 5 of 79 serge fix branches (6%) are orphaned
+# patches with no PR, which is what this shape leaves behind.
+_PROCESS_START = time.monotonic()
+# Leave the runner room to open the PR and report after the poll gives up.
+_VERIFY_WINDDOWN_SECONDS = 180
+
+
+def effective_poll_timeout(
+    configured: int, runner_timeout: Optional[int], *, now: Optional[float] = None
+) -> int:
+    """The verify poll timeout, clamped to the runner's remaining budget.
+
+    Returns ``configured`` unchanged when there is no runner deadline (an
+    unbounded or locally-run task). Never returns less than 0; a caller that
+    gets 0 should treat the gate as unavailable rather than poll forever.
+    """
+    if not runner_timeout:
+        return configured
+    elapsed = (now if now is not None else time.monotonic()) - _PROCESS_START
+    remaining = runner_timeout - elapsed - _VERIFY_WINDDOWN_SECONDS
+    return max(0, int(min(configured, remaining)))
 
 
 def _make_verify_gate(
@@ -1048,7 +1094,9 @@ def _make_verify_gate(
             default_machine_type=cfg.verify_machine_type,
             run_collateral=cfg.verify_run_collateral,
             transformersci_ref=cfg.verify_transformersci_ref,
-            poll_timeout=cfg.verify_poll_timeout,
+            poll_timeout=effective_poll_timeout(
+                cfg.verify_poll_timeout, getattr(cfg, "task_runner_timeout", None)
+            ),
             poll_interval=cfg.verify_poll_interval,
             emit=emit_fn,
         )
@@ -1207,6 +1255,32 @@ def _commit_changes(
     if verify is not None:
         outcome = verify(parent_sha, commit_sha)
         verdict = outcome.verdict
+        if gate_did_not_run(verdict):
+            # The gate never judged this patch — no runner picked the job up, the
+            # dispatch failed, or no artifact came back. That says nothing about
+            # the candidate, so deleting the branch throws away work for a reason
+            # that is not about the work. KEEP it, and report it: the branch name
+            # travels in TaskResult.to_json(), so the triage reconciler can link
+            # it from the tracking issue and say verification could not run.
+            #
+            # No PR: an unverified patch must not land in the review queue looking
+            # like a verified one. 5 of 79 serge fix branches were orphaned this
+            # way before this existed — committed patches with no PR and no
+            # verdict, invisible unless someone listed the refs.
+            emit_fn(
+                "log",
+                f"GPU verify could not run ({verdict}); keeping branch {branch} "
+                "unverified and opening no PR.",
+            )
+            return TaskResult(
+                mode=req.mode,
+                no_change=True,
+                branch=branch,
+                commit_sha=commit_sha,
+                message=_verify_unjudged_message(outcome, branch),
+                verify_verdict=verdict,
+                verify_tracebacks=outcome.tracebacks,
+            )
         if not outcome.is_fixed:
             try:
                 gh.delete_ref(owner, repo, f"heads/{branch}")

--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -81,6 +81,19 @@ NO_RESULT = "no_result"
 # retried — another LLM turn can't change them.
 _RETRYABLE = frozenset({NOT_FIXED, BROKE_OTHERS})
 
+# Verdicts where the gate never adjudicated the patch: the workflow could not be
+# dispatched, no runner picked it up, or no artifact came back. These say nothing
+# about the candidate, so a caller must not treat them as a rejection — the patch
+# is unjudged, not bad. `error` is deliberately NOT here: that is the workflow
+# running and reporting something unverifiable (a skipped or missing test), which
+# IS a reason to refuse the patch.
+_GATE_DID_NOT_RUN = frozenset({NO_TARGETS, DISPATCH_FAILED, TIMEOUT, NO_RESULT})
+
+
+def gate_did_not_run(verdict: str) -> bool:
+    """True when the verify gate never reached a judgement about the patch."""
+    return verdict in _GATE_DID_NOT_RUN
+
 
 def should_retry(verdict: str) -> bool:
     return verdict in _RETRYABLE

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -78,6 +78,8 @@ from .reviewer import (
     _UnparseableLLMOutput,
     merge_session_records,
     no_llm_session_record,
+    STOP_NO_LLM_TURNS,
+    STOP_RUNNER_LOST,
     prepare_review,
     publish_review,
     run_followup,
@@ -893,7 +895,13 @@ def _session_with_outcome(job: Job) -> dict[str, Any]:
     ``published``. Freezing it here — the store's session write is first-wins —
     keeps the exported label stable, and it is the more honest reading anyway:
     the session ended when the loop did, not when someone clicked publish."""
-    session = job.session or no_llm_session_record()
+    # A missing session means the runner never reported. For an errored job that
+    # is a killed or crashed runner, whose spend is UNKNOWN — recording it as
+    # `no_llm_turns` (the cheap "never ran the loop" outcome) is wrong data, not
+    # missing data, and it is the metric this repo's own analysis reads.
+    session = job.session or no_llm_session_record(
+        STOP_RUNNER_LOST if job.status == "error" else STOP_NO_LLM_TURNS
+    )
     # Stamped onto the Job, not a copy: _persist_terminal runs again when a human
     # publishes a draft, and re-stamping there would move the label after all.
     session.setdefault("outcome", job.status)

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -397,3 +397,21 @@ def test_the_runner_is_told_its_own_deadline():
     from reviewbot import launcher
 
     assert "task_runner_timeout" in launcher.RUNNER_CONFIG_FIELDS
+
+
+# ── A killed runner must not be recorded as a free 0-turn bail ──────────────
+
+
+def test_runner_lost_is_distinct_from_never_running_the_loop():
+    from reviewbot.reviewer import (
+        STOP_NO_LLM_TURNS,
+        STOP_RUNNER_LOST,
+        no_llm_session_record,
+    )
+
+    assert STOP_RUNNER_LOST != STOP_NO_LLM_TURNS
+    assert no_llm_session_record()["stop_reason"] == STOP_NO_LLM_TURNS
+    assert no_llm_session_record(STOP_RUNNER_LOST)["stop_reason"] == STOP_RUNNER_LOST
+    # Counters stay zero either way; the stop_reason is what says whether zero
+    # means "spent nothing" or "we do not know what it spent".
+    assert no_llm_session_record(STOP_RUNNER_LOST)["turns"] == 0

--- a/tests/test_verify_retry.py
+++ b/tests/test_verify_retry.py
@@ -295,3 +295,105 @@ def test_recording_fixed_does_not_trigger_a_retry_round():
     is not in `_RETRYABLE`."""
     assert not verify.should_retry(verify.FIXED)
     assert not verify.should_retry(verify.ALREADY_PASSING)
+
+
+# ── A gate that never ran is not a rejection ────────────────────────────────
+# Job b228e033 (2026-08-31) committed a candidate, dispatched GPU verify, and
+# was killed by TASK_RUNNER_TIMEOUT while the run sat queued for a runner. No
+# code got to react, so the branch survived with no PR and no verdict. 5 of 79
+# serge fix branches were orphaned that way.
+
+
+def test_gate_did_not_run_covers_only_orchestration_verdicts():
+    for v in (
+        verify.TIMEOUT,
+        verify.NO_RESULT,
+        verify.DISPATCH_FAILED,
+        verify.NO_TARGETS,
+    ):
+        assert verify.gate_did_not_run(v), v
+    # `error` is the workflow RUNNING and reporting something unverifiable — a
+    # real reason to refuse the patch, not an infrastructure miss.
+    for v in (
+        verify.FIXED,
+        verify.NOT_FIXED,
+        verify.BROKE_OTHERS,
+        verify.ALREADY_PASSING,
+        verify.ERROR,
+    ):
+        assert not verify.gate_did_not_run(v), v
+
+
+def _commit_with_verdict(verdict, monkeypatch):
+    from reviewbot.clone_cache import FileChange
+
+    monkeypatch.setattr(
+        tasks, "post_task_pr_created_notification", lambda **_k: None, raising=False
+    )
+    gh = _VerdictGH()
+    req = tasks.TaskRequest(
+        owner="acme",
+        repo="widget",
+        base_ref="main",
+        instruction="fix",
+        context="",
+        mode="new_pr",
+    )
+    result = tasks._commit_changes(
+        _full_cfg(),
+        gh,
+        req,
+        changes=[FileChange(path="a.txt", status="M", content=b"x", mode="100644")],
+        plan=tasks.TaskPlan(title="t", body="b", patch="p"),
+        job_id="job12345",
+        emit_fn=lambda *_a: None,
+        verify=lambda parent, candidate: verify.VerifyOutcome(verdict=verdict),
+    )
+    return result, gh
+
+
+def test_an_unjudged_verdict_keeps_the_branch_and_opens_no_pr(monkeypatch):
+    result, gh = _commit_with_verdict(verify.TIMEOUT, monkeypatch)
+    assert gh.created_pr is None, "an unverified patch must not enter the review queue"
+    assert gh.deleted == [], "the branch is the only surviving artifact — keep it"
+    assert result.branch, "the branch name must travel so the issue can link it"
+    assert result.no_change
+    assert result.verify_verdict == verify.TIMEOUT
+    assert result.branch in result.message
+    assert "UNVERIFIED" in result.message
+
+
+def test_a_real_rejection_still_tears_the_branch_down(monkeypatch):
+    result, gh = _commit_with_verdict(verify.NOT_FIXED, monkeypatch)
+    assert gh.created_pr is None
+    assert gh.deleted, "a judged-bad patch should not leave a branch behind"
+    assert result.verify_verdict == verify.NOT_FIXED
+
+
+def test_error_is_a_rejection_not_an_infrastructure_miss(monkeypatch):
+    _result, gh = _commit_with_verdict(verify.ERROR, monkeypatch)
+    assert gh.deleted, "`error` means the workflow ran and reported it"
+
+
+def test_effective_poll_timeout_is_clamped_to_the_runner_budget():
+    # 78 minutes into a 120-minute budget, the poll believed it had 60.
+    t0 = tasks._PROCESS_START
+    out = tasks.effective_poll_timeout(3600, 7200, now=t0 + 78 * 60)
+    assert out == 7200 - 78 * 60 - tasks._VERIFY_WINDDOWN_SECONDS
+    assert out < 3600
+
+
+def test_effective_poll_timeout_passes_through_without_a_deadline():
+    assert tasks.effective_poll_timeout(3600, None) == 3600
+    assert tasks.effective_poll_timeout(3600, 0) == 3600
+
+
+def test_effective_poll_timeout_never_goes_negative():
+    t0 = tasks._PROCESS_START
+    assert tasks.effective_poll_timeout(3600, 7200, now=t0 + 10_000) == 0
+
+
+def test_the_runner_is_told_its_own_deadline():
+    from reviewbot import launcher
+
+    assert "task_runner_timeout" in launcher.RUNNER_CONFIG_FIELDS

--- a/tests/test_webapp_metrics.py
+++ b/tests/test_webapp_metrics.py
@@ -152,3 +152,49 @@ class WebappMetricsTests(unittest.TestCase):
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()
+
+
+class RunnerLostSessionTests(WebappMetricsTests):
+    """A runner killed before it reports leaves no session. Falling back to the
+    `no_llm_turns` record makes an expensive job look free: job `b228e033` was
+    killed by TASK_RUNNER_TIMEOUT after 28 LLM turns and 879,010 input tokens
+    and was recorded as `no_llm_turns` with turns=0. 1 of the 7 `no_llm_turns`
+    rows in the prod store was that, i.e. 14% of the "free bail" population."""
+
+    def _job(self, status, session=None):
+        j = self.webapp.Job(
+            id="j1",
+            user="u",
+            target_owner="acme",
+            target_repo="widget",
+            target_number=1,
+            trigger_comment="",
+            llm_provider="p",
+            llm_api_base="b",
+            llm_model="m",
+            created_at=0.0,
+            kind="task",
+        )
+        j.status = status
+        j.session = session
+        return j
+
+    def test_an_errored_job_with_no_session_is_runner_lost(self) -> None:
+        from reviewbot.reviewer import STOP_RUNNER_LOST
+
+        s = self.webapp._session_with_outcome(self._job("error"))
+        self.assertEqual(s["stop_reason"], STOP_RUNNER_LOST)
+        self.assertEqual(s["outcome"], "error")
+
+    def test_a_non_error_job_with_no_session_still_reads_no_llm_turns(self) -> None:
+        from reviewbot.reviewer import STOP_NO_LLM_TURNS
+
+        s = self.webapp._session_with_outcome(self._job("no_fix"))
+        self.assertEqual(s["stop_reason"], STOP_NO_LLM_TURNS)
+
+    def test_a_reported_session_is_never_overwritten(self) -> None:
+        s = self.webapp._session_with_outcome(
+            self._job("error", {"turns": 28, "stop_reason": "repeat_guard"})
+        )
+        self.assertEqual(s["turns"], 28)
+        self.assertEqual(s["stop_reason"], "repeat_guard")


### PR DESCRIPTION
Job `b228e033` committed a candidate for `deepseek_vl_hybrid`, dispatched GPU verify **78 minutes into its 120-minute budget**, and was killed by `TASK_RUNNER_TIMEOUT` while the run still sat `queued` for a GPU runner.

The patch survives on [`serge/fix/itf-71ca76cde2a9-b228e033`](https://github.com/huggingface/transformers/tree/serge/fix/itf-71ca76cde2a9-b228e033) with no PR, no verdict, and nothing pointing at it — and it is a good patch: a class-level `tearDown` calling `cleanup(torch_device, gc_collect=True)` plus dropping a contradictory `device_map="auto"`, with every expectation untouched.

**5 of 79 serge fix branches (6%) are orphaned this way** — committed patches invisible unless someone lists the refs:

```
6b0bc7da 2026-07-27  plbart            32 files  +350/-184
77767bd8 2026-07-31  dab_detr           1 file   +5/-0
3ad60fee 2026-07-24  qwen3_vl_moe      27 files  +1118/-1258
dec11ddf 2026-08-20  cwm (OOM)          1 file   +3/-0
67825ea3 2026-08-31  deepseek_vl_hybrid 1 file   +7/-9
```

Two independent causes, one fixed each.

## 1. The poll outlived the process waiting on it

`TASK_RUNNER_TIMEOUT` is enforced from **outside** the runner — `webapp` waits on the subprocess and kills it on `TimeoutExpired`. So a poll that runs past the runner's deadline is not a slow poll, it is a *lost job*: no code in the runner gets to react to anything.

`VERIFY_POLL_TIMEOUT` was an absolute 3600s, so a verify dispatched 78 minutes in believed it had 60 minutes when 42 remained:

| | |
| --- | --- |
| job started | 15:21 |
| verify dispatched | 16:39 |
| runner killed (`TASK_RUNNER_TIMEOUT=7200`) | **17:21** |
| poll would have given up (`VERIFY_POLL_TIMEOUT=3600`) | 17:39 |

The runner now receives `task_runner_timeout`, and `effective_poll_timeout` clamps the poll to the budget left minus a wind-down, so it gives up *inside* the process and there is room to report.

## 2. A gate that never ran was treated as a rejection

`is_fixed` is `verdict == FIXED`, so `timeout`, `no_result`, `dispatch_failed` and `no_targets` all took the teardown path and deleted the branch. **Those verdicts say nothing about the candidate** — the patch is unjudged, not bad.

They now keep the branch and return it in the `TaskResult`. That travels in `to_json()` and so reaches the triage reconciler through `GET /tasks/.../status`, which is what lets the tracking issue link the branch and say verification could not run.

**No PR is opened.** An unverified patch must not enter the review queue looking like a verified one.

`error` is deliberately **not** in the unjudged set: that is the workflow *running* and reporting something unverifiable (a skipped or missing test), which is a real reason to refuse the patch. There is a test pinning that distinction.

## Tests

830 pass, 8 new. Mutation-checked three ways — emptying the unjudged set, adding `error` to it, and unclamping the poll each turn tests red.

## Follow-up not in this PR

The triage side still has to *render* the linked branch in the tracking issue; this PR only makes the data available. And the 5 existing orphans are a manual decision — two of them (27 and 32 files) look like normalizer blowups that were probably right to abandon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)