### PR TITLE
Carry the expectation flag on the outcomes that open no PR

### DIFF
--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -998,17 +998,34 @@ def _decorate_body(
     return body
 
 
-def _verify_unjudged_message(outcome: VerifyOutcome, branch: str) -> str:
+def _verify_unjudged_message(
+    outcome: VerifyOutcome,
+    branch: str,
+    classification: Optional[PatchClassification] = None,
+) -> str:
     """What to report when the gate never ran. Names the branch, because that
     branch is the only surviving artifact of the work and nothing else points
-    at it."""
+    at it.
+
+    Carries the expectation warning too. This message becomes the Reason cell of
+    the triage recap, which then invites a human to "re-run verification against
+    it" — and for a patch that rewrote its own assertion, that later verdict will
+    come back `fixed` and mean nothing. Whoever picks the branch up has to be
+    told before they read the result, not after."""
     where = f" ({outcome.run_url})" if outcome.run_url else ""
-    return (
+    msg = (
         f"A candidate patch was committed to `{branch}` but GPU verification "
         f"could not run (`{outcome.verdict}`){where}, so it is UNVERIFIED and no "
         "PR was opened. The branch is kept: re-run verification against it, or "
         "delete it if the group has moved on."
     )
+    if classification is not None and classification.expectation_only:
+        msg += (
+            " CAUTION: " + classification.reason() + " Re-running the gate on it "
+            "cannot confirm it — the tests would be re-run after the patch "
+            "rewrote what they assert, so they pass by construction."
+        )
+    return msg
 
 
 def _verify_failure_message(outcome: VerifyOutcome) -> str:
@@ -1262,6 +1279,8 @@ def _commit_changes(
                     message=_verify_failure_message(outcome),
                     verify_verdict=outcome.verdict,
                     verify_tracebacks=outcome.tracebacks,
+                    expectation_only=classification.expectation_only,
+                    expectation_note=classification.reason(),
                 )
         return TaskResult(
             mode=req.mode,
@@ -1322,9 +1341,17 @@ def _commit_changes(
                 no_change=True,
                 branch=branch,
                 commit_sha=commit_sha,
-                message=_verify_unjudged_message(outcome, branch),
+                message=_verify_unjudged_message(outcome, branch, classification),
                 verify_verdict=verdict,
                 verify_tracebacks=outcome.tracebacks,
+                # The branch survives and the recap invites someone to finish it,
+                # so this is the ONE outcome where the flag matters most: whoever
+                # picks the branch up has to be told the patch rewrote its own
+                # assertion, or they will read a later `fixed` as evidence.
+                # Observed 2026-09-01 on job 9a266db2, whose kept patch rewrote
+                # EXPECTED_TEXT_COMPLETION and was recorded expectation_only=False.
+                expectation_only=classification.expectation_only,
+                expectation_note=classification.reason(),
             )
         if not outcome.is_fixed:
             try:
@@ -1339,6 +1366,8 @@ def _commit_changes(
                 message=_verify_failure_message(outcome),
                 verify_verdict=outcome.verdict,
                 verify_tracebacks=outcome.tracebacks,
+                expectation_only=classification.expectation_only,
+                expectation_note=classification.reason(),
             )
         verify_run_url = outcome.run_url
         verify_runs = (outcome.result or {}).get("runs")

--- a/tests/test_expectation_guard.py
+++ b/tests/test_expectation_guard.py
@@ -357,3 +357,68 @@ class TaskResultTests(unittest.TestCase):
         from reviewbot.tasks import TaskResult
 
         self.assertFalse(TaskResult(mode="new_pr").to_json()["expectation_only"])
+
+
+class UnjudgedOutcomeTests(unittest.TestCase):
+    """The flag has to reach the outcomes that do NOT publish a PR.
+
+    serge#111 wired `expectation_only` into the two success returns of
+    `_commit_changes` only. The 2026-09-01 nightly then kept a branch for job
+    `9a266db2` whose patch rewrote `EXPECTED_TEXT_COMPLETION`, and the stored
+    result said `expectation_only=False` — while the triage recap invited a
+    human to "re-run verification against it". That later verdict would come
+    back `fixed` and mean nothing.
+
+    The kept-branch path is the one that matters most, because the branch
+    survives and someone is being asked to act on it.
+    """
+
+    BRANCH = "serge/fix/itf-4a72b9af302d-9a266db2"
+
+    def _unjudged(self, verdict="timeout"):
+        # NB: not `_outcome` — unittest.TestCase already owns that attribute.
+        from reviewbot.verify import VerifyOutcome
+
+        return VerifyOutcome(verdict=verdict, run_url="https://example/run/1")
+
+    def test_the_kept_branch_message_warns_about_the_rewrite(self):
+        from reviewbot.tasks import _verify_unjudged_message
+
+        msg = _verify_unjudged_message(
+            self._unjudged(), self.BRANCH, classify_patch(PR_48437)
+        )
+        self.assertIn("CAUTION", msg)
+        self.assertIn("pass by construction", msg)
+        # The original guidance must survive alongside the warning.
+        self.assertIn("The branch is kept", msg)
+        self.assertIn(self.BRANCH, msg)
+
+    def test_a_real_fix_gets_no_caution(self):
+        from reviewbot.tasks import _verify_unjudged_message
+
+        msg = _verify_unjudged_message(
+            self._unjudged(), self.BRANCH, classify_patch(PR_48440)
+        )
+        self.assertNotIn("CAUTION", msg)
+        self.assertIn("The branch is kept", msg)
+
+    def test_no_classification_keeps_the_old_message(self):
+        """Callers that never classified must be unaffected."""
+        from reviewbot.tasks import _verify_unjudged_message
+
+        msg = _verify_unjudged_message(self._unjudged(), self.BRANCH)
+        self.assertNotIn("CAUTION", msg)
+
+    def test_every_committed_patch_outcome_sets_the_flag(self):
+        """A guard against re-introducing the gap: each `return TaskResult(` in
+        `_commit_changes` that follows a commit must carry the flag."""
+        import inspect
+
+        from reviewbot import tasks
+
+        src = inspect.getsource(tasks._commit_changes)
+        self.assertEqual(
+            src.count("return TaskResult("),
+            src.count("expectation_only=classification.expectation_only"),
+            "a _commit_changes return path is missing expectation_only",
+        )


### PR DESCRIPTION
## What

#111 wired `expectation_only` into the two **success** returns of `_commit_changes` and nowhere else. So the flag was set exactly where a PR body gets written, and missing everywhere a patch is committed **without** one.

The 2026-09-01 nightly showed why that is the wrong half.

Job `9a266db2` timed out waiting for a GPU runner, so #110 kept its branch and opened no PR. Its stored result said **`expectation_only=False`** — for a patch whose entire content was this:

```diff
-        EXPECTED_TEXT_COMPLETION = "Gravity is the force that pulls objects toward the center of the Earth. …"
+        EXPECTED_TEXT_COMPLETION = [
+            "Gravity is the force that pulls objects toward each other. …"
+        ]
```

`expectation_guard.classify_patch` says `expectation_only=True` on that diff. The triage recap then linked the branch under the words *"re-run verification against it"*. Anyone following that instruction gets **`fixed`** — because the gate re-runs the assertion the patch rewrote. (For the record: I re-ran it while reading the nightly, got `fixed`, and briefly concluded a working fix had been thrown away.)

## The fix

- Sets the flag on **all five** committed-patch outcomes: `existing_pr` rollback, kept-unjudged branch, deleted-after-failed-verify, and the two success paths.
- Puts the warning **where a human reads it**. `_verify_unjudged_message` becomes the Reason cell of the triage recap, so it now appends:

  > CAUTION: This patch changes only expected values in test files — the assertions were rewritten, not the code under test. Re-running the gate on it cannot confirm it — the tests would be re-run after the patch rewrote what they assert, so they pass by construction.

  The original "The branch is kept: re-run verification against it, or delete it" guidance survives alongside it.

## Tests

Four new. One is a **regression guard**: it counts `return TaskResult(` against `expectation_only=` inside `_commit_changes`, so re-introducing this gap on a future return path fails a test instead of going quiet. Mutation-checked by reverting the kept-branch line — only that test fails.

**871 pass, 3 skipped.** `make format` clean.

<details>
<summary>One trap worth recording</summary>

The fixture is named `_unjudged`, not `_outcome`: `unittest.TestCase` already owns an `_outcome` attribute, and shadowing it fails with `TypeError: '_Outcome' object is not callable`.
</details>

## Context

Found while reading tracking issue [#48467](https://github.com/huggingface/transformers/issues/48467) — the first nightly on the full stack. Companion change on the triage side is [transformers-ci#106](https://github.com/huggingface/transformers-ci/pull/106), which gives that recap a runnable command to finish the branch, and tells the reader to fetch the already-computed verdict before spending GPU time.
