### PR TITLE
Harden task patch validation retries

### DIFF
--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -1144,6 +1144,9 @@ def _run_agentic_loop(
     final_force_message: Optional[str] = None,
     validate: Optional[Callable[[ChatResult], Optional[str]]] = None,
     max_validation_retries: int = 0,
+    validation_retry_messages: Optional[
+        Callable[[ChatResult, str, int], list[dict[str, Any]]]
+    ] = None,
     parses: Optional[Callable[[str], bool]] = None,
 ) -> tuple[ChatResult, _AggregateMetrics]:
     """Run a tool-augmented chat loop until the model emits a final
@@ -1234,6 +1237,17 @@ def _run_agentic_loop(
     # Set for one turn to recover a truncated final answer: disable tools and
     # force minimal reasoning so the whole output budget goes to the JSON.
     force_json_only = False
+
+    def _add_validation_feedback(chat: ChatResult, feedback: str) -> None:
+        nonlocal messages
+        if validation_retry_messages is not None:
+            messages = validation_retry_messages(chat, feedback, validation_retries)
+            return
+        # Continue the SAME conversation: append the rejected answer and the
+        # feedback, then loop so the model can browse + correct.
+        messages.append({"role": "assistant", "content": chat.content or None})
+        messages.append({"role": "user", "content": feedback})
+
     while True:
         iteration += 1
         if iteration > ABSOLUTE_ITER_CEILING:
@@ -1359,10 +1373,8 @@ def _run_agentic_loop(
                     f"{validation_retries}/{max_validation_retries}); "
                     "asking the model to fix it",
                 )
-            # Continue the SAME conversation: append the rejected answer and
-            # the feedback, then loop so the model can browse + correct.
-            messages.append({"role": "assistant", "content": chat.content or None})
-            messages.append({"role": "user", "content": feedback})
+            _add_validation_feedback(chat, feedback)
+            force_json_only = validation_retry_messages is not None
             continue
 
         # A "blind" tool turn is one where the model fired tool calls
@@ -1535,8 +1547,7 @@ def _run_agentic_loop(
                 f"{validation_retries}/{max_validation_retries}); "
                 "asking the model to fix it (no tools)",
             )
-        messages.append({"role": "assistant", "content": chat.content or None})
-        messages.append({"role": "user", "content": feedback})
+        _add_validation_feedback(chat, feedback)
 
 
 def _wrap_chunk_cb(

--- a/reviewbot/static/task.html
+++ b/reviewbot/static/task.html
@@ -258,7 +258,7 @@
       if (!body && !calls) return `assistant: (thinking…)${metaStr}`;
       return `assistant:${body ? " " + body : ""}${calls}${metaStr}`;
     }
-    ["step", "tool", "error", "log", "chat", "normalize_error", "patch_apply_error"].forEach(kind => {
+    ["step", "tool", "error", "log", "chat", "normalize_error", "patch_apply_error", "rejected_patch"].forEach(kind => {
       es.addEventListener(kind, (e) => {
         // The browser also fires a native "error" event (no .data) on a
         // dropped connection; ignore those here — es.onerror handles them.

--- a/reviewbot/store.py
+++ b/reviewbot/store.py
@@ -115,6 +115,7 @@ PERSIST_EVENT_KINDS = frozenset(
         "chat",
         "normalize_error",
         "patch_apply_error",
+        "rejected_patch",
     }
 )
 

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -62,6 +62,9 @@ from .verify import (
 log = logging.getLogger(__name__)
 
 _NORMALIZE_FEEDBACK_CHARS = 80_000
+_REJECTED_PATCH_EVENT_CHARS = 80_000
+_VALIDATION_RETRY_CONTEXT_CHARS = 120_000
+_VALIDATION_RETRY_OUTPUT_CHARS = 80_000
 
 # The task JSON contract from prompts.py. Passed to `_extract_json` so a stray
 # `{...}` in the reply — notably a leaked tool call's own argument object —
@@ -85,6 +88,14 @@ _TASK_FORCE_FINAL_MESSAGE = (
     "possible\n"
     "Return JSON only: no surrounding prose, no code fences, no extra commentary, "
     "and no tool requests."
+)
+
+_TASK_VALIDATION_RETRY_SYSTEM_MESSAGE = (
+    "You are fixing a previously rejected task patch. Reply with a single "
+    "compact JSON object that starts with `{` and has EXACTLY these keys: "
+    '"title", "body", and "patch". The patch must be a valid unified diff '
+    "against the current checkout, or an empty string if no safe fix is "
+    "possible. Return JSON only: no prose, no code fences, no tool requests."
 )
 _BRANCH_PREFIX_RE = re.compile(r"^serge/[A-Za-z0-9._/-]+$")
 _CANDIDATE_HEADING_RE = re.compile(
@@ -629,6 +640,7 @@ def _validate_patch(
         clone_cache.apply_patch(checkout, patch)
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or b"").decode("utf-8", errors="replace")[:1200]
+        emit("rejected_patch", _bounded_rejected_patch(patch))
         emit(
             "patch_apply_error",
             f"`git apply` rejected the proposed patch:\n{stderr}",
@@ -662,6 +674,7 @@ def _validate_patch(
         clone_cache.reset_worktree(checkout)
         cmd = " ".join(command)
         feedback_output = _bounded_normalize_feedback(output)
+        emit("rejected_patch", _bounded_rejected_patch(patch))
         emit(
             "normalize_error",
             f"Normalizer failed (exit {returncode}) for `{cmd}`:\n{output}",
@@ -716,6 +729,82 @@ def _bounded_normalize_feedback(output: str) -> str:
         + f"\n\n--- omitted {omitted} chars of normalize output from LLM feedback ---\n\n"
         + output[-tail:].lstrip()
     ).rstrip()
+
+
+def _bounded_rejected_patch(patch: str) -> str:
+    """Bound rejected patch events kept for operator diagnosis."""
+    return _bound_middle(
+        patch,
+        _REJECTED_PATCH_EVENT_CHARS,
+        "chars of rejected patch",
+    )
+
+
+def _bounded_validation_retry_output(text: str) -> str:
+    """Bound rejected assistant JSON resent to the correction turn."""
+    return _bound_middle(
+        text,
+        _VALIDATION_RETRY_OUTPUT_CHARS,
+        "chars of rejected assistant output",
+    )
+
+
+def _bounded_validation_retry_context(text: str) -> str:
+    """Bound original task context resent to a validation correction turn."""
+    return _bound_middle(
+        text,
+        _VALIDATION_RETRY_CONTEXT_CHARS,
+        "chars of task context",
+    )
+
+
+def _bound_middle(text: str, limit: int, label: str) -> str:
+    if len(text) <= limit:
+        return text
+    head = limit // 2
+    tail = limit - head
+    omitted = len(text) - limit
+    return (
+        text[:head].rstrip()
+        + f"\n\n--- omitted {omitted} {label} ---\n\n"
+        + text[-tail:].lstrip()
+    ).rstrip()
+
+
+def _task_validation_retry_messages(
+    *,
+    repo_full_name: str,
+    base_ref: str,
+    instruction: str,
+    context: str,
+    existing_diff: Optional[str],
+    rejected_content: Optional[str],
+    feedback: str,
+    retry_number: int,
+) -> list[dict[str, Any]]:
+    """Build the compact no-tools retry prompt for rejected task patches."""
+    body = (
+        f"Repository: {repo_full_name}\n"
+        f"Base ref: {base_ref}\n"
+        f"Validation correction: {retry_number}\n\n"
+        "Original task instruction:\n"
+        f"{instruction.strip() or '(none)'}\n\n"
+        "Original failure context:\n"
+        f"{_bounded_validation_retry_context(context.strip()) or '(none)'}\n\n"
+    )
+    if existing_diff:
+        body += f"Existing diff to preserve:\n{existing_diff.strip()}\n\n"
+    body += (
+        "Validator rejection to fix:\n"
+        f"{feedback.strip()}\n\n"
+        "Rejected assistant output:\n"
+        f"{_bounded_validation_retry_output(rejected_content or '')}\n\n"
+        "Return a corrected task JSON object only."
+    )
+    return [
+        {"role": "system", "content": _TASK_VALIDATION_RETRY_SYSTEM_MESSAGE},
+        {"role": "user", "content": body},
+    ]
 
 
 def _read_repo_conventions(cfg: Config, checkout: Checkout) -> str:
@@ -903,6 +992,20 @@ def prepare_task(
         final_force_message=_TASK_FORCE_FINAL_MESSAGE,
         validate=_validate if normalize_configured else None,
         max_validation_retries=cfg.task_normalize_max_retries,
+        validation_retry_messages=(
+            lambda chat, feedback, retry_number: _task_validation_retry_messages(
+                repo_full_name=req.repo_full_name,
+                base_ref=req.base_ref,
+                instruction=req.instruction,
+                context=req.context,
+                existing_diff=existing_diff,
+                rejected_content=chat.content,
+                feedback=feedback,
+                retry_number=retry_number,
+            )
+        )
+        if normalize_configured
+        else None,
         parses=_parses,
     )
     for brevity_chat in brevity_chats:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -2,43 +2,44 @@ import json
 import os
 import tempfile
 import unittest
+from typing import Any
 from unittest.mock import Mock, patch
 
 from reviewbot.llm_client import ChatCompletionClient, ChatResult, ToolCall
 from reviewbot.patch import parse_patch
-from reviewbot.tools import ToolEnv
 from reviewbot.reviewer import (
     _LOG_MSG_MAX_CHARS,
     _MAX_TRUNCATION_RETRIES,
-    _AggregateMetrics,
-    _UnparseableLLMOutput,
-    _condense_review,
-    _final_answer_defect,
-    _assistant_tool_call_dict,
-    _build_annotated_diff_chunks,
-    _content_preview,
-    _emit_chat_message,
-    _recovery_message_for,
-    _is_model_markup_only,
-    _needs_final_salvage,
-    _salvage_decision,
-    _extract_json,
     _REVIEW_JSON_KEYS,
-    _merge_chunk_event,
-    _merge_chunk_summaries,
-    _prose_outside_json,
-    _run_agentic_loop,
-    _summarize_rejected_comments,
     STOP_ANSWERED,
     STOP_BLIND_TURN_CAP,
     STOP_INPUT_TOKEN_CAP,
     STOP_NO_LLM_TURNS,
     STOP_PATH_REVISIT_GUARD,
     STOP_REPEAT_GUARD,
+    _AggregateMetrics,
+    _assistant_tool_call_dict,
+    _build_annotated_diff_chunks,
+    _condense_review,
+    _content_preview,
+    _emit_chat_message,
+    _extract_json,
+    _final_answer_defect,
+    _is_model_markup_only,
+    _merge_chunk_event,
+    _merge_chunk_summaries,
+    _needs_final_salvage,
+    _prose_outside_json,
+    _recovery_message_for,
+    _run_agentic_loop,
+    _salvage_decision,
+    _summarize_rejected_comments,
+    _UnparseableLLMOutput,
     merge_session_records,
     no_llm_session_record,
     session_record,
 )
+from reviewbot.tools import ToolEnv
 
 
 class EmitChatMessageTests(unittest.TestCase):
@@ -874,6 +875,50 @@ class ValidationGateTests(unittest.TestCase):
                 for m in second_turn
             )
         )
+
+    def test_validation_feedback_can_replace_history_with_compact_retry(self) -> None:
+        cfg = _CfgStub()
+        llm = _FakeLLM(
+            [self._result('{"patch": "v1"}'), self._result('{"patch": "v2"}')]
+        )
+
+        def validate(chat: ChatResult) -> str | None:
+            return "git apply failed" if chat.content == '{"patch": "v1"}' else None
+
+        def compact_retry(
+            chat: ChatResult, feedback: str, retry_number: int
+        ) -> list[dict[str, Any]]:
+            return [
+                {"role": "system", "content": "compact validation retry"},
+                {
+                    "role": "user",
+                    "content": f"retry={retry_number}; {feedback}; {chat.content}",
+                },
+            ]
+
+        chat, _ = _run_agentic_loop(
+            llm,  # type: ignore[arg-type]
+            [{"role": "user", "content": "huge original history"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+            validate=validate,
+            max_validation_retries=2,
+            validation_retry_messages=compact_retry,
+        )
+
+        self.assertEqual(chat.content, '{"patch": "v2"}')
+        self.assertEqual(
+            llm.calls[1]["messages"],
+            [
+                {"role": "system", "content": "compact validation retry"},
+                {
+                    "role": "user",
+                    "content": 'retry=1; git apply failed; {"patch": "v1"}',
+                },
+            ],
+        )
+        self.assertIsNone(llm.calls[1]["tools"])
+        self.assertEqual(llm.calls[1]["extra"], {"reasoning_effort": "low"})
 
     def test_retries_exhausted_returns_last_answer(self) -> None:
         cfg = _CfgStub()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -152,10 +152,11 @@ class JobStoreTests(unittest.TestCase):
             self.assertIn("chat", kinds)
             self.assertIn("tool", kinds)
             self.assertNotIn("patch_apply_error", kinds)
+            self.assertNotIn("rejected_patch", kinds)
             self.assertNotIn("token", kinds)
             self.assertNotIn("reasoning", kinds)
 
-    def test_persists_patch_apply_error_events(self) -> None:
+    def test_persists_patch_validation_diagnostics(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             db = os.path.join(tmp, "jobs.db")
             store = JobStore(db)
@@ -172,7 +173,10 @@ class JobStoreTests(unittest.TestCase):
                 created_at=3.0,
                 status="running",
             )
-            history = [{"kind": "patch_apply_error", "text": "patch does not apply"}]
+            history = [
+                {"kind": "patch_apply_error", "text": "patch does not apply"},
+                {"kind": "rejected_patch", "text": "diff --git a/x b/x\n"},
+            ]
             store.save_terminal(
                 "j3",
                 status="error",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -11,10 +11,9 @@ from unittest.mock import patch
 
 from reviewbot.clone_cache import Checkout, CloneCache
 from reviewbot.config import Config
-from reviewbot.llm_client import ChatResult
 from reviewbot.github_client import SERGE_GIT_EMAIL
+from reviewbot.llm_client import ChatResult
 from reviewbot.tasks import (
-    prompt_prefix_summary,
     MAX_REVIEWERS,
     NormalizeGateBroken,
     TaskError,
@@ -22,8 +21,10 @@ from reviewbot.tasks import (
     TaskRequest,
     _read_repo_conventions,
     _selected_failure_context,
+    _task_validation_retry_messages,
     _validate_patch,
     build_task_request,
+    prompt_prefix_summary,
     publish_task,
     resolve_existing_pr,
     task_candidate_requests,
@@ -1270,6 +1271,8 @@ class ValidatePatchTests(unittest.TestCase):
         self.assertEqual(len(apply_errors), 1)
         self.assertIn("`git apply` rejected the proposed patch", apply_errors[0])
         self.assertIn("hello.txt", apply_errors[0])
+        rejected_patches = [text for kind, text in events if kind == "rejected_patch"]
+        self.assertEqual(rejected_patches, [bad_patch])
 
     def test_operator_guidance_is_appended_to_feedback(self):
         cfg = self._cfg(
@@ -1280,6 +1283,26 @@ class ValidatePatchTests(unittest.TestCase):
         feedback, prepared = self._validate(cfg, self._content(self._PATCH))
         self.assertFalse(prepared)
         self.assertIn("HOUSE RULE: never add new dependencies.", feedback)
+
+    def test_task_validation_retry_prompt_is_compact_and_json_only(self):
+        messages = _task_validation_retry_messages(
+            repo_full_name="o/r",
+            base_ref="main",
+            instruction="fix the failing test",
+            context="traceback",
+            existing_diff="diff --git a/x b/x\n",
+            rejected_content='{"patch": "bad"}',
+            feedback="git apply failed",
+            retry_number=2,
+        )
+
+        self.assertEqual([m["role"] for m in messages], ["system", "user"])
+        self.assertIn("JSON object", messages[0]["content"])
+        self.assertIn("no tool requests", messages[0]["content"])
+        self.assertIn("fix the failing test", messages[1]["content"])
+        self.assertIn("git apply failed", messages[1]["content"])
+        self.assertIn('{"patch": "bad"}', messages[1]["content"])
+        self.assertNotIn("tool_call_id", json.dumps(messages))
 
     def test_broken_gate_raises_instead_of_blaming_the_patch(self):
         # The prod shape (transformers#48037): the normalizer fails for a reason


### PR DESCRIPTION
## Summary
- persist rejected task patches as validation diagnostics
- retry rejected task patches with a compact no-tools correction prompt
- expose rejected patch events in the task stream UI

## Tests
- .venv/bin/python -m pytest tests/test_reviewer.py::ValidationGateTests tests/test_tasks.py::ValidatePatchTests tests/test_store.py
- .venv/bin/ruff check --select I tests/test_reviewer.py tests/test_tasks.py

Note: full make test hit local file descriptor exhaustion in unrelated webapp tests after 893 tests had passed.