### PR TITLE
Catch reshaped assertions, verify shared-fixture patches, drop the checker list

### DIFF
--- a/deploy/helm/env/prod.yaml
+++ b/deploy/helm/env/prod.yaml
@@ -122,21 +122,24 @@ envVars:
     # found" and, again, every task fails.
     uv pip install -e . --system --no-deps --no-build-isolation
 
-    # ruff lint + format over the whole repo.
-    make style
-
-    # The repo consistency checkers, in the order transformers itself runs them.
-    # --fix rewrites what it can (check-only checkers are skipped in fix mode);
-    # --keep-going reports every failure instead of stopping at the first, so one
-    # gate run tells the model everything it has to correct.
-    CHECKERS=ruff_check,ruff_format,init_isort,sort_auto_mappings
-    CHECKERS=$CHECKERS,types,modeling_structure,auto_mappings,imports
-    CHECKERS=$CHECKERS,import_complexity,copies,modular_conversion,doc_toc
-    CHECKERS=$CHECKERS,modeling_rules_doc,docstrings,dummies,repo,inits
-    CHECKERS=$CHECKERS,pipeline_typing,config_docstrings,config_attributes
-    CHECKERS=$CHECKERS,doctest_list,update_metadata,deps_table
-
-    python utils/checkers.py "$CHECKERS" --fix --keep-going
+    # The repo normalizer: ruff lint + format plus every consistency checker,
+    # with --fix and --keep-going, so one gate run tells the model everything it
+    # has to correct. This is `python utils/checkers.py $(ALL_CHECKERS) --fix
+    # --keep-going` -- the target exists precisely so the list cannot drift, and
+    # spelling the list out here is what made it drift: the hand-copied set was
+    # missing `noisy_comments` (a repo checker for comments that restate the
+    # code, which is exactly what an LLM patch adds), `reviewers` and
+    # `add_dates`, all three of which CI runs. A patch could clear this gate and
+    # still land a red `check-code-quality` / `Check repository consistency`.
+    #
+    # transformers is set up for this sandbox: checkers that need a package
+    # declare it (`needs_requirements`), so the ones that would reach for pip in
+    # a --network none container are the only ones that try, and the env var
+    # below turns even that off. `add_dates` shells out to git and only looks at
+    # the models the patch actually touches, so a test-only patch never reaches
+    # the network through it.
+    export TRANSFORMERS_SKIP_CHECKER_REQUIREMENTS=1
+    make fix-repo
     '
   TASK_NORMALIZE_TIMEOUT: "1800"
   TASK_NORMALIZE_MAX_RETRIES: "2"

--- a/reviewbot/expectation_guard.py
+++ b/reviewbot/expectation_guard.py
@@ -69,6 +69,24 @@ _LAYOUT = re.compile(r"[\s,()\[\]{}:]+")
 
 _COMMENT = re.compile(r"^\s*#")
 
+# Calls that change the SHAPE or ORDER of what an assertion compares, not the
+# thing it asserts about. Adding one of these to the actual side redefines
+# passing exactly as editing the expected literal does, and it is harder to see:
+# transformers#48553 added `.flatten()` to `output.sequences.squeeze().tolist()`
+# so a `[2, N]` result would compare against a flat 8-token expectation. Rule 2
+# read the new identifier as a code change and called it a real fix.
+#
+# Kept to operations that only re-arrange a comparison. `.to(...)`, `.cpu()`,
+# `.float()` and friends are deliberately absent: those change the value's
+# device or dtype, and a patch that adds one is making a substantive claim.
+_SHAPE_OP = re.compile(
+    r"\.(?:flatten|ravel|reshape|view|squeeze|unsqueeze|transpose|permute|sort"
+    r"|argsort|tolist|item|round)\s*\((?:[^()]*)\)"
+    r"|\.(?:T|item)\b"
+    r"|\[\s*-?\d+\s*\]"
+    r"|\b(?:sorted|set|list|abs|len|tuple)\s*\("
+)
+
 # Values that are not a new baseline but a broken one. Kept short and literal on
 # purpose: this list is quoted at a human, so a false positive costs a sentence
 # in a PR body, and a miss costs nothing that the label itself does not already
@@ -117,6 +135,20 @@ def _residue(lines: list[str]) -> str:
     return _LAYOUT.sub(" ", joined).strip()
 
 
+def _shape_residue(lines: list[str]) -> str:
+    """:func:`_residue`, with shape/ordering operations dropped as well.
+
+    Two sides that agree here but differ under :func:`_residue` differ only in
+    how the compared values are re-arranged — which is an assertion rewrite
+    wearing a method call.
+    """
+    return _residue([_SHAPE_OP.sub("", ln) for ln in lines])
+
+
+def _shape_ops(lines: list[str]) -> int:
+    return sum(len(_SHAPE_OP.findall(ln)) for ln in lines)
+
+
 def _literals(lines: list[str]) -> list[str]:
     out: list[str] = []
     for m in _STRING_LITERAL.finditer("\n".join(lines)):
@@ -149,6 +181,9 @@ class PatchClassification:
     test_files: list[str] = field(default_factory=list)
     #: Added literal values that read as broken rather than merely new.
     degenerate_values: list[str] = field(default_factory=list)
+    #: Test files where the change is a reshaped comparison rather than a new
+    #: literal — `.flatten()`, `[0]`, `sorted(...)` added to an assertion.
+    reshaped_comparisons: list[str] = field(default_factory=list)
 
     def to_json(self) -> dict:
         return {
@@ -156,16 +191,26 @@ class PatchClassification:
             "source_files": self.source_files,
             "test_files": self.test_files,
             "degenerate_values": self.degenerate_values,
+            "reshaped_comparisons": self.reshaped_comparisons,
         }
 
     def reason(self) -> str:
         """One sentence for a PR body or a log line."""
         if not self.expectation_only:
             return ""
-        base = (
-            "This patch changes only expected values in test files — the "
-            "assertions were rewritten, not the code under test."
-        )
+        if self.reshaped_comparisons:
+            base = (
+                "This patch rewrites how an assertion compares its values "
+                "(a reshaping or extracting call added to one side, e.g. "
+                "`.flatten()`, `[0]`, `sorted(...)`) rather than changing the "
+                "code under test. A shape or ordering difference is a sign the "
+                "inputs changed, so re-arranging the comparison hides it."
+            )
+        else:
+            base = (
+                "This patch changes only expected values in test files — the "
+                "assertions were rewritten, not the code under test."
+            )
         if self.degenerate_values:
             shown = ", ".join(f"`{v}`" for v in self.degenerate_values[:3])
             base += (
@@ -245,7 +290,16 @@ def classify_patch(
             continue
         saw_change = True
         if _residue(old) != _residue(new):
-            literal_only = False
+            # A residue difference explained entirely by shape/ordering
+            # operations appearing on one side is an assertion rewrite, not a
+            # code change: same skeleton, different comparison.
+            if _shape_residue(old) == _shape_residue(new) and _shape_ops(
+                new
+            ) != _shape_ops(old):
+                if path not in result.reshaped_comparisons:
+                    result.reshaped_comparisons.append(path)
+            else:
+                literal_only = False
 
     for path in changed_files if changed_files is not None else result.changed_files:
         if path not in result.changed_files:

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -54,6 +54,7 @@ from .verify import (
     VerifyOutcome,
     extract_verify_targets,
     gate_did_not_run,
+    patch_needs_collateral,
     run_gpu_reproduce,
     run_gpu_verify,
     should_retry,
@@ -1312,6 +1313,21 @@ def _make_verify_gate(
     if not cfg.verify_on_gpu:
         return None
     block = _select_failure_block(req, plan)
+    # The gate re-runs the group's own node-ids, which is full coverage for a
+    # patch confined to those tests and none at all for a patch that edits the
+    # scaffolding they share with the rest of the file. Ask for the collateral
+    # suite in the second case even when it is globally off.
+    node_ids, _, _ = extract_verify_targets(block, cfg.verify_machine_type)
+    collateral = cfg.verify_run_collateral or patch_needs_collateral(
+        plan.patch, node_ids
+    )
+    if collateral and not cfg.verify_run_collateral:
+        emit_fn(
+            "log",
+            "GPU verify: the patch touches shared test scaffolding, so the "
+            "collateral suite runs too (the targeted node-ids alone would not "
+            "see a sibling test break).",
+        )
 
     def _gate(base_sha: str, candidate_sha: str) -> VerifyOutcome:
         outcome = run_gpu_verify(
@@ -1325,7 +1341,7 @@ def _make_verify_gate(
             workflow_file=cfg.verify_workflow_file,
             ref=cfg.verify_ref,
             default_machine_type=cfg.verify_machine_type,
-            run_collateral=cfg.verify_run_collateral,
+            run_collateral=collateral,
             transformersci_ref=cfg.verify_transformersci_ref,
             poll_timeout=effective_poll_timeout(
                 cfg.verify_poll_timeout, getattr(cfg, "task_runner_timeout", None)

--- a/reviewbot/verify.py
+++ b/reviewbot/verify.py
@@ -158,6 +158,91 @@ def extract_verify_targets(
     return node_ids, model, machine_type
 
 
+# Scaffolding a whole test class shares. A patch that edits one of these can
+# break tests the failure group never named, and the gate only re-runs the
+# group's own node-ids — which is how transformers#48425 changed the
+# `input_audio` fixture from one 2-channel sample to two mono samples, verified
+# its own 6 targeted tests green, and left `test_to_rus_speech` (same class,
+# same fixture) comparing a nested list against a flat expectation. The collateral
+# suite exists for exactly this; it just had to be asked for.
+_SCAFFOLDING_MARKERS = (
+    "def setUp",
+    "def tearDown",
+    "def setUpClass",
+    "def tearDownClass",
+    "@cached_property",
+    "@classmethod",
+    "@property",
+    "@staticmethod",
+)
+_DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+([A-Za-z_]\w*)")
+
+
+def _hunks_by_file(patch: str):
+    """Yield ``(path, hunk_lines)`` per hunk of a unified diff, hunk_lines being
+    every line of the hunk including context."""
+    path: Optional[str] = None
+    hunk: list[str] = []
+    for raw in patch.splitlines():
+        if (
+            raw.startswith("diff --git ")
+            or raw.startswith("+++ ")
+            or raw.startswith("--- ")
+        ):
+            if hunk and path:
+                yield path, hunk
+            hunk = []
+            if raw.startswith("+++ "):
+                target = raw[4:].strip()
+                if target != "/dev/null":
+                    path = target[2:] if target.startswith("b/") else target
+            elif raw.startswith("diff --git "):
+                path = None
+            continue
+        if raw.startswith("@@"):
+            if hunk and path:
+                yield path, hunk
+            hunk = []
+            continue
+        if path:
+            hunk.append(raw)
+    if hunk and path:
+        yield path, hunk
+
+
+def patch_needs_collateral(patch: str, node_ids: list[str]) -> bool:
+    """Whether this patch edits scaffolding the targeted tests only share.
+
+    The gate re-runs the group's node-ids, so a patch confined to a targeted
+    test's own body is fully covered by it. A patch that changes a `setUp`, a
+    `cached_property` fixture, a helper, or a sibling test is not: the tests it
+    can break are the ones nobody is watching. Those runs get the collateral
+    suite (`tests/models/<model>`) on both trees as well.
+
+    Decided from the hunk text alone — the patch is the model's proposal, so its
+    `@@` headers carry no function context to trust. A hunk counts as
+    scaffolding when it shows a scaffolding marker, or a `def` that is not one
+    of the targeted tests.
+    """
+    targeted = {nid.rsplit("::", 1)[-1] for nid in node_ids}
+    for path, hunk in _hunks_by_file(patch):
+        if not path.endswith(".py"):
+            continue
+        parts = path.split("/")
+        name = parts[-1]
+        is_test = "tests" in parts or name.startswith("test_") or name == "conftest.py"
+        if not is_test:
+            continue
+        for line in hunk:
+            body = line[1:] if line[:1] in "+- " else line
+            if any(marker in body for marker in _SCAFFOLDING_MARKERS):
+                return True
+            m = _DEF_RE.match(body)
+            if m and m.group(1) not in targeted:
+                return True
+    return False
+
+
 def parse_verify_result_zip(zip_bytes: bytes) -> Optional[dict]:
     """Extract and parse ``verify-result.json`` from an artifact zip."""
     try:

--- a/tests/test_expectation_guard.py
+++ b/tests/test_expectation_guard.py
@@ -422,3 +422,85 @@ class UnjudgedOutcomeTests(unittest.TestCase):
             src.count("expectation_only=classification.expectation_only"),
             "a _commit_changes return path is missing expectation_only",
         )
+
+
+class ReshapedComparisonTests(unittest.TestCase):
+    """transformers#48553: `.flatten()` added to the actual side of an
+    assertion. Rule 2 saw a new identifier and called it a real fix, so serge
+    published "verified on GPU" for a patch that cannot make the test pass."""
+
+    PATH = "tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py"
+
+    def _patch(self, old: str, new: str, path: str | None = None) -> str:
+        path = path or self.PATH
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            "@@ -1,1 +1,1 @@\n"
+            f"-{old}\n"
+            f"+{new}\n"
+        )
+
+    def _classify(self, old: str, new: str, path: str | None = None):
+        path = path or self.PATH
+        return classify_patch(self._patch(old, new, path), changed_files=[path])
+
+    def test_the_real_48553_diff_is_caught(self):
+        got = self._classify(
+            "        self.assertListEqual(expected, output.sequences.squeeze().tolist())",
+            "        self.assertListEqual(expected, output.sequences.squeeze().flatten().tolist())",
+        )
+        self.assertTrue(got.expectation_only)
+        self.assertEqual(got.reshaped_comparisons, [self.PATH])
+
+    def test_an_added_index_is_caught(self):
+        got = self._classify(
+            "        self.assertEqual(expected, decode(output))",
+            "        self.assertEqual(expected, decode(output)[0])",
+        )
+        self.assertTrue(got.expectation_only)
+
+    def test_sorting_one_side_is_caught(self):
+        got = self._classify(
+            "        self.assertEqual(expected, got)",
+            "        self.assertEqual(sorted(expected), sorted(got))",
+        )
+        self.assertTrue(got.expectation_only)
+
+    def test_the_reason_names_the_rewrite_not_a_new_value(self):
+        got = self._classify(
+            "        self.assertListEqual(expected, out.squeeze().tolist())",
+            "        self.assertListEqual(expected, out.squeeze().flatten().tolist())",
+        )
+        self.assertIn("rewrites how an assertion compares", got.reason())
+        self.assertNotIn("changes only expected values", got.reason())
+
+    def test_a_dtype_or_device_move_is_still_a_real_fix(self):
+        """`.to(...)`/`.float()` change the value, not its shape — a patch that
+        adds one is making a substantive claim and keeps its verification."""
+        got = self._classify(
+            "        got = model(**inputs).logits",
+            "        got = model(**inputs).logits.float()",
+        )
+        self.assertFalse(got.expectation_only)
+        self.assertEqual(got.reshaped_comparisons, [])
+
+    def test_a_new_kwarg_is_still_a_real_fix(self):
+        """#48440's shape, which was merged as a real fix."""
+        got = self._classify(
+            "        out = model.generate(**inputs, max_new_tokens=20)",
+            "        out = model.generate(**inputs, max_new_tokens=20, tokenizer=tokenizer)",
+        )
+        self.assertFalse(got.expectation_only)
+
+    def test_a_source_file_still_wins(self):
+        """A reshape in a source file is not an expectation change: the split on
+        `source_files` is authoritative."""
+        path = "src/transformers/models/foo/modeling_foo.py"
+        got = self._classify(
+            "        x = hidden.squeeze()",
+            "        x = hidden.squeeze().flatten()",
+            path=path,
+        )
+        self.assertFalse(got.expectation_only)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -378,3 +378,124 @@ def test_a_real_model_is_still_passed_through():
     (_o, _r, _wf, _ref, inputs) = gh.dispatched[0]
     assert inputs["model"] == "whisper"
     assert inputs["run_collateral"] == "true"
+
+
+# ── patch_needs_collateral ───────────────────────────────────────────────────
+# The gate re-runs the group's node-ids only, so a patch that edits scaffolding
+# the whole class shares is unverified where it matters. transformers#48425 is
+# the case: it changed the `input_audio` fixture, verified its 6 targeted tests
+# green, and broke `test_to_rus_speech` in the same class.
+
+_TARGETED = [
+    "tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py"
+    "::SeamlessM4Tv2ModelIntegrationTest::test_speech_to_speech_model"
+]
+
+
+def _patch(path, *lines):
+    head = (
+        f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -1,6 +1,6 @@\n"
+    )
+    return head + "".join(f"{ln}\n" for ln in lines)
+
+
+def test_a_shared_cached_property_fixture_asks_for_collateral():
+    patch = _patch(
+        "tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py",
+        "     @cached_property",
+        "     def input_audio(self):",
+        "         set_seed(42)",
+        "-        return self.processor(audio=[features.tolist()], **kw)",
+        "+        return self.processor(audio=features.tolist(), **kw)",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is True
+
+
+def test_a_teardown_asks_for_collateral():
+    patch = _patch(
+        "tests/models/glm4_moe/test_modeling_glm4_moe.py",
+        "     def tearDown(self):",
+        "-        cleanup(torch_device, gc_collect=False)",
+        "+        cleanup(torch_device, gc_collect=True)",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is True
+
+
+def test_a_sibling_test_asks_for_collateral():
+    patch = _patch(
+        "tests/models/x/test_modeling_x.py",
+        "     def test_some_other_thing(self):",
+        "-        self.assertEqual(a, 1)",
+        "+        self.assertEqual(a, 2)",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is True
+
+
+def test_a_change_inside_the_targeted_test_does_not():
+    patch = _patch(
+        "tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py",
+        "     def test_speech_to_speech_model(self):",
+        "         out = model.generate(**inputs)",
+        '-        self.assertEqual(text, "a")',
+        '+        self.assertEqual(text, "b")',
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is False
+
+
+def test_an_expectation_hunk_with_no_def_in_context_does_not():
+    patch = _patch(
+        "tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py",
+        "         out = model.generate(**inputs)",
+        '-        self.assertEqual(text, "a")',
+        '+        self.assertEqual(text, "b")',
+        "         self.assertTrue(ok)",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is False
+
+
+def test_a_source_only_patch_does_not():
+    patch = _patch(
+        "src/transformers/models/x/modeling_x.py",
+        "     def forward(self, x):",
+        "-        return x",
+        "+        return x + 1",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is False
+
+
+def test_a_source_change_next_to_a_test_change_still_counts():
+    """A patch touching both is judged on its test half."""
+    patch = _patch(
+        "src/transformers/models/x/modeling_x.py",
+        "-        return x",
+        "+        return x + 1",
+    ) + _patch(
+        "tests/models/x/test_modeling_x.py",
+        "     def setUp(self):",
+        "-        self.model_id = 'a'",
+        "+        self.model_id = 'b'",
+    )
+    assert verify.patch_needs_collateral(patch, _TARGETED) is True
+
+
+def test_no_node_ids_treats_every_def_as_unwatched():
+    patch = _patch(
+        "tests/models/x/test_modeling_x.py",
+        "     def test_thing(self):",
+        "-        self.assertEqual(a, 1)",
+        "+        self.assertEqual(a, 2)",
+    )
+    assert verify.patch_needs_collateral(patch, []) is True
+
+
+def test_the_gate_passes_the_computed_collateral_flag_not_the_config_one():
+    """A guard against re-pinning the gate to `cfg.verify_run_collateral`, which
+    is off in prod: the whole point is that a scaffolding patch turns it on."""
+    import inspect
+
+    from reviewbot import tasks
+
+    src = inspect.getsource(tasks._make_verify_gate)
+    assert "patch_needs_collateral(" in src
+    assert "run_collateral=collateral" in src
+    assert "run_collateral=cfg.verify_run_collateral" not in src


### PR DESCRIPTION
Three gaps behind the 2026-09-04..06 task PRs on transformers.

### `expectation_guard`: an assertion rewrite wearing a method call

Rule 2 asks whether removing literals leaves both sides identical, so a *new identifier* reads as a real code change. [transformers#48553](https://github.com/huggingface/transformers/pull/48553) added `.flatten()` to `output.sequences.squeeze().tolist()` and was therefore classified a real fix, keeping its verification claim — for a patch that cannot make the test pass.

A residue difference explained entirely by shape/ordering operations appearing on one side is now `expectation_only`, with its own sentence in `reason()` ("rewrites how an assertion compares its values… a shape or ordering difference is a sign the inputs changed"). `.to(...)`, `.cpu()`, `.float()` are deliberately **not** in the set: those change the value rather than its shape, so a patch adding one keeps its claim. The module stays a label, not a blocker.

### `verify`: the gate cannot see what it does not run

`extract_verify_targets` returns the failure group's own node-ids, which is full coverage for a patch confined to those tests and none at all for one that edits scaffolding they share. [transformers#48425](https://github.com/huggingface/transformers/pull/48425) changed the `input_audio` `cached_property` from one 2-channel sample to two mono samples, verified its 6 targeted tests green, and left `test_to_rus_speech` — same class, same fixture — comparing a nested list against a flat expectation. #48553 then tried to paper over that.

`patch_needs_collateral(patch, node_ids)` spots a hunk that shows scaffolding (`setUp`, `tearDown`, `setUpClass`, `@cached_property`, `@classmethod`, `@property`) or a `def` that is not one of the targeted tests, and `_make_verify_gate` turns the collateral suite on for that run even when `VERIFY_RUN_COLLATERAL` is off. The mechanism already existed; it just had to be asked for.

It is judged from the hunk text alone — the patch is the model's proposal, so its `@@` headers carry no function context to trust. A change inside a targeted test's body, or an expectation hunk whose context shows no `def`, does not trigger it.

### `prod.yaml`: the checker list had drifted

`TASK_NORMALIZE_COMMAND` spelled out 23 checker names instead of calling `make fix-repo`, and was missing `noisy_comments`, `reviewers` and `add_dates` — all three of which transformers' CI runs. A patch could clear this gate and still land a red `check-code-quality` / `Check repository consistency`. (`noisy_comments` is the one that stings: it flags comments that restate the code, which is exactly what an LLM patch adds.)

transformers' Makefile derives `fix-repo` from the CI sets *precisely so the list cannot drift*, and its `utils/checkers-requirements.txt` is already written for this `--network none` sandbox (per-checker opt-in). `TRANSFORMERS_SKIP_CHECKER_REQUIREMENTS=1` keeps even those installs from burning retries. `make` is guaranteed by `docker/Dockerfile.task-runner`.

`948 passed, 3 skipped` (`tests/test_app.py` deselected — it needs `flask`, absent from my local env and unrelated).
