### PR TITLE
Raise the instruction cap above the per-category triage instruction

### DIFF
--- a/reviewbot/prompts.py
+++ b/reviewbot/prompts.py
@@ -539,7 +539,15 @@ def build_user_prompt(
 # as reviews (LLM proposes comments; serge publishes).
 # ---------------------------------------------------------------------------
 
-MAX_INSTRUCTION_CHARS = 8000
+# The instruction is the trusted channel and it is head-truncated, so anything
+# past this is silently dropped from the END — which is where the caller appends
+# its newest guidance. transformers-ci's integration-failure triage sends a
+# shared trunk plus a per-category block, and the `output_mismatch` one reached
+# 8,821 chars in transformers-ci#114: the whole point of that change (do not
+# rewrite the actual side of an assertion; a shape mismatch means the input
+# moved) sat in the 821 chars that fell off. Kept well above today's largest
+# block, and transformers-ci has a test that fails if a category outgrows it.
+MAX_INSTRUCTION_CHARS = 12000
 MAX_CONTEXT_CHARS = 40000
 # How much of the END of a task context is protected from truncation. The
 # appended GPU reproduce/verify block lives there and is the authoritative

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,6 +3,7 @@ import unittest
 from reviewbot.prompts import (
     CONTEXT_TAIL_RESERVE_CHARS,
     MAX_CONTEXT_CHARS,
+    MAX_INSTRUCTION_CHARS,
     _truncate_middle,
     build_task_user_prompt,
     build_followup_system_prompt,
@@ -247,3 +248,33 @@ class ChangedExpectationsRuleTests(unittest.TestCase):
         """The template is rendered with str.format, so the `Expectations({...})`
         example has to be brace-escaped or every review prompt raises."""
         self.assertIn("`Expectations({...})`", self._prompt())
+
+
+class InstructionBudgetTests(unittest.TestCase):
+    """The instruction is head-truncated, so an over-long one loses its END.
+
+    transformers-ci sends a shared trunk plus a per-category block, appending
+    the newest guidance last: at the old 8,000-char cap its `output_mismatch`
+    instruction (8,821 chars after transformers-ci#114) lost exactly the bullets
+    that change had added, and nothing said so — the model just saw a truncation
+    marker where the reasoning should have been.
+    """
+
+    def _instruction_in(self, text: str) -> str:
+        return build_task_user_prompt(
+            repo_full_name="huggingface/transformers",
+            base_ref="main",
+            instruction=text,
+            context="ctx",
+        )
+
+    def test_a_real_sized_per_category_instruction_survives_whole(self) -> None:
+        instruction = "x" * 9000 + "TAIL-OF-THE-GUIDANCE"
+        prompt = self._instruction_in(instruction)
+        self.assertIn("TAIL-OF-THE-GUIDANCE", prompt)
+        self.assertNotIn("truncated", prompt)
+
+    def test_the_cap_still_bites_eventually(self) -> None:
+        prompt = self._instruction_in("x" * (MAX_INSTRUCTION_CHARS + 10) + "LOST")
+        self.assertNotIn("LOST", prompt)
+        self.assertIn("truncated", prompt)


### PR DESCRIPTION
`build_task_user_prompt` head-truncates the instruction at `MAX_INSTRUCTION_CHARS`, so an over-long one loses its **end** — and transformers-ci appends its newest guidance last.

Its `output_mismatch` instruction (shared trunk + per-category block) is **8,821 chars** after [transformers-ci#114](https://github.com/huggingface/transformers-ci/pull/114), against a cap of **8,000**. The 821 chars that fell off were exactly the bullets that change existed to add:

```
[... truncated, 821 chars omitted ...]
```
> cessor/tokenizer call) and check it against what the expectation assumes: a flat list of N tokens, one waveform, one `.squeeze()` that the test expects to collapse everything — all of those say batch size 1…

So the guidance was written, reviewed, merged, and never reached the model. Nothing on either side noticed: the truncation is silent apart from a marker in the prompt.

12,000 leaves room above today's largest block (sizes: output_mismatch 8,821 · cluster 4,753 · crash 4,688 · load_error 3,217 · import_or_config 3,121 · trunk alone 2,641). The other half is [transformers-ci#115](https://github.com/huggingface/transformers-ci/pull/115), a test that fails when a category outgrows this number — that repo is where the growth happens.

`24 passed` in `tests/test_prompts.py`.