### PR TITLE
Report peak and cached input tokens, and add an opt-in transcript window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,22 @@ LLM_API_KEY=sk-...
 # Optional. "true" to consume the chat-completion response as a streaming SSE
 # feed. Useful when proxies drop long non-streaming connections.
 # LLM_STREAM=false
+# Optional. Hard cap on the input tokens one agent loop may spend. This counts
+# every turn's WHOLE prompt, and the loop re-sends the conversation each turn,
+# so it is a cumulative billing figure, not a context size — and it grows
+# quadratically in turns, so doubling it buys about 1.5x the turns. 0 disables.
+# LLM_MAX_INPUT_TOKENS=2000000
+# Optional. Send only the newest N browse-tool results verbatim; older ones
+# travel as a stub the model can re-run. Trades the cumulative figure above
+# down (86% of a measured 2M-token task was the transcript being re-sent) at
+# the risk of the model re-reading what it can no longer see. 0 = off, the
+# default. See reviewbot/transcript.py and docs/web-app.md before setting it;
+# in particular check serge_job_cached_input_tokens first, because eliding
+# history defeats a provider prefix-cache.
+# TOOL_RESULT_WINDOW=0
+# Optional. Task-only override for the window above, so it can be rolled out to
+# /tasks (where the input-token cap actually binds) without touching reviews.
+# TASK_TOOL_RESULT_WINDOW=0
 
 # --- Review behaviour ---
 # Phrase that must appear in a PR/issue comment to trigger a review.

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -110,6 +110,33 @@ retries, and two numbers about how the budget was spent browsing:
 | `serge_job_repeat_calls` | Tool calls that re-ran an *earlier call verbatim* — what `TOOL_REPEAT_LIMIT` counts. |
 | `serge_job_path_revisits` | Calls that re-opened a *path already opened*, counted per path as visits−1. A second `read_file` of the same file at a different line range is a revisit but not a verbatim repeat, and that is the shape that dominates in practice. |
 
+### Reading the token numbers
+
+`serge_job_input_tokens` is **not** the size of a context. The loop re-sends the
+whole conversation every turn, so it is each turn's prompt *summed over the
+session* — the API-billing sense of "input tokens", and the quantity
+`LLM_MAX_INPUT_TOKENS` caps. Two more series exist so it can be read correctly:
+
+| Metric | Meaning |
+| ------ | ------- |
+| `serge_job_peak_input_tokens` | The largest single request's prompt. The only one that says whether the model came near its context limit. |
+| `serge_job_cached_input_tokens` | Input tokens the provider served from its prefix cache. **Absent, not zero,** when the provider reported no cache figure — wherever it has no sample, `serge_job_input_tokens` is an upper bound on the bill, not the bill. |
+
+The gap between the two is wide in practice. On prod task `d9d4b022`
+(transformers#48534, 2026-09-07) the sum was 2,094,215 and the peak 56,400 — 37×
+— because 62 accumulated tool results were re-billed once per remaining turn,
+while the fixed prompt prefix was only ~5,100 tokens (14% of the session).
+Because the sum grows quadratically in turns, doubling the cap buys roughly
+1.5× the turns, not 2×.
+
+`TOOL_RESULT_WINDOW` (and `TASK_TOOL_RESULT_WINDOW`) trades that sum down by
+sending only the newest N tool results verbatim and replacing older ones with a
+stub the model can re-run; `serge_job_elided_tool_results` and
+`serge_job_elided_chars` report what the widest single request dropped. It
+defaults to **0 (off)**: the loop being append-only is the shape a provider
+prefix-cache wants, and rewriting history invalidates that cache, so check
+`serge_job_cached_input_tokens` before assuming a window saves money.
+
 Both have a nudge attached (`TOOL_REPEAT_LIMIT` / `TOOL_PATH_REVISIT_LIMIT`) and a separate cut-off budget (`TOOL_REPEAT_LIMIT` / `TOOL_PATH_TRIP_AFTER`), because they are different failures: one model is stuck on a single call, the other is browsing in circles.
 
 The label that matters most is `stop_reason` on `serge_job_info`:

--- a/reviewbot/config.py
+++ b/reviewbot/config.py
@@ -89,6 +89,14 @@ class Config:
     # stop the agentic loop, ask the model for a final review with tools
     # off, and skip any remaining diff chunks. Set to 0 to disable.
     llm_max_input_tokens: int = 2_000_000
+    # How many of the newest browse-tool results to keep verbatim in the
+    # transcript sent each turn; older ones travel as a stub the model can
+    # re-run (:mod:`reviewbot.transcript`). 0 — the default — sends the whole
+    # transcript, which is what every run measured to date did. Non-zero is a
+    # spend lever, not a quality one: the cap above counts each turn's entire
+    # prompt, and on prod task d9d4b022 86% of a 2M-token session was the
+    # transcript being re-sent. Read that module before setting it.
+    tool_result_window: int = 0
     # How many *repeated* (byte-identical) tool calls to tolerate before
     # declaring the agent stuck and forcing a final answer. Each repeat is told
     # it is repeating; past this many the loop stops rather than spending the
@@ -222,6 +230,11 @@ class Config:
     # normal review values.
     task_llm_max_input_tokens: Optional[int] = None
     task_tool_max_iterations: Optional[int] = None
+    # Task-only transcript window. Tasks are where the cap actually binds --
+    # 16 of the 86 jobs in the 30 days to 2026-09-08 ended on
+    # `input_token_cap`, at 65 turns on average — so this can be rolled out to
+    # tasks without touching reviews.
+    task_tool_result_window: Optional[int] = None
     # Cap on serge-authored commits per fix branch (follow-up loop guard).
     task_max_followups: int = 5
 
@@ -536,6 +549,7 @@ class Config:
             # PRs complete without being forced to truncate.
             tool_max_iterations=_int_env("TOOL_MAX_ITERATIONS", 30),
             llm_max_input_tokens=_int_env("LLM_MAX_INPUT_TOKENS", 2_000_000),
+            tool_result_window=_int_env("TOOL_RESULT_WINDOW", 0),
             tool_repeat_limit=_int_env("TOOL_REPEAT_LIMIT", 6),
             tool_path_revisit_limit=_int_env("TOOL_PATH_REVISIT_LIMIT", 3),
             tool_path_trip_after=_int_env("TOOL_PATH_TRIP_AFTER", 40),
@@ -576,6 +590,7 @@ class Config:
                 _int_env("TASK_LLM_MAX_INPUT_TOKENS", 0) or None
             ),
             task_tool_max_iterations=(_int_env("TASK_TOOL_MAX_ITERATIONS", 0) or None),
+            task_tool_result_window=(_int_env("TASK_TOOL_RESULT_WINDOW", 0) or None),
             task_max_followups=_int_env("TASK_MAX_FOLLOWUPS", 5),
             task_execution=task_execution,
             review_execution=review_execution,

--- a/reviewbot/launcher.py
+++ b/reviewbot/launcher.py
@@ -66,6 +66,7 @@ RUNNER_CONFIG_FIELDS: tuple[str, ...] = (
     "llm_max_input_tokens",
     "tool_max_iterations",
     "tool_max_iterations_strict",
+    "tool_result_window",
     "tool_repeat_limit",
     "task_scope_commit_to_patch",
     "task_commit_always_include",

--- a/reviewbot/llm_client.py
+++ b/reviewbot/llm_client.py
@@ -64,6 +64,25 @@ def _is_anthropic_base(api_base: str) -> bool:
     return "api.anthropic.com" in api_base.lower()
 
 
+def cached_tokens_from_usage(usage: dict[str, Any]) -> Optional[int]:
+    """Pull the prefix-cache hit count out of a ``usage`` block, or None.
+
+    Split out of :attr:`ChatResult.cached_tokens` so the per-call log line can
+    read it straight off the raw usage dict. See that property for why None and
+    zero must stay distinguishable, and for the three spellings.
+    """
+    details = usage.get("prompt_tokens_details")
+    if isinstance(details, dict):
+        value = details.get("cached_tokens")
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    for key in ("cache_read_input_tokens", "cached_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return None
+
+
 class LLMResponseError(requests.HTTPError):
     """Non-OK HTTP response from the chat-completions endpoint that
     exhausted retries (or wasn't retryable to begin with). Carries the
@@ -122,6 +141,26 @@ class ChatResult:
     def completion_tokens(self) -> Optional[int]:
         v = self.usage.get("completion_tokens")
         return v if isinstance(v, int) else None
+
+    @property
+    def cached_tokens(self) -> Optional[int]:
+        """How many of ``prompt_tokens`` the provider served from its prefix
+        cache, or None when it did not say.
+
+        None is NOT zero, and the difference is the whole point of reading
+        this: the agent loop is append-only, so every turn re-sends the entire
+        conversation and ``prompt_tokens`` summed over a session is an *upper
+        bound* on what was billed. Reporting an unknown as 0 would assert that
+        a run was entirely uncached on no evidence — so a provider that says
+        nothing exports no sample at all (see ``metrics._number``).
+
+        Three spellings for the same number, because serge talks to three
+        shapes of OpenAI-compatible endpoint: OpenAI and the HF Router nest it
+        under ``prompt_tokens_details``, Anthropic's OpenAI shim reports
+        ``cache_read_input_tokens`` next to ``prompt_tokens``, and some vLLM
+        builds put a flat ``cached_tokens`` at the top level.
+        """
+        return cached_tokens_from_usage(self.usage)
 
 
 # Rate-limit headers, in the spellings the OpenAI-compatible endpoints serge
@@ -747,10 +786,13 @@ class ChatCompletionClient:
                     )
             latency = time.monotonic() - started
             log.info(
-                "LLM call ok in %.1fs (prompt=%s, completion=%s, stream=%s, "
-                "tool_calls=%d, finish=%s)",
+                "LLM call ok in %.1fs (prompt=%s, cached=%s, completion=%s, "
+                "stream=%s, tool_calls=%d, finish=%s)",
                 latency,
                 usage.get("prompt_tokens"),
+                # None here means the provider reported no cache figure, not
+                # that nothing was cached; see ChatResult.cached_tokens.
+                cached_tokens_from_usage(usage),
                 usage.get("completion_tokens"),
                 self.stream,
                 len(tool_calls),

--- a/reviewbot/metrics.py
+++ b/reviewbot/metrics.py
@@ -40,6 +40,22 @@ _JOB_GAUGES: tuple[tuple[str, str, str], ...] = (
         "LLM_MAX_INPUT_TOKENS; a job running several rounds can exceed it.",
     ),
     (
+        "serge_job_peak_input_tokens",
+        "peak_prompt_tokens",
+        "Largest single request's prompt in the job. serge_job_input_tokens is "
+        "this figure summed over every turn, because the loop re-sends the "
+        "whole conversation each time; only this one says how close the model "
+        "came to its context limit.",
+    ),
+    (
+        "serge_job_cached_input_tokens",
+        "cached_tokens",
+        "Input tokens the provider served from its prefix cache. Absent, not "
+        "zero, when the provider reported no cache figure — so "
+        "serge_job_input_tokens is an upper bound on the bill wherever this "
+        "series has no sample.",
+    ),
+    (
         "serge_job_output_tokens",
         "completion_tokens",
         "Cumulative output tokens billed to the job.",
@@ -63,6 +79,20 @@ _JOB_GAUGES: tuple[tuple[str, str, str], ...] = (
         "counted per path as visits-1. Not the same as repeat_calls: a re-read "
         "of a different line range of the same file is a revisit but not an "
         "exact repeat, and that is the shape that dominates.",
+    ),
+    (
+        "serge_job_elided_tool_results",
+        "elided_tool_results",
+        "Tool results the browse-transcript window replaced with a stub in the "
+        "widest single request (TOOL_RESULT_WINDOW). 0 when the window is off, "
+        "which is the default.",
+    ),
+    (
+        "serge_job_elided_chars",
+        "elided_chars",
+        "Characters the browse-transcript window removed from the widest "
+        "single request. A max across turns, not a sum: elision is recomputed "
+        "from the full transcript every turn.",
     ),
     (
         "serge_job_validation_retries",

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -24,6 +24,7 @@ from .prompts import (
     build_user_prompt,
 )
 from .tool_repeat import ToolRepeatGuard
+from .transcript import elide_old_tool_results
 from .tools import (
     RepoHelperTool,
     ToolEnv,
@@ -470,6 +471,20 @@ class _AggregateMetrics:
     latency_seconds: float = 0.0
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Largest single call's prompt in this loop, as opposed to `prompt_tokens`,
+    # which is that figure *summed over every turn*. Both are needed and they
+    # answer different questions: the sum is what the input-token cap governs
+    # and roughly what gets billed, while the peak is the only one that says
+    # whether the model was anywhere near its context limit. On prod task
+    # d9d4b022 the sum was 2,094,215 and the peak 56,400 — a 37x gap that made
+    # the cap look like a context problem when it is a spend problem.
+    peak_prompt_tokens: int = 0
+    # Prompt tokens the provider served from its prefix cache, summed over the
+    # turns that reported one. Stays None when no turn reported any, which is
+    # the honest reading of a provider that says nothing — see
+    # :attr:`llm_client.ChatResult.cached_tokens`. Without it, `prompt_tokens`
+    # is only an upper bound on the bill and there is no way to tell how loose.
+    cached_tokens: Optional[int] = None
     # Why the loop stopped. ``STOP_ANSWERED`` is the *only* value meaning the
     # model decided it was done; every other value is a guard cutting it off and
     # forcing an answer out of whatever budget was left. Worth recording per job:
@@ -485,6 +500,42 @@ class _AggregateMetrics:
     # the truncated-final-answer salvage respectively.
     validation_retries: int = 0
     truncation_retries: int = 0
+    # Widest single request's browse-transcript elision (see
+    # :mod:`reviewbot.transcript`): how many tool results were replaced by a
+    # stub, and how many characters that removed. A MAX across turns, not a
+    # sum — elision is recomputed from the full transcript on every turn, so
+    # adding the per-turn figures up would count the same saving once per
+    # remaining turn. Both are 0 when the window is off, which is the default.
+    elided_tool_results: int = 0
+    elided_chars: int = 0
+
+    def record_usage(self, chat: "ChatResult") -> None:
+        """Fold one LLM call's tokens and latency in, without spending a turn.
+
+        For calls that are not the agentic loop browsing the PR: the comment
+        brevity pass on either side. ``turns`` is read as loop iterations by the
+        serge-agent-sessions dashboard, so those calls must not inflate it.
+
+        Every site that folds usage in at all goes through here or
+        :meth:`record_call`. There are five of them, and `peak_prompt_tokens`
+        and `cached_tokens` were both added long after the first three — a
+        counter wired into five places by hand is one that will silently be
+        wrong at one of them.
+        """
+        self.latency_seconds += chat.latency_seconds or 0.0
+        if chat.prompt_tokens is not None:
+            self.prompt_tokens += chat.prompt_tokens
+            self.peak_prompt_tokens = max(self.peak_prompt_tokens, chat.prompt_tokens)
+        if chat.completion_tokens is not None:
+            self.completion_tokens += chat.completion_tokens
+        cached = chat.cached_tokens
+        if cached is not None:
+            self.cached_tokens = (self.cached_tokens or 0) + cached
+
+    def record_call(self, chat: "ChatResult") -> None:
+        """Fold in one LLM call that *was* a turn of the agentic loop."""
+        self.turns += 1
+        self.record_usage(chat)
 
 
 # Loop-exit reasons, recorded on _AggregateMetrics.stop_reason. Only ANSWERED
@@ -526,6 +577,9 @@ def no_llm_session_record(stop_reason: str = STOP_NO_LLM_TURNS) -> dict[str, Any
         "turns": 0,
         "tool_calls": 0,
         "prompt_tokens": 0,
+        "peak_prompt_tokens": 0,
+        # Not 0: no call was made, so no provider ever reported a cache figure.
+        "cached_tokens": None,
         "completion_tokens": 0,
         "seconds": 0.0,
         "stop_reason": stop_reason,
@@ -534,6 +588,8 @@ def no_llm_session_record(stop_reason: str = STOP_NO_LLM_TURNS) -> dict[str, Any
         "path_revisits": 0,
         "validation_retries": 0,
         "truncation_retries": 0,
+        "elided_tool_results": 0,
+        "elided_chars": 0,
         "rounds": 0,
     }
 
@@ -563,6 +619,10 @@ def session_record(m: "_AggregateMetrics") -> dict[str, Any]:
         "turns": m.turns,
         "tool_calls": m.tool_calls,
         "prompt_tokens": m.prompt_tokens,
+        "peak_prompt_tokens": m.peak_prompt_tokens,
+        # May be None — "the provider told us nothing", which must not be
+        # reported as "nothing was cached". metrics._number drops the sample.
+        "cached_tokens": m.cached_tokens,
         "completion_tokens": m.completion_tokens,
         "seconds": round(m.latency_seconds, 1),
         "stop_reason": m.stop_reason,
@@ -571,6 +631,8 @@ def session_record(m: "_AggregateMetrics") -> dict[str, Any]:
         "path_revisits": m.path_revisits,
         "validation_retries": m.validation_retries,
         "truncation_retries": m.truncation_retries,
+        "elided_tool_results": m.elided_tool_results,
+        "elided_chars": m.elided_chars,
         "rounds": 1,
     }
 
@@ -587,6 +649,30 @@ _SESSION_SUMS = (
     "validation_retries",
     "truncation_retries",
 )
+
+# Counters where folding two loops together means taking the larger, not adding:
+# each round is a fresh conversation, so the widest prompt the job ever sent is
+# the widest any one round sent — summing them would invent a context that never
+# existed. `distinct_paths` is here for the older reason that summing it
+# double-counts a file two chunks both opened.
+_SESSION_MAXES = (
+    "distinct_paths",
+    "peak_prompt_tokens",
+    "elided_tool_results",
+    "elided_chars",
+)
+
+
+def _merge_optional_sum(left: Any, right: Any) -> Optional[int]:
+    """Add two counters that may each be None, where None means "unknown".
+
+    None + None is None (still unknown); None + 5 is 5. Used for
+    ``cached_tokens``, where a provider that reports nothing must not be folded
+    in as a zero and make the job look entirely uncached.
+    """
+    if left is None and right is None:
+        return None
+    return int(left or 0) + int(right or 0)
 
 
 def _rounds(record: dict[str, Any]) -> int:
@@ -626,9 +712,15 @@ def merge_session_records(
         + float(part.get("seconds", 0.0) or 0.0),
         1,
     )
-    merged["distinct_paths"] = max(
-        int(merged.get("distinct_paths", 0) or 0),
-        int(part.get("distinct_paths", 0) or 0),
+    for key in _SESSION_MAXES:
+        merged[key] = max(
+            int(merged.get(key, 0) or 0),
+            int(part.get(key, 0) or 0),
+        )
+    # Kept out of _SESSION_SUMS because None must survive the fold: `int(x or 0)`
+    # would turn "neither round knew" into a confident zero.
+    merged["cached_tokens"] = _merge_optional_sum(
+        merged.get("cached_tokens"), part.get("cached_tokens")
     )
     merged["rounds"] = _rounds(merged) + _rounds(part)
     if part.get("stop_reason", STOP_ANSWERED) != STOP_ANSWERED:
@@ -650,6 +742,12 @@ def _merge_metrics(total: "_AggregateMetrics", part: "_AggregateMetrics") -> Non
     # summing them double-counts a file two chunks both opened. An upper bound is
     # the honest reading available without keeping every path around.
     total.distinct_paths = max(total.distinct_paths, part.distinct_paths)
+    # Peaks and elision figures are per-request, so the job-level value is the
+    # widest one any chunk saw, not the total (see _SESSION_MAXES).
+    total.peak_prompt_tokens = max(total.peak_prompt_tokens, part.peak_prompt_tokens)
+    total.elided_tool_results = max(total.elided_tool_results, part.elided_tool_results)
+    total.elided_chars = max(total.elided_chars, part.elided_chars)
+    total.cached_tokens = _merge_optional_sum(total.cached_tokens, part.cached_tokens)
     # A cut-off chunk means the session was cut off, whatever later chunks did.
     if part.stop_reason != STOP_ANSWERED:
         total.stop_reason = part.stop_reason
@@ -866,12 +964,7 @@ def _synthesize_merged_summary(
         log.warning("synthesis merge failed: %s", exc)
         return None, None
 
-    metrics.turns += 1
-    metrics.latency_seconds += chat.latency_seconds
-    if chat.prompt_tokens is not None:
-        metrics.prompt_tokens += chat.prompt_tokens
-    if chat.completion_tokens is not None:
-        metrics.completion_tokens += chat.completion_tokens
+    metrics.record_call(chat)
     _emit_metrics(emit, metrics)
 
     text = (chat.content or "").strip()
@@ -924,9 +1017,7 @@ def _condense_review(
         # Tokens and latency, but not a turn: this is not the agentic loop
         # browsing the PR, and `session`'s turn count is read as loop
         # iterations (see the serge-agent-sessions dashboard).
-        metrics.prompt_tokens += result.chat.prompt_tokens or 0
-        metrics.completion_tokens += result.chat.completion_tokens or 0
-        metrics.latency_seconds += result.chat.latency_seconds or 0.0
+        metrics.record_usage(result.chat)
     return shortened[0]
 
 
@@ -1202,6 +1293,15 @@ def _run_agentic_loop(
     input_tokens_cap: Optional[int] = (
         cfg.llm_max_input_tokens if cfg.llm_max_input_tokens > 0 else None
     )
+    # How many of the newest tool results to keep verbatim in the transcript;
+    # older ones are sent as a stub (:mod:`reviewbot.transcript`). 0 — the
+    # default — sends the whole transcript, which is the behaviour every
+    # measured run above had. Worth knowing before turning it on: the loop is
+    # append-only today, which is the shape a provider prefix-cache wants, and
+    # rewriting history invalidates that cache from the elision point on. If
+    # the provider is discounting cache reads, a window can cost *more* than it
+    # saves — read serge_job_cached_input_tokens first.
+    tool_result_window: int = getattr(cfg, "tool_result_window", 0) or 0
     # Absolute backstop: at least twice the configured blind-turn cap,
     # but never below 60. Prevents a runaway model from chaining tool
     # calls indefinitely while still leaving real investigations room
@@ -1217,6 +1317,9 @@ def _run_agentic_loop(
     )
     iteration = 0
     blind_tool_turns = 0
+    # The window is reported to the journal once, not once a turn: it elides on
+    # every one of 50+ turns and a line each would bury the run log.
+    elision_announced = False
     validation_retries = 0
     truncation_retries = 0
     # The defect the last re-ask was issued for. A re-ask that produces the same
@@ -1307,8 +1410,37 @@ def _run_agentic_loop(
             emit("log", f"LLM turn (blind={label})")
         turn_tools = None if force_json_only else tools_arg
         turn_effort = "low" if force_json_only else cfg.llm_reasoning_effort
-        chat = llm.complete(
+        # Window the transcript for browse turns only. `force_json_only` is the
+        # salvage turn that has to *produce* the patch out of what it read, so
+        # it gets the full transcript however big it is — one wide request is
+        # cheap next to the sum, and starving the answer is the one failure this
+        # must not cause. Same reasoning keeps the forced final answer below
+        # unwindowed.
+        request_messages, elided, elided_chars = elide_old_tool_results(
             messages,
+            keep_recent=0 if force_json_only else tool_result_window,
+        )
+        if elided:
+            metrics.elided_tool_results = max(metrics.elided_tool_results, elided)
+            metrics.elided_chars = max(metrics.elided_chars, elided_chars)
+            log.info(
+                "Elided %d older tool result(s) (%d chars) from the request; "
+                "keeping the newest %d verbatim",
+                elided,
+                elided_chars,
+                tool_result_window,
+            )
+            if not elision_announced and emit is not None:
+                emit(
+                    "log",
+                    f"Browse transcript windowed to the newest "
+                    f"{tool_result_window} tool results; {elided} older "
+                    f"result(s) ({elided_chars:,} chars) are being sent as a "
+                    "stub the model can re-run",
+                )
+                elision_announced = True
+        chat = llm.complete(
+            request_messages,
             max_tokens=cfg.llm_max_tokens,
             tools=turn_tools,
             tool_choice="auto" if turn_tools else None,
@@ -1316,12 +1448,7 @@ def _run_agentic_loop(
             extra={"reasoning_effort": turn_effort} if turn_effort else None,
         )
         force_json_only = False
-        metrics.turns += 1
-        metrics.latency_seconds += chat.latency_seconds
-        if chat.prompt_tokens is not None:
-            metrics.prompt_tokens += chat.prompt_tokens
-        if chat.completion_tokens is not None:
-            metrics.completion_tokens += chat.completion_tokens
+        metrics.record_call(chat)
         _emit_metrics(emit, metrics)
         # Log what the model emitted this turn (content + finish_reason +
         # tool-call names). Captures the empty final turn behind
@@ -1494,12 +1621,7 @@ def _run_agentic_loop(
             chunk_callback=chunk_cb,
             extra=final_extra,
         )
-        metrics.turns += 1
-        metrics.latency_seconds += chat.latency_seconds
-        if chat.prompt_tokens is not None:
-            metrics.prompt_tokens += chat.prompt_tokens
-        if chat.completion_tokens is not None:
-            metrics.completion_tokens += chat.completion_tokens
+        metrics.record_call(chat)
         _emit_metrics(emit, metrics)
         _emit_chat_message(
             emit,
@@ -1604,17 +1726,22 @@ def _emit_metrics(
         if metrics.latency_seconds > 0
         else 0.0
     )
-    payload = json.dumps(
-        {
-            "in": metrics.prompt_tokens,
-            "out": metrics.completion_tokens,
-            "rate": round(rate, 1),
-            "seconds": round(metrics.latency_seconds, 1),
-            "turns": metrics.turns,
-            "tools": metrics.tool_calls,
-        }
-    )
-    emit("metrics", payload)
+    payload: dict[str, Any] = {
+        "in": metrics.prompt_tokens,
+        "out": metrics.completion_tokens,
+        "rate": round(rate, 1),
+        "seconds": round(metrics.latency_seconds, 1),
+        "turns": metrics.turns,
+        "tools": metrics.tool_calls,
+    }
+    # Additive: review.js reads only `in`. `peak` is what makes the per-turn
+    # deltas in a job's journal readable without differencing `in` by hand, and
+    # `cached` is omitted rather than zeroed when the provider said nothing.
+    if metrics.peak_prompt_tokens:
+        payload["peak"] = metrics.peak_prompt_tokens
+    if metrics.cached_tokens is not None:
+        payload["cached"] = metrics.cached_tokens
+    emit("metrics", json.dumps(payload))
 
 
 # Per-message log cap. Assistant turns are small (the model's own output),

--- a/reviewbot/tasks.py
+++ b/reviewbot/tasks.py
@@ -910,17 +910,21 @@ def prepare_task(
         existing_diff=existing_diff,
     )
 
-    # This prefix is resent on EVERY turn, so its size -- not the number of tool
-    # calls -- sets how many turns the input-token cap buys. Measured on a real
-    # 51-turn task (mm_grounding_dino, 2026-08-31): turn 1 cost 25,335 input
-    # tokens and the conversation itself then grew only ~510 tokens a turn, so
-    # ~63% of the whole 2M budget went on re-sending this prefix. The known
-    # components (system template, conventions, tool schemas, dispatched ITF
-    # context) account for only ~3.2k of those 25.3k, and the residue is
-    # believed to be the GPU reproduce/verify feedback that `_with_feedback`
-    # appends to `req.context`. "Believed" is the problem: it was reached by
-    # subtraction because the request body is never logged. Log the breakdown
-    # once per task so the dominant component is a fact in the job row.
+    # This prefix is resent on EVERY turn, so log its breakdown once per task —
+    # it is the only way the dominant component of a session's bill is a fact in
+    # the job row rather than something reached by subtraction.
+    #
+    # It is no longer the dominant component, and this comment used to say it
+    # was. Measured on mm_grounding_dino (2026-08-31, 51 turns), turn 1 cost
+    # 25,335 input tokens and the conversation grew only ~510 a turn, so ~63% of
+    # the 2M budget went on re-sending this prefix. Re-measured across all 8
+    # tasks that hit the cap in the 30 days to 2026-09-08, the prefix is
+    # 16.7k–20.2k chars (~5k tokens) and the transcript is what dominates: on
+    # d9d4b022 the prefix was 14% of a 2,094,215-token session and 62
+    # accumulated tool results were the other 86%, with the widest single
+    # request at 56,400 tokens. So shrinking this buys little now, and the
+    # lever is `TOOL_RESULT_WINDOW` (:mod:`reviewbot.transcript`). Keep logging
+    # it anyway: that conclusion is only checkable because this line exists.
     _emit(
         "log",
         prompt_prefix_summary(
@@ -1010,9 +1014,9 @@ def prepare_task(
         parses=_parses,
     )
     for brevity_chat in brevity_chats:
-        metrics.prompt_tokens += brevity_chat.prompt_tokens or 0
-        metrics.completion_tokens += brevity_chat.completion_tokens or 0
-        metrics.latency_seconds += brevity_chat.latency_seconds or 0.0
+        # Tokens and latency, but not a turn — same reasoning as the review-side
+        # brevity pass in reviewer._condense_review.
+        metrics.record_usage(brevity_chat)
     metrics_line = _format_aggregated_metrics(metrics)
     _emit("log", f"LLM done: {metrics_line}")
 

--- a/reviewbot/transcript.py
+++ b/reviewbot/transcript.py
@@ -1,0 +1,102 @@
+"""Sliding window over the browse transcript sent to the model each turn.
+
+Why this exists: the agent loop is append-only, and the input-token cap
+(``LLM_MAX_INPUT_TOKENS``) counts *every* call's whole prompt, so a session's
+cost is the sum of a context that only grows — quadratic in turns, not linear.
+Measured on prod task ``d9d4b022`` (transformers#48534, 2026-09-07, 56 turns,
+2,094,215 cumulative input tokens):
+
+* the fixed prefix was 17,526 chars (~5,100 tokens) — 14% of the budget;
+* the other 86% was 62 accumulated tool results being re-sent;
+* the last turn's prompt was 56,400 tokens, 37x the largest message in it;
+* per-turn prompts grew 5,100 -> 56,400 at roughly 936 tokens a turn.
+
+So the cap is not a context-window problem (the peak is a third of what the
+model allows) and not a prefix problem — it is the transcript being re-billed
+once per remaining turn. Windowing it turns that sum back into roughly linear:
+with 20 results kept, that job's per-turn prompt would hold near ~21k instead
+of climbing to 56k, and the turn ceiling under the same 2M cap rises from 56 to
+roughly 95.
+
+What this does NOT do is de-duplicate reads. It is the obvious next thought and
+it is wrong here: on the same job, 3,101 lines were read across 33 ``read_file``
+calls covering 2,802 distinct lines — 1.11x. The six reads of ``modular_blt.py``
+were six *different windows*, not the same text six times. There is nothing to
+reclaim by de-duplicating, and a de-duplicating cache would spend its
+complexity on 9%.
+
+Two constraints shape the implementation:
+
+* **Every ``role: "tool"`` message must stay in place.** Providers reject a
+  request where an assistant ``tool_calls`` entry has no matching tool reply,
+  so dropping the message outright 400s the turn. Only ``content`` is replaced.
+* **The stub has to read as "this happened and you can redo it".** A model that
+  reads a bare ``[elided]`` can conclude the file does not exist and give up on
+  the path; one that is told the call returned N characters and can be re-run
+  will re-run it if it still needs the text.
+
+Non-destructive by contract: the caller keeps its full ``messages`` list and
+passes a windowed *copy* to the provider, so every turn re-windows from the
+complete transcript. That keeps the function pure, keeps the journal's copy of
+what was read intact, and means an elided message is never elided twice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ELIDED = (
+    "[The earlier {name} call was made and returned {size:,} characters, but "
+    "its output has been removed from this transcript to stay inside the "
+    "input-token budget. Run the call again if you still need the output.]"
+)
+
+
+def elided_stub(name: str, size: int) -> str:
+    """The placeholder left in place of a tool result's content."""
+    return _ELIDED.format(name=name or "tool", size=size)
+
+
+def elide_old_tool_results(
+    messages: list[dict[str, Any]],
+    *,
+    keep_recent: int,
+    min_chars: int = 0,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Return ``messages`` with all but the newest ``keep_recent`` tool results
+    replaced by :func:`elided_stub`, plus how many were replaced and how many
+    characters that removed.
+
+    ``keep_recent <= 0`` disables the window and returns the input list itself
+    (not a copy) with zero counts — the default, so this is inert until an
+    operator sets ``TOOL_RESULT_WINDOW``. ``min_chars`` leaves results at or
+    below that size alone; a stub is not always shorter than the two-line grep
+    output it would replace, and a result is never made *longer* than it was.
+    """
+    if keep_recent <= 0:
+        return messages, 0, 0
+    tool_positions = [
+        index
+        for index, message in enumerate(messages)
+        if isinstance(message, dict) and message.get("role") == "tool"
+    ]
+    if len(tool_positions) <= keep_recent:
+        return messages, 0, 0
+
+    windowed = list(messages)
+    elided = 0
+    saved = 0
+    for index in tool_positions[:-keep_recent]:
+        message = windowed[index]
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        stub = elided_stub(str(message.get("name") or "tool"), len(content))
+        if len(content) <= max(len(stub), min_chars):
+            continue
+        windowed[index] = {**message, "content": stub}
+        elided += 1
+        saved += len(content) - len(stub)
+    if not elided:
+        return messages, 0, 0
+    return windowed, elided, saved

--- a/reviewbot/webapp.py
+++ b/reviewbot/webapp.py
@@ -108,11 +108,13 @@ log = logging.getLogger("serge.web")
 cfg = Config.from_env(require_app=False, require_web=True)
 log.info(
     "Config: llm_stream=%s, llm_max_tokens=%d, tool_max_iterations=%s, "
-    "llm_max_input_tokens=%s, max_diff_chars=%d, mention_trigger=%r",
+    "llm_max_input_tokens=%s, tool_result_window=%s, max_diff_chars=%d, "
+    "mention_trigger=%r",
     cfg.llm_stream,
     cfg.llm_max_tokens,
     cfg.tool_max_iterations if cfg.tool_max_iterations > 0 else "unlimited",
     cfg.llm_max_input_tokens if cfg.llm_max_input_tokens > 0 else "unlimited",
+    cfg.tool_result_window if cfg.tool_result_window > 0 else "off",
     cfg.max_diff_chars,
     cfg.mention_trigger,
 )
@@ -503,6 +505,11 @@ def _resolve_task_worker_cfg(
         ),
         tool_max_iterations=cfg.task_tool_max_iterations or cfg.tool_max_iterations,
         tool_max_iterations_strict=cfg.task_tool_max_iterations is not None,
+        tool_result_window=(
+            cfg.task_tool_result_window
+            if cfg.task_tool_result_window is not None
+            else cfg.tool_result_window
+        ),
     )
     return worker_cfg, provider, llm_api_base, llm_model or None
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,8 +7,10 @@ import requests
 
 from reviewbot.llm_client import (
     ChatCompletionClient,
+    ChatResult,
     LLMResponseError,
     _parse_text_tool_calls,
+    cached_tokens_from_usage,
 )
 
 
@@ -1166,6 +1168,80 @@ class TextToolCallRecoveryTests(unittest.TestCase):
         self.assertEqual([c.name for c in result.tool_calls], ["grep"])
         # The structured field was authoritative, so content is left alone.
         self.assertEqual(result.content, self.PROD_CONTENT)
+
+
+class CachedTokenReadingTests(unittest.TestCase):
+    """Reading the prefix-cache figure off a usage block.
+
+    Why it matters: the agent loop re-sends the whole conversation every turn,
+    so summed `prompt_tokens` is an upper bound on the bill. How loose that
+    bound is depends entirely on this number, and None (the provider said
+    nothing) must never collapse into 0 (nothing was cached).
+    """
+
+    def test_openai_and_hf_router_nest_it_under_details(self) -> None:
+        chat = ChatResult(
+            content="",
+            usage={
+                "prompt_tokens": 56_400,
+                "prompt_tokens_details": {"cached_tokens": 51_200},
+            },
+        )
+        self.assertEqual(chat.cached_tokens, 51_200)
+
+    def test_the_anthropic_shim_spelling_is_read(self) -> None:
+        chat = ChatResult(
+            content="",
+            usage={"prompt_tokens": 900, "cache_read_input_tokens": 750},
+        )
+        self.assertEqual(chat.cached_tokens, 750)
+
+    def test_a_flat_cached_tokens_is_read(self) -> None:
+        chat = ChatResult(content="", usage={"prompt_tokens": 900, "cached_tokens": 40})
+        self.assertEqual(chat.cached_tokens, 40)
+
+    def test_a_silent_provider_reads_as_unknown(self) -> None:
+        chat = ChatResult(content="", usage={"prompt_tokens": 900})
+        self.assertIsNone(chat.cached_tokens)
+
+    def test_a_reported_zero_is_kept_as_zero(self) -> None:
+        """A provider that says "nothing was cached" is real information, and
+        distinct from one that says nothing at all."""
+        chat = ChatResult(
+            content="",
+            usage={"prompt_tokens": 900, "prompt_tokens_details": {"cached_tokens": 0}},
+        )
+        self.assertEqual(chat.cached_tokens, 0)
+
+    def test_junk_is_ignored_rather_than_returned(self) -> None:
+        for usage in (
+            {"prompt_tokens_details": {"cached_tokens": "800"}},
+            {"prompt_tokens_details": "800"},
+            {"cached_tokens": None},
+            {"cached_tokens": True},
+            {},
+        ):
+            with self.subTest(usage=usage):
+                self.assertIsNone(ChatResult(content="", usage=usage).cached_tokens)
+
+    def test_details_win_over_the_flat_spelling(self) -> None:
+        chat = ChatResult(
+            content="",
+            usage={
+                "prompt_tokens_details": {"cached_tokens": 700},
+                "cached_tokens": 1,
+            },
+        )
+        self.assertEqual(chat.cached_tokens, 700)
+
+    def test_the_helper_reads_a_bare_usage_dict(self) -> None:
+        """Split out so the per-call log line does not have to build a
+        ChatResult just to log the number."""
+        self.assertEqual(
+            cached_tokens_from_usage({"prompt_tokens_details": {"cached_tokens": 12}}),
+            12,
+        )
+        self.assertIsNone(cached_tokens_from_usage({}))
 
 
 if __name__ == "__main__":

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,6 +41,10 @@ def _row(job_id: str, **overrides) -> dict:
             "path_revisits": 14,
             "validation_retries": 1,
             "truncation_retries": 0,
+            "peak_prompt_tokens": 56_400,
+            "cached_tokens": 1_800_000,
+            "elided_tool_results": 0,
+            "elided_chars": 0,
             "rounds": 1,
         },
     }
@@ -89,6 +93,51 @@ class ExpositionShapeTests(unittest.TestCase):
         self.assertIn('serge_job_distinct_paths{job_id="a"} 12', body)
         self.assertIn('serge_job_rounds{job_id="a"} 1', body)
         self.assertIn('serge_job_llm_seconds{job_id="a"} 1234.5', body)
+
+    def test_the_peak_is_exported_next_to_the_cumulative_total(self) -> None:
+        """serge_job_input_tokens is the cumulative bill, not a context size —
+        the peak is the only series that says how wide a single request got."""
+        body = render_job_metrics([_row("a")])
+        self.assertIn('serge_job_input_tokens{job_id="a"} 2111885', body)
+        self.assertIn('serge_job_peak_input_tokens{job_id="a"} 56400', body)
+        self.assertIn('serge_job_cached_input_tokens{job_id="a"} 1800000', body)
+
+    def test_an_unknown_cache_figure_exports_no_sample(self) -> None:
+        """Absent is the honest encoding of "the provider told us nothing".
+        Exporting 0 would claim the run was entirely uncached, and a dashboard
+        would then report a bill that was never charged."""
+        row = _row("a")
+        row["session"] = {**row["session"], "cached_tokens": None}
+        body = render_job_metrics([row])
+        self.assertEqual(_samples(body, "serge_job_cached_input_tokens"), [])
+        self.assertNotIn("serge_job_cached_input_tokens", body)
+        # The rest of the job still exports.
+        self.assertIn('serge_job_input_tokens{job_id="a"} 2111885', body)
+
+    def test_a_session_from_an_older_build_exports_what_it_has(self) -> None:
+        """Session records are JSON written by an older build as easily as this
+        one; a missing key must skip its sample, not break the scrape."""
+        row = _row("a")
+        row["session"] = {
+            "turns": 12,
+            "prompt_tokens": 500,
+            "stop_reason": "answered",
+            "rounds": 1,
+        }
+        body = render_job_metrics([row])
+        self.assertIn('serge_job_input_tokens{job_id="a"} 500', body)
+        self.assertEqual(_samples(body, "serge_job_peak_input_tokens"), [])
+
+    def test_the_elision_counters_are_exported(self) -> None:
+        row = _row("a")
+        row["session"] = {
+            **row["session"],
+            "elided_tool_results": 34,
+            "elided_chars": 121_000,
+        }
+        body = render_job_metrics([row])
+        self.assertIn('serge_job_elided_tool_results{job_id="a"} 34', body)
+        self.assertIn('serge_job_elided_chars{job_id="a"} 121000', body)
 
     def test_finished_timestamp_orders_the_window(self) -> None:
         body = render_job_metrics([_row("a")])

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -530,6 +530,7 @@ class _CfgStub:
         tool_repeat_limit: int = 0,
         tool_path_revisit_limit: int = 0,
         tool_path_trip_after: int = 0,
+        tool_result_window: int = 0,
         review_comment_brevity: bool = True,
         comment_brevity_min_chars: int = 100,
         comment_brevity_max_items: int = 40,
@@ -544,6 +545,7 @@ class _CfgStub:
         self.tool_repeat_limit = tool_repeat_limit
         self.tool_path_revisit_limit = tool_path_revisit_limit
         self.tool_path_trip_after = tool_path_trip_after
+        self.tool_result_window = tool_result_window
 
 
 class _FakeLLM:
@@ -1265,6 +1267,78 @@ class StopReasonTests(unittest.TestCase):
         )
         self.assertEqual(metrics.stop_reason, STOP_INPUT_TOKEN_CAP)
 
+    def test_peak_is_the_widest_turn_not_the_sum(self) -> None:
+        """The number that made 2M look like a context problem. `prompt_tokens`
+        sums each turn's whole prompt because the loop re-sends the
+        conversation; only the peak says how big any one request was."""
+        metrics = _AggregateMetrics()
+        for prompt in (5_100, 31_522, 56_400, 3_528):
+            metrics.record_call(
+                ChatResult(
+                    content="",
+                    usage={"prompt_tokens": prompt, "completion_tokens": 10},
+                )
+            )
+        self.assertEqual(metrics.prompt_tokens, 96_550)
+        self.assertEqual(metrics.peak_prompt_tokens, 56_400)
+        self.assertEqual(metrics.turns, 4)
+
+    def test_a_silent_provider_leaves_cached_unknown_not_zero(self) -> None:
+        """Reporting an unknown as 0 would assert the run was entirely uncached
+        on no evidence, and `prompt_tokens` is only an upper bound on the bill
+        when we cannot tell."""
+        metrics = _AggregateMetrics()
+        metrics.record_call(ChatResult(content="", usage={"prompt_tokens": 100}))
+        self.assertIsNone(metrics.cached_tokens)
+        self.assertIsNone(session_record(metrics)["cached_tokens"])
+
+    def test_cached_tokens_sum_over_the_turns_that_reported_them(self) -> None:
+        metrics = _AggregateMetrics()
+        metrics.record_call(ChatResult(content="", usage={"prompt_tokens": 100}))
+        metrics.record_call(
+            ChatResult(
+                content="",
+                usage={
+                    "prompt_tokens": 900,
+                    "prompt_tokens_details": {"cached_tokens": 800},
+                },
+            )
+        )
+        metrics.record_call(
+            ChatResult(
+                content="",
+                usage={
+                    "prompt_tokens": 900,
+                    "prompt_tokens_details": {"cached_tokens": 850},
+                },
+            )
+        )
+        self.assertEqual(metrics.cached_tokens, 1_650)
+        self.assertEqual(metrics.prompt_tokens, 1_900)
+
+    def test_record_usage_does_not_spend_a_turn(self) -> None:
+        """The brevity passes are not the loop browsing the PR, and `turns` is
+        read as loop iterations by the serge-agent-sessions dashboard."""
+        metrics = _AggregateMetrics()
+        metrics.record_usage(
+            ChatResult(content="", usage={"prompt_tokens": 700, "cached_tokens": 200})
+        )
+        self.assertEqual(metrics.turns, 0)
+        self.assertEqual(metrics.prompt_tokens, 700)
+        self.assertEqual(metrics.peak_prompt_tokens, 700)
+        self.assertEqual(metrics.cached_tokens, 200)
+
+    def test_the_loop_records_the_peak_it_saw(self) -> None:
+        cfg = _CfgStub(llm_max_input_tokens=100_000)
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([self._tool_turn(60_000), self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.peak_prompt_tokens, 60_000)
+        self.assertGreater(metrics.prompt_tokens, metrics.peak_prompt_tokens)
+
     def test_repeat_guard(self) -> None:
         cfg = _CfgStub(tool_max_iterations=0, tool_repeat_limit=2)
         _, metrics = _run_agentic_loop(
@@ -1411,6 +1485,39 @@ class SessionRecordTests(unittest.TestCase):
         self.assertEqual(merge_session_records(a, {}), a)
         self.assertEqual(merge_session_records(None, None), {})
 
+    def test_merging_takes_the_widest_peak_not_the_total(self) -> None:
+        """Each round is a fresh conversation, so summing peaks would invent a
+        request that never happened."""
+        a = {"peak_prompt_tokens": 40_000, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        b = {"peak_prompt_tokens": 56_400, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        self.assertEqual(merge_session_records(a, b)["peak_prompt_tokens"], 56_400)
+        self.assertEqual(merge_session_records(b, a)["peak_prompt_tokens"], 56_400)
+
+    def test_merging_two_unknown_cache_figures_stays_unknown(self) -> None:
+        """`int(x or 0)` would fold "neither round knew" into a confident zero,
+        which reads as "nothing was cached" — the opposite of the truth."""
+        a = {"cached_tokens": None, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        b = {"cached_tokens": None, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        self.assertIsNone(merge_session_records(a, b)["cached_tokens"])
+
+    def test_a_known_cache_figure_survives_an_unknown_one(self) -> None:
+        known = {"cached_tokens": 1_200, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        unknown = {"cached_tokens": None, "rounds": 1, "stop_reason": STOP_ANSWERED}
+        self.assertEqual(merge_session_records(known, unknown)["cached_tokens"], 1_200)
+        self.assertEqual(merge_session_records(unknown, known)["cached_tokens"], 1_200)
+        self.assertEqual(
+            merge_session_records(known, dict(known))["cached_tokens"], 2_400
+        )
+
+    def test_a_legacy_record_without_the_new_keys_still_merges(self) -> None:
+        """Session records are JSON written by older builds; a missing key must
+        not raise or invent a value."""
+        legacy = {"turns": 5, "prompt_tokens": 100, "rounds": 1}
+        merged = merge_session_records(legacy, dict(legacy))
+        self.assertEqual(merged["prompt_tokens"], 200)
+        self.assertEqual(merged["peak_prompt_tokens"], 0)
+        self.assertIsNone(merged["cached_tokens"])
+
     def test_a_job_that_never_ran_the_loop_still_reports(self) -> None:
         """Reproduce-first classifying a group ENVIRONMENT is 0 LLM turns, and
         that has to be countable — otherwise it is indistinguishable from serge
@@ -1419,6 +1526,146 @@ class SessionRecordTests(unittest.TestCase):
         self.assertEqual(record["rounds"], 0)
         self.assertEqual(record["turns"], 0)
         self.assertEqual(record["stop_reason"], STOP_NO_LLM_TURNS)
+
+
+class TranscriptWindowLoopTests(unittest.TestCase):
+    """The loop has to send the *windowed* transcript, not just compute one.
+
+    Patching the window itself keeps these tests independent of how big a real
+    tool result happens to be — what is under test is the wiring: which list
+    reaches the provider, what budget is asked for, and which turn opts out.
+    """
+
+    def _tool_turn(self) -> ChatResult:
+        return ChatResult(
+            content="",
+            usage={"prompt_tokens": 10_000, "completion_tokens": 20},
+            tool_calls=[ToolCall(id="t", name="grep", arguments='{"pattern": "Foo"}')],
+        )
+
+    def _answer(self) -> ChatResult:
+        return ChatResult(
+            content='{"summary": "ok", "comments": []}',
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+        )
+
+    def test_the_windowed_messages_are_what_reaches_the_provider(self) -> None:
+        sentinel = [{"role": "user", "content": "windowed"}]
+        llm = _FakeLLM([self._tool_turn(), self._answer()])
+        with patch(
+            "reviewbot.reviewer.elide_old_tool_results",
+            return_value=(sentinel, 7, 90_000),
+        ):
+            _, metrics = _run_agentic_loop(
+                llm,  # type: ignore[arg-type]
+                [{"role": "user", "content": "x"}],
+                cfg=_CfgStub(tool_result_window=20),  # type: ignore[arg-type]
+                tool_env=ToolEnv(repo_root="/tmp"),
+            )
+        self.assertEqual(llm.calls[0]["messages"], sentinel)
+        self.assertEqual(metrics.elided_tool_results, 7)
+        self.assertEqual(metrics.elided_chars, 90_000)
+
+    def test_the_configured_window_is_the_budget_asked_for(self) -> None:
+        llm = _FakeLLM([self._tool_turn(), self._answer()])
+        with patch(
+            "reviewbot.reviewer.elide_old_tool_results",
+            side_effect=lambda messages, **kw: (messages, 0, 0),
+        ) as window:
+            _run_agentic_loop(
+                llm,  # type: ignore[arg-type]
+                [{"role": "user", "content": "x"}],
+                cfg=_CfgStub(tool_result_window=12),  # type: ignore[arg-type]
+                tool_env=ToolEnv(repo_root="/tmp"),
+            )
+        self.assertTrue(window.call_args_list)
+        for call in window.call_args_list:
+            self.assertEqual(call.kwargs["keep_recent"], 12)
+
+    def test_the_window_is_off_by_default(self) -> None:
+        """Every measured run to date sent the whole transcript; the shipped
+        default must not change that silently."""
+        llm = _FakeLLM([self._tool_turn(), self._answer()])
+        with patch(
+            "reviewbot.reviewer.elide_old_tool_results",
+            side_effect=lambda messages, **kw: (messages, 0, 0),
+        ) as window:
+            _run_agentic_loop(
+                llm,  # type: ignore[arg-type]
+                [{"role": "user", "content": "x"}],
+                cfg=_CfgStub(),  # type: ignore[arg-type]
+                tool_env=ToolEnv(repo_root="/tmp"),
+            )
+        for call in window.call_args_list:
+            self.assertEqual(call.kwargs["keep_recent"], 0)
+
+    def test_a_cfg_without_the_field_does_not_crash_the_loop(self) -> None:
+        """Older per-task runner pods rebuild Config from their own env, and a
+        review pod on a previous image has no such attribute."""
+
+        class _Ancient:
+            llm_max_tokens = 1024
+            tool_max_iterations = 30
+            llm_max_input_tokens = 0
+            llm_reasoning_effort = None
+
+        _, metrics = _run_agentic_loop(
+            _FakeLLM([self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=_Ancient(),  # type: ignore[arg-type]
+            tool_env=None,
+        )
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+        self.assertEqual(metrics.elided_tool_results, 0)
+
+    def test_the_salvage_turn_gets_the_whole_transcript(self) -> None:
+        """`force_json_only` is the turn that has to *produce* the patch out of
+        what it read; starving it is the one failure the window must not cause.
+        """
+        llm = _FakeLLM(
+            [
+                self._tool_turn(),
+                # Empty final answer -> salvage re-ask with tools off.
+                ChatResult(content="", usage={"prompt_tokens": 900}),
+                self._answer(),
+            ]
+        )
+        with patch(
+            "reviewbot.reviewer.elide_old_tool_results",
+            side_effect=lambda messages, **kw: (messages, 0, 0),
+        ) as window:
+            _run_agentic_loop(
+                llm,  # type: ignore[arg-type]
+                [{"role": "user", "content": "x"}],
+                cfg=_CfgStub(tool_result_window=5),  # type: ignore[arg-type]
+                tool_env=ToolEnv(repo_root="/tmp"),
+            )
+        budgets = [call.kwargs["keep_recent"] for call in window.call_args_list]
+        self.assertIn(5, budgets)
+        self.assertIn(0, budgets)
+
+    def test_the_widest_request_is_reported_not_the_running_total(self) -> None:
+        """Elision is recomputed from the full transcript every turn, so adding
+        the per-turn figures up would count one saving once per turn left."""
+        llm = _FakeLLM([self._tool_turn(), self._tool_turn(), self._answer()])
+        counts = iter([(3, 1_000), (9, 5_000), (4, 2_000)])
+
+        def _window(messages, **kw):
+            try:
+                elided, saved = next(counts)
+            except StopIteration:
+                elided, saved = 0, 0
+            return messages, elided, saved
+
+        with patch("reviewbot.reviewer.elide_old_tool_results", side_effect=_window):
+            _, metrics = _run_agentic_loop(
+                llm,  # type: ignore[arg-type]
+                [{"role": "user", "content": "x"}],
+                cfg=_CfgStub(tool_result_window=8),  # type: ignore[arg-type]
+                tool_env=ToolEnv(repo_root="/tmp"),
+            )
+        self.assertEqual(metrics.elided_tool_results, 9)
+        self.assertEqual(metrics.elided_chars, 5_000)
 
 
 class PathRevisitLoopTests(unittest.TestCase):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,218 @@
+"""Tests for the browse-transcript window.
+
+The window exists to stop the input-token cap being spent re-sending tool
+results (86% of a measured 2M-token task), so the numbers it reports have to be
+right or the change cannot be shown to have helped. Its dangerous failure is
+structural, not arithmetic: a request whose assistant `tool_calls` entry has no
+matching `role: "tool"` reply is a 400 from every provider serge talks to, so
+the shape assertions here matter more than the savings ones.
+"""
+
+import unittest
+
+from reviewbot.transcript import elide_old_tool_results, elided_stub
+
+
+def _tool(call_id: str, name: str = "read_file", content: str = "") -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "name": name,
+        "content": content or ("x" * 5_000),
+    }
+
+
+def _assistant(call_id: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    }
+
+
+def _transcript(count: int) -> list[dict]:
+    """A prefix plus ``count`` assistant/tool exchanges, as the loop builds it."""
+    messages: list[dict] = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "task"},
+    ]
+    for index in range(count):
+        messages.append(_assistant(f"c{index}"))
+        messages.append(_tool(f"c{index}", content=f"result {index} " + "y" * 5_000))
+    return messages
+
+
+class WindowOffTests(unittest.TestCase):
+    def test_zero_keeps_everything_and_does_not_copy(self) -> None:
+        """0 is the default, so this is the shipped behaviour: inert."""
+        messages = _transcript(30)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=0)
+        self.assertIs(windowed, messages)
+        self.assertEqual((elided, saved), (0, 0))
+
+    def test_negative_is_treated_as_off(self) -> None:
+        messages = _transcript(5)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=-3)
+        self.assertIs(windowed, messages)
+        self.assertEqual((elided, saved), (0, 0))
+
+    def test_transcript_shorter_than_the_window_is_untouched(self) -> None:
+        messages = _transcript(4)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=10)
+        self.assertIs(windowed, messages)
+        self.assertEqual((elided, saved), (0, 0))
+
+    def test_exactly_the_window_is_untouched(self) -> None:
+        messages = _transcript(6)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=6)
+        self.assertIs(windowed, messages)
+        self.assertEqual(elided, 0)
+
+
+class ElisionTests(unittest.TestCase):
+    def test_only_the_oldest_results_are_elided(self) -> None:
+        messages = _transcript(10)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=3)
+        self.assertEqual(elided, 7)
+        self.assertGreater(saved, 0)
+        tools = [m for m in windowed if m["role"] == "tool"]
+        self.assertEqual(len(tools), 10)
+        for message in tools[:7]:
+            self.assertIn("has been removed from this transcript", message["content"])
+        for index, message in enumerate(tools[7:], start=7):
+            self.assertTrue(message["content"].startswith(f"result {index} "))
+
+    def test_every_tool_reply_keeps_its_position_and_call_id(self) -> None:
+        """The 400-shaped failure: a tool_calls entry with no matching reply."""
+        messages = _transcript(8)
+        windowed, _, _ = elide_old_tool_results(messages, keep_recent=2)
+        self.assertEqual(len(windowed), len(messages))
+        for before, after in zip(messages, windowed):
+            self.assertEqual(before["role"], after["role"])
+            self.assertEqual(before.get("tool_call_id"), after.get("tool_call_id"))
+            self.assertEqual(before.get("name"), after.get("name"))
+            self.assertEqual(before.get("tool_calls"), after.get("tool_calls"))
+
+    def test_the_prefix_and_assistant_turns_are_never_touched(self) -> None:
+        messages = _transcript(9)
+        windowed, _, _ = elide_old_tool_results(messages, keep_recent=1)
+        self.assertEqual(windowed[0], {"role": "system", "content": "sys"})
+        self.assertEqual(windowed[1], {"role": "user", "content": "task"})
+        self.assertEqual(
+            [m for m in windowed if m["role"] == "assistant"],
+            [m for m in messages if m["role"] == "assistant"],
+        )
+
+    def test_the_input_list_is_not_mutated(self) -> None:
+        """Non-destructive by contract: the caller re-windows the full
+        transcript every turn, which is what keeps the function pure and an
+        elided message from being elided twice."""
+        messages = _transcript(10)
+        originals = [m["content"] for m in messages if m["role"] == "tool"]
+        elide_old_tool_results(messages, keep_recent=2)
+        self.assertEqual(
+            [m["content"] for m in messages if m["role"] == "tool"], originals
+        )
+
+    def test_re_windowing_the_same_transcript_is_stable(self) -> None:
+        messages = _transcript(12)
+        first, elided_a, saved_a = elide_old_tool_results(messages, keep_recent=4)
+        second, elided_b, saved_b = elide_old_tool_results(messages, keep_recent=4)
+        self.assertEqual((elided_a, saved_a), (elided_b, saved_b))
+        self.assertEqual(first, second)
+
+    def test_saved_is_the_characters_actually_removed(self) -> None:
+        messages = _transcript(6)
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=2)
+        before = sum(len(m["content"]) for m in messages if m["role"] == "tool")
+        after = sum(len(m["content"]) for m in windowed if m["role"] == "tool")
+        self.assertEqual(saved, before - after)
+        self.assertEqual(elided, 4)
+
+
+class StubTests(unittest.TestCase):
+    def test_the_stub_tells_the_model_it_can_rerun_the_call(self) -> None:
+        """A bare "[elided]" invites the model to conclude the file is gone and
+        abandon the path; it has to read as "this happened, do it again"."""
+        stub = elided_stub("read_file", 5_000)
+        self.assertIn("read_file", stub)
+        self.assertIn("5,000 characters", stub)
+        self.assertIn("Run the call again", stub)
+
+    def test_the_tool_name_travels_into_the_stub(self) -> None:
+        messages = [
+            {"role": "user", "content": "task"},
+            _tool("a", name="grep", content="g" * 4_000),
+            _tool("b", name="read_file", content="r" * 4_000),
+            _tool("c", name="read_file", content="keep"),
+        ]
+        windowed, _, _ = elide_old_tool_results(messages, keep_recent=1)
+        self.assertIn("grep", windowed[1]["content"])
+        self.assertIn("read_file", windowed[2]["content"])
+
+    def test_a_nameless_reply_still_gets_a_stub(self) -> None:
+        messages = [
+            {"role": "tool", "tool_call_id": "a", "content": "z" * 4_000},
+            _tool("b", content="keep"),
+        ]
+        windowed, elided, _ = elide_old_tool_results(messages, keep_recent=1)
+        self.assertEqual(elided, 1)
+        self.assertIn("tool", windowed[0]["content"])
+
+
+class SkipTests(unittest.TestCase):
+    def test_a_result_is_never_made_longer_than_it_was(self) -> None:
+        """The stub is ~200 chars, so eliding a two-line grep hit would spend
+        tokens rather than save them."""
+        messages = [
+            {"role": "user", "content": "task"},
+            _tool("a", content="one hit"),
+            _tool("b", content="another hit"),
+            _tool("c", content="x" * 9_000),
+            _tool("d", content="keep"),
+        ]
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=1)
+        self.assertEqual(elided, 1)
+        self.assertGreater(saved, 0)
+        self.assertEqual(windowed[1]["content"], "one hit")
+        self.assertEqual(windowed[2]["content"], "another hit")
+
+    def test_min_chars_leaves_smaller_results_verbatim(self) -> None:
+        messages = _transcript(3) + [_tool("small", content="s" * 3_000)]
+        messages.append(_tool("newest", content="n" * 3_000))
+        windowed, elided, _ = elide_old_tool_results(
+            messages, keep_recent=1, min_chars=4_000
+        )
+        self.assertEqual(elided, 3)
+        self.assertEqual(windowed[-2]["content"], "s" * 3_000)
+
+    def test_non_string_content_is_skipped_not_crashed(self) -> None:
+        messages = [
+            {"role": "tool", "tool_call_id": "a", "name": "grep", "content": None},
+            _tool("b", content="x" * 9_000),
+            _tool("c", content="keep"),
+        ]
+        windowed, elided, _ = elide_old_tool_results(messages, keep_recent=1)
+        self.assertEqual(elided, 1)
+        self.assertIsNone(windowed[0]["content"])
+
+    def test_nothing_elidable_returns_the_input_list(self) -> None:
+        messages = [
+            {"role": "user", "content": "task"},
+            _tool("a", content="tiny"),
+            _tool("b", content="tiny"),
+            _tool("c", content="tiny"),
+        ]
+        windowed, elided, saved = elide_old_tool_results(messages, keep_recent=1)
+        self.assertIs(windowed, messages)
+        self.assertEqual((elided, saved), (0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`LLM_MAX_INPUT_TOKENS` (2M) is hit often, and the number looked implausible. It is not a math error, but it does not mean what the name suggests: the agent loop is append-only, so every turn re-sends the whole conversation, and `metrics.prompt_tokens` sums each turn's *entire* prompt. The cap therefore governs a cumulative billing figure that grows **quadratically in turns**.

Reconstructed from prod task `d9d4b022` (transformers#48534, 2026-09-07, 56 turns, `stop_reason=input_token_cap`) via its journal's per-turn `metrics` events:

| turn | cumulative | that turn's prompt |
|---|---|---|
| 1 | 5,100 | 5,100 |
| 20 | 431,541 | 31,522 |
| 40 | 1,261,483 | 45,709 |
| 55 | 2,037,915 | 56,400 |

The widest single request was **56,400 tokens — 37× smaller than the 2,094,215 total**. Same shape on all 8 jobs that hit the cap in the 30 days to 2026-09-08 (peaks 43k–59k, ratios 35–48×). Nothing exported let anyone tell a spend problem from a context problem, so this PR adds the two numbers that do, and the lever that acts on the finding.

Also worth recording: the re-reads are *not* waste. 3,101 lines were read across 33 `read_file` calls covering 2,802 distinct lines — 1.11×. The six reads of `modular_blt.py` were six different windows. There is nothing to reclaim by de-duplicating, which is why this PR does not.

## What changed

**Accounting**
- `ChatResult.cached_tokens` — reads `prompt_tokens_details.cached_tokens` (OpenAI / HF Router), `cache_read_input_tokens` (Anthropic's OpenAI shim) and a flat `cached_tokens` (some vLLM builds). Returns **None when the provider reports nothing**, kept distinct from a reported 0: without it, summed `prompt_tokens` is an upper bound on the bill with no way to tell how loose.
- `_AggregateMetrics.peak_prompt_tokens` / `.cached_tokens`, folded in through new `record_call()` / `record_usage()`. All five usage sites now go through them — `record_usage` is the one that deliberately does **not** spend a turn, for the two brevity passes (`turns` is read as loop iterations by the serge-agent-sessions dashboard).
- Merging is per-counter rather than uniform: peaks take the **max** across rounds (each round is a fresh conversation; summing invents a request that never happened), and `cached_tokens` uses `_merge_optional_sum` so `None + None` stays `None` instead of becoming a confident zero.
- `serge_job_peak_input_tokens`, `serge_job_cached_input_tokens`, `serge_job_elided_tool_results`, `serge_job_elided_chars`. The cache series exports **no sample** when unknown — Prometheus's own encoding of "no data".
- `_format_aggregated_metrics` is deliberately untouched: that string is published into GitHub review footers.

**The window** — new `reviewbot/transcript.py`
- Keeps the newest N tool results verbatim; older ones become a stub naming the tool and its size.
- Every `role: "tool"` message **stays in place** with only `content` swapped. An assistant `tool_calls` entry with no matching reply is a 400 from every provider serge talks to.
- The stub reads as "this call happened and you can re-run it". A bare `[elided]` invites the model to conclude the file does not exist and abandon the path.
- **Non-destructive**: the loop keeps its full list and sends a windowed copy, so it re-windows from the complete transcript each turn and nothing is elided twice.
- **The answer-producing turns get the whole transcript** — the `force_json_only` salvage turn and the forced final answer both have to *produce* the patch from what was read. Starving them is the one failure this must not cause.
- A result no larger than the stub is left alone, so no request is ever made bigger.

## Validation against the real job

Replaying `d9d4b022`'s measured per-turn prompts and the measured char size of all 62 tool results through the actual function (chars/token calibrated at 3.64 from the run itself; the replay reproduces the measured 2,094,215 to within 4.8%):

| window | cumulative | peak | saving | turns under the same 2M cap |
|---|---|---|---|---|
| off | 2,194,015 | 56,400 | — | 59 |
| 30 | 1,594,888 | 38,077 | 27% | ~76 |
| **20** | **1,227,429** | **26,740** | **44%** | **~99** |
| 12 | 921,358 | 20,208 | 58% | ~125 |

## Default is off, on purpose

`TOOL_RESULT_WINDOW` / `TASK_TOOL_RESULT_WINDOW` default to **0**, which is exactly today's behaviour. Being append-only is the shape a provider prefix-cache wants, and rewriting history invalidates that cache from the elision point on — so if HF Router is discounting cache reads on Kimi, a window can cost *more* than it saves. Read `serge_job_cached_input_tokens` for a night first. That ordering is why the accounting and the lever ship together.

The known behavioural risk when it is enabled: a model that can no longer see what it read may re-read it, which would show up as more `repeat_guard` / `path_revisit_guard` terminations. `serge_job_elided_*` plus the existing guard counters are what makes that measurable.

## Also

Corrects the prefix comment in `tasks.py`. It recorded that ~63% of the budget went on the resent prefix (mm_grounding_dino, 2026-08-31, when turn 1 cost 25,335 tokens). Re-measured, the prefix is 16.7k–20.2k chars (~5k tokens) on all 8 capped jobs — 14% — and the transcript is the 86%. Anyone trusting that comment would optimise the wrong half. The `prompt_prefix_summary` logging stays: that conclusion is only checkable because it exists.

## Tests

`1007 passed, 3 skipped`; `ruff format` / `ruff check` clean. New `tests/test_transcript.py` covers the structural invariant (tool replies keep position, `tool_call_id` and `name`), non-destructiveness, re-window stability, the skip cases, and the savings arithmetic. Loop wiring tests assert the *windowed* list is what reaches the provider, that the configured budget is what is asked for, that the default is 0, that a `cfg` from an older runner image without the field does not crash the loop, and that the salvage turn opts out.