### PR TITLE
Count a tool turn as blind only if it asked for nothing new

### DIFF
--- a/reviewbot/metrics.py
+++ b/reviewbot/metrics.py
@@ -81,6 +81,15 @@ _JOB_GAUGES: tuple[tuple[str, str, str], ...] = (
         "exact repeat, and that is the shape that dominates.",
     ),
     (
+        "serge_job_blind_tool_turns",
+        "blind_tool_turns",
+        "Tool turns that spent the TOOL_MAX_ITERATIONS budget: no reasoning, "
+        "no content, and nothing asked for the session had not already asked "
+        "for. Compare with serge_job_turns — a job where these are equal and "
+        "stop_reason is blind_turn_cap was cut off without the exemption ever "
+        "firing.",
+    ),
+    (
         "serge_job_elided_tool_results",
         "elided_tool_results",
         "Tool results the browse-transcript window replaced with a stub in the "

--- a/reviewbot/reviewer.py
+++ b/reviewbot/reviewer.py
@@ -26,7 +26,7 @@ from .prompts import (
     build_user_prompt,
 )
 from .review_history import build_prior_review_context
-from .tool_repeat import ToolRepeatGuard
+from .tool_repeat import ToolRepeatGuard, normalize_arguments
 from .transcript import elide_old_tool_results
 from .tools import (
     RepoHelperTool,
@@ -503,6 +503,13 @@ class _AggregateMetrics:
     # the truncated-final-answer salvage respectively.
     validation_retries: int = 0
     truncation_retries: int = 0
+    # Tool turns that spent the iteration budget: no reasoning, no content, and
+    # nothing asked for that the session had not already asked for. Recorded
+    # because the definition changed on 2026-09-09 and the old one was inert on
+    # the production model (30 of 30 turns counted as blind on review
+    # b489863b) — without this counter, "did that change anything?" can only be
+    # answered by hand-replaying a job journal before it is evicted.
+    blind_tool_turns: int = 0
     # Widest single request's browse-transcript elision (see
     # :mod:`reviewbot.transcript`): how many tool results were replaced by a
     # stub, and how many characters that removed. A MAX across turns, not a
@@ -591,6 +598,7 @@ def no_llm_session_record(stop_reason: str = STOP_NO_LLM_TURNS) -> dict[str, Any
         "path_revisits": 0,
         "validation_retries": 0,
         "truncation_retries": 0,
+        "blind_tool_turns": 0,
         "elided_tool_results": 0,
         "elided_chars": 0,
         "rounds": 0,
@@ -634,6 +642,7 @@ def session_record(m: "_AggregateMetrics") -> dict[str, Any]:
         "path_revisits": m.path_revisits,
         "validation_retries": m.validation_retries,
         "truncation_retries": m.truncation_retries,
+        "blind_tool_turns": m.blind_tool_turns,
         "elided_tool_results": m.elided_tool_results,
         "elided_chars": m.elided_chars,
         "rounds": 1,
@@ -651,6 +660,7 @@ _SESSION_SUMS = (
     "path_revisits",
     "validation_retries",
     "truncation_retries",
+    "blind_tool_turns",
 )
 
 # Counters where folding two loops together means taking the larger, not adding:
@@ -741,6 +751,7 @@ def _merge_metrics(total: "_AggregateMetrics", part: "_AggregateMetrics") -> Non
     total.path_revisits += part.path_revisits
     total.validation_retries += part.validation_retries
     total.truncation_retries += part.truncation_retries
+    total.blind_tool_turns += part.blind_tool_turns
     # Each chunk browses with a fresh guard, so distinct paths are per-chunk and
     # summing them double-counts a file two chunks both opened. An upper bound is
     # the honest reading available without keeping every path around.
@@ -1280,12 +1291,18 @@ def _run_agentic_loop(
     # final answer just as well across every provider we target.
 
     # ``tool_max_iterations <= 0`` means "no cap". By default, the cap
-    # counts only *blind* tool turns: the model emitted tool calls
-    # without any reasoning OR content. Productive turns — where the
-    # model either thought (reasoning_chars > 0), said something
-    # (content), or returned a final answer (no tool calls) — don't
-    # burn the budget. /tasks can opt into a stricter mode where the cap
-    # counts total tool calls, preserving budget for the final patch JSON.
+    # counts only *blind* tool turns: the model fired tool calls without
+    # reasoning, without content, AND without asking for anything it had
+    # not already asked for. Productive turns — where the model thought
+    # (reasoning_chars > 0), said something (content), asked for a file,
+    # range or pattern new to the session, or returned a final answer (no
+    # tool calls) — don't burn the budget. /tasks can opt into a stricter
+    # mode where the cap counts total tool calls, preserving budget for
+    # the final patch JSON.
+    #
+    # The novelty clause is load-bearing, not a refinement: the older
+    # reasoning-only test is INERT on the model in production. See the
+    # blind-turn determination below for the measurements.
     iter_cap: Optional[int] = (
         cfg.tool_max_iterations if cfg.tool_max_iterations > 0 else None
     )
@@ -1320,6 +1337,10 @@ def _run_agentic_loop(
     )
     iteration = 0
     blind_tool_turns = 0
+    # Normalized signatures of every tool call the session has asked for, used
+    # to tell an investigating turn from a re-issuing one (see the blind-turn
+    # determination below).
+    seen_call_signatures: set[str] = set()
     # The window is reported to the journal once, not once a turn: it elides on
     # every one of 50+ turns and a line each would bury the run log.
     elision_announced = False
@@ -1338,6 +1359,7 @@ def _run_agentic_loop(
         metrics.path_revisits = repeat_guard.path_revisits
         metrics.validation_retries = validation_retries
         metrics.truncation_retries = truncation_retries
+        metrics.blind_tool_turns = blind_tool_turns
         return chat, metrics
 
     # Set for one turn to recover a truncated final answer: disable tools and
@@ -1507,15 +1529,56 @@ def _run_agentic_loop(
             force_json_only = validation_retry_messages is not None
             continue
 
-        # A "blind" tool turn is one where the model fired tool calls
-        # without reasoning or content — i.e. chaining tools without
-        # thinking between them. Those are the turns we want to limit;
-        # tool calls preceded by reasoning are healthy investigation.
+        # A "blind" tool turn is one where the model fired tool calls without
+        # reasoning, without content, and without asking for anything new —
+        # i.e. chaining tools without thinking between them.
+        #
+        # Why the reasoning test is not enough on its own: it is INERT for the
+        # model in production. Kimi does not interleave reasoning with tool
+        # calls; it thinks once, when it writes the answer. Measured on reviews
+        # b489863b (K2.6) and 936b0d05 (K2.7-Coder), 2026-09-08: 30 of 30 tool
+        # turns had reasoning_chars=0 and empty content, every one of them
+        # `finish_reason=tool_calls`, and ALL the reasoning arrived on the final
+        # turn (72,063 and 10,759 chars). Both reviews were investigating
+        # normally and both were cut off at TOOL_MAX_ITERATIONS, so the
+        # exemption never fired once and the cap silently degenerated into a
+        # flat 30-tool-turn limit. Five of the eight reviews that ran that day
+        # ended this way.
+        #
+        # Novelty is the model-agnostic reading of the same intent. The failure
+        # this cap exists for is a model re-issuing calls it has already made
+        # (tool_repeat.py carries the prod cases: one grep 21 times, another
+        # 44), and such a turn asks for nothing new by construction. A turn that
+        # opens a file, line range or pattern the session has not seen is
+        # investigating, whether or not the provider chooses to show us any
+        # thinking. Signatures are normalized the same way the repeat guard
+        # normalizes them, but tracked here rather than there on purpose: the
+        # guard stops counting when TOOL_REPEAT_LIMIT=0, and the meaning of the
+        # iteration cap must not depend on an unrelated setting.
+        #
+        # What novelty deliberately does NOT catch is the browsing-in-circles
+        # shape — re-reading one file at a different line range each time (prod
+        # task 9d210794: 137 of 153 calls), which is a fresh signature every
+        # time and so reads as productive here. That is fine: it has its own
+        # budget in ToolRepeatGuard (TOOL_PATH_REVISIT_LIMIT nudge,
+        # TOOL_PATH_TRIP_AFTER cut-off) and its own stop reason. Both of those
+        # guards are untouched by this — the only thing that changed is what
+        # spends the *iteration* cap, so nothing that used to be stopped stops
+        # being stopped.
         thought = bool(chat.reasoning_chars) or bool((chat.content or "").strip())
-        if not thought:
+        asked_for_something_new = False
+        for tool_call in chat.tool_calls:
+            signature = (
+                f"{tool_call.name}\x00{normalize_arguments(tool_call.arguments)}"
+            )
+            if signature not in seen_call_signatures:
+                seen_call_signatures.add(signature)
+                asked_for_something_new = True
+        if not thought and not asked_for_something_new:
             blind_tool_turns += 1
             log.info(
-                "Blind tool turn (no reasoning/content); blind_tool_turns=%d",
+                "Blind tool turn (no reasoning/content, nothing new asked for); "
+                "blind_tool_turns=%d",
                 blind_tool_turns,
             )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,6 +41,7 @@ def _row(job_id: str, **overrides) -> dict:
             "path_revisits": 14,
             "validation_retries": 1,
             "truncation_retries": 0,
+            "blind_tool_turns": 46,
             "peak_prompt_tokens": 56_400,
             "cached_tokens": 1_800_000,
             "elided_tool_results": 0,
@@ -127,6 +128,14 @@ class ExpositionShapeTests(unittest.TestCase):
         body = render_job_metrics([row])
         self.assertIn('serge_job_input_tokens{job_id="a"} 500', body)
         self.assertEqual(_samples(body, "serge_job_peak_input_tokens"), [])
+
+    def test_blind_turns_are_exported_for_comparison_with_turns(self) -> None:
+        """A job where these equal serge_job_turns and stop_reason is
+        blind_turn_cap was cut off without the exemption firing once — the
+        shape 5 of 8 reviews had on 2026-09-08."""
+        body = render_job_metrics([_row("a")])
+        self.assertIn('serge_job_blind_tool_turns{job_id="a"} 46', body)
+        self.assertIn('serge_job_turns{job_id="a"} 46', body)
 
     def test_the_elision_counters_are_exported(self) -> None:
         row = _row("a")

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1349,19 +1349,111 @@ class StopReasonTests(unittest.TestCase):
         )
         self.assertEqual(metrics.stop_reason, STOP_REPEAT_GUARD)
 
+    def _silent_grep(self, pattern: str, call_id: str = "t") -> ChatResult:
+        """A tool turn with no reasoning and no content — the shape every turn
+        of a real Kimi review has."""
+        return ChatResult(
+            content="",
+            usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+            tool_calls=[
+                ToolCall(
+                    id=call_id,
+                    name="grep",
+                    arguments='{"pattern": "%s"}' % pattern,
+                )
+            ],
+        )
+
     def test_blind_turn_cap(self) -> None:
+        """Re-issuing one call with nothing to show for it burns the budget."""
         cfg = _CfgStub(tool_max_iterations=2, tool_repeat_limit=0)
-        turns = [
+        turns = [self._silent_grep("Foo", f"t{i}") for i in range(4)]
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(turns + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_BLIND_TURN_CAP)
+
+    def test_distinct_searches_do_not_burn_the_budget(self) -> None:
+        """The regression this definition exists for.
+
+        Until 2026-09-09 the cap counted any turn without reasoning or content,
+        and Kimi emits neither on a tool turn — it thinks once, when it writes
+        the answer. So reviews investigating perfectly normally were cut off at
+        TOOL_MAX_ITERATIONS: 30 of 30 turns counted as blind on prod review
+        b489863b, and 5 of the 8 reviews on 2026-09-08 ended that way. Four
+        different searches is investigation, whatever the provider shows us.
+        """
+        cfg = _CfgStub(tool_max_iterations=2, tool_repeat_limit=0)
+        turns = [self._silent_grep(f"P{i}", f"t{i}") for i in range(4)]
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(turns + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+        self.assertEqual(metrics.blind_tool_turns, 0)
+
+    def test_a_turn_is_productive_if_any_one_call_is_new(self) -> None:
+        """Mixed turns are the common real shape — a repeat alongside a fresh
+        read still moved the investigation forward."""
+        cfg = _CfgStub(tool_max_iterations=1, tool_repeat_limit=0)
+        repeat_plus_new = [
             ChatResult(
                 content="",
                 usage={"prompt_tokens": 1_000, "completion_tokens": 10},
                 tool_calls=[
-                    ToolCall(
-                        id=f"t{i}", name="grep", arguments='{"pattern": "P%d"}' % i
-                    )
+                    ToolCall(id="a", name="grep", arguments='{"pattern": "Foo"}'),
+                    ToolCall(id="b", name="grep", arguments='{"pattern": "New%d"}' % i),
                 ],
             )
-            for i in range(4)
+            for i in range(3)
+        ]
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(repeat_plus_new + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.stop_reason, STOP_ANSWERED)
+
+    def test_reasoning_still_exempts_a_repeated_call(self) -> None:
+        """The original exemption is kept, not replaced: a model that thinks
+        out loud is investigating even when it re-reads."""
+        cfg = _CfgStub(tool_max_iterations=2, tool_repeat_limit=0)
+        turns = []
+        for i in range(4):
+            turn = self._silent_grep("Foo", f"t{i}")
+            turn.reasoning_chars = 500
+            turns.append(turn)
+        _, metrics = _run_agentic_loop(
+            _FakeLLM(turns + [self._answer()]),  # type: ignore[arg-type]
+            [{"role": "user", "content": "x"}],
+            cfg=cfg,  # type: ignore[arg-type]
+            tool_env=ToolEnv(repo_root="/tmp"),
+        )
+        self.assertEqual(metrics.blind_tool_turns, 0)
+
+    def test_argument_spelling_does_not_disguise_a_repeat(self) -> None:
+        """Signatures are normalized, so key order and whitespace cannot buy
+        extra turns."""
+        cfg = _CfgStub(tool_max_iterations=2, tool_repeat_limit=0)
+        spellings = (
+            '{"pattern": "Foo", "path": "src"}',
+            '{"path": "src", "pattern": "Foo"}',
+            '{"pattern":"Foo","path":"src"}',
+            '{ "path" : "src" , "pattern" : "Foo" }',
+        )
+        turns = [
+            ChatResult(
+                content="",
+                usage={"prompt_tokens": 1_000, "completion_tokens": 10},
+                tool_calls=[ToolCall(id=f"t{i}", name="grep", arguments=raw)],
+            )
+            for i, raw in enumerate(spellings)
         ]
         _, metrics = _run_agentic_loop(
             _FakeLLM(turns + [self._answer()]),  # type: ignore[arg-type]


### PR DESCRIPTION
## The bug

`TOOL_MAX_ITERATIONS` counts *blind* tool turns — "the model emitted tool calls without any reasoning OR content", i.e. chaining tools without thinking — and exempts turns that reasoned or spoke. **That exemption is inert on the model we run in production.** Kimi does not interleave reasoning with tool calls; it thinks once, when it writes the answer.

Journal replay of review `b489863b` (huggingface/serge#119, K2.6, 2026-09-08):

```
turn  1: reasoning=     0  content=    0  finish=tool_calls  tools=['read_file','grep','grep']
turn 30: reasoning=     0  content=    0  finish=tool_calls  tools=['grep']
turn 31: reasoning=72,063  content=2,024  finish=stop        tools=[]
```

30 of 30 tool turns counted as blind. `936b0d05` (transformers#48618, K2.7-Coder) is identical with 10,759 reasoning chars on its turn 31. Both were investigating normally — distinct files, distinct patterns — and both were cut off at 30, so the cap had silently become a flat tool-turn limit and the "productive turns don't burn the budget" design never fired once.

Scope: **5 of the 8 reviews that ran on 2026-09-08** ended on `blind_turn_cap` at exactly 31 turns (three reviews of transformers#48618, two of serge#119). They still published, from whatever the forced tool-free final turn produced. Not caused by the K2.6→K2.7-Coder change — both models show it, and reviews on 2026-08-31 already had 2 of 3 ending this way. Tasks are unaffected: they run `TASK_TOOL_MAX_ITERATIONS=80` in strict mode, which counts tool calls rather than blind turns.

## The change

A turn is now productive if it reasoned, spoke, returned a final answer, **or asked for a file, line range or pattern the session had not seen**. That is the model-agnostic reading of the original intent — the pathology this cap exists for is a model re-issuing calls it has already made (`tool_repeat.py` carries the prod cases: one grep 21 times, another 44), and such a turn asks for nothing new by construction.

Signatures are normalized exactly as `ToolRepeatGuard` normalizes them, but tracked in the loop rather than in the guard on purpose: the guard stops counting when `TOOL_REPEAT_LIMIT=0`, and the meaning of the iteration cap must not depend on an unrelated setting.

**Nothing that used to be stopped stops being stopped.** The exact-repeat and path-revisit guards are untouched. In particular the browsing-in-circles shape — re-reading one file at a different line range each time (prod task `9d210794`: 137 of 153 calls) — produces a fresh signature every time and so reads as productive *here*, which is fine: it has its own budget (`TOOL_PATH_REVISIT_LIMIT` nudge, `TOOL_PATH_TRIP_AFTER` cut-off) and its own stop reason. The only thing that changed is what spends the *iteration* cap.

## Also

- `blind_tool_turns` is now recorded per job and exported as `serge_job_blind_tool_turns`. Without it, "did that change anything?" can only be answered by hand-replaying a journal before the 25-job store evicts it — which is how this bug was found, and is not a repeatable method. Compare it with `serge_job_turns`: equal, plus `stop_reason=blind_turn_cap`, is the shape above.
- The comment documenting the cap is corrected. It stated a premise that is false for the model in production, which is how someone tunes the wrong knob later.

## Tests

`1024 passed`, ruff clean. `test_blind_turn_cap` **changed meaning and its fixture had to change**: it built four turns with four *distinct* grep patterns, which under the new definition is investigation, so it now uses a repeated call. Four new tests pin the rest of the contract:

- `test_distinct_searches_do_not_burn_the_budget` — the regression itself.
- `test_a_turn_is_productive_if_any_one_call_is_new` — mixed turns (a repeat alongside a fresh read) are the common real shape.
- `test_reasoning_still_exempts_a_repeated_call` — the original exemption is kept, not replaced.
- `test_argument_spelling_does_not_disguise_a_repeat` — key order and whitespace cannot buy extra turns.

## Deploy note

Shipping with a values-only bump of `TOOL_MAX_ITERATIONS` 30 → 60 for reviews, in the same deploy. Both reviews above had genuinely exhausted 30 turns of real investigation on large PRs, and a turn is cheap: `b489863b` billed 646,507 cumulative input tokens but only **57,579 fresh** (~1,857/turn) because 91% came from HF Router's prefix cache, so 30 more turns costs ~55k fresh tokens.